### PR TITLE
Fix package domain in the setup plugin

### DIFF
--- a/plugins/setup/build.gradle
+++ b/plugins/setup/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'opensearch.pluginzip'
 
 def pluginName = 'wazuh-indexer-setup'
 def pluginDescription = 'Wazuh Indexer setup plugin'
-def projectPath = 'org.wazuh'
+def projectPath = 'com.wazuh'
 def pathToPlugin = 'setup'
 def pluginClassName = 'SetupPlugin'
 

--- a/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
@@ -5,8 +5,9 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.wazuh.setup;
+package com.wazuh.setup;
 
+import com.wazuh.setup.index.WazuhIndices;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -21,7 +22,6 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.watcher.ResourceWatcherService;
-import org.wazuh.setup.index.WazuhIndices;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,12 +34,13 @@ import java.util.function.Supplier;
  */
 public class SetupPlugin extends Plugin implements ClusterPlugin {
 
+    private WazuhIndices indices;
+
     /**
      * Default constructor
      */
-    public SetupPlugin() {}
-
-    private WazuhIndices indices;
+    public SetupPlugin() {
+    }
 
     @Override
     public Collection<Object> createComponents(

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/WazuhIndices.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/WazuhIndices.java
@@ -5,8 +5,9 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.wazuh.setup.index;
+package com.wazuh.setup.index;
 
+import com.wazuh.setup.utils.IndexTemplateUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -16,10 +17,10 @@ import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 
-import org.wazuh.setup.utils.IndexTemplateUtils;
-
 import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class contains the logic to create the index templates and the indices
@@ -27,16 +28,14 @@ import java.util.*;
  */
 public class WazuhIndices {
     private static final Logger log = LogManager.getLogger(WazuhIndices.class);
-
-    private final Client client;
-    private final ClusterService clusterService;
-
     /**
      * | Key                 | value      |
      * | ------------------- | ---------- |
      * | Index template name | index name |
      */
     public final Map<String, String> indexTemplates = new HashMap<>();
+    private final Client client;
+    private final ClusterService clusterService;
 
     /**
      * Constructor

--- a/plugins/setup/src/main/java/com/wazuh/setup/utils/IndexTemplateUtils.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/utils/IndexTemplateUtils.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.wazuh.setup.utils;
+package com.wazuh.setup.utils;
 
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.DeprecationHandler;

--- a/plugins/setup/src/test/java/com/wazuh/setup/SetupPluginIT.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/SetupPluginIT.java
@@ -5,7 +5,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.wazuh.setup;
+package com.wazuh.setup;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.ParseException;

--- a/plugins/setup/src/test/java/com/wazuh/setup/SetupPluginTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/SetupPluginTests.java
@@ -5,8 +5,9 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.wazuh.setup;
+package com.wazuh.setup;
 
+import com.wazuh.setup.index.WazuhIndices;
 import org.junit.After;
 import org.junit.Before;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -23,7 +24,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
-import org.wazuh.setup.index.WazuhIndices;
 
 import static org.mockito.Mockito.*;
 import static org.opensearch.test.ClusterServiceUtils.createClusterService;
@@ -31,9 +31,9 @@ import static org.opensearch.test.ClusterServiceUtils.createClusterService;
 public class SetupPluginTests extends OpenSearchTestCase {
 
     public static final String INDEX_NAME = "wazuh-indexer-setup-test-index";
+    public ClusterService clusterService;
     private WazuhIndices wazuhIndices;
     private ThreadPool threadPool;
-    public ClusterService clusterService;
     private Client mockClient;
 
     /**

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/WazuhIndicesTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/WazuhIndicesTests.java
@@ -5,10 +5,10 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.wazuh.setup.index;
+package com.wazuh.setup.index;
 
+import com.wazuh.setup.utils.IndexTemplateUtils;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.mockito.*;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
@@ -17,12 +17,10 @@ import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
 import org.opensearch.client.IndicesAdminClient;
-import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.ClusterState;
-
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.test.OpenSearchTestCase;
-import org.wazuh.setup.utils.IndexTemplateUtils;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/plugins/setup/src/yamlRestTest/java/com/wazuh/setup/SetupPluginClientYamlTestSuiteIT.java
+++ b/plugins/setup/src/yamlRestTest/java/com/wazuh/setup/SetupPluginClientYamlTestSuiteIT.java
@@ -5,7 +5,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.wazuh.setup;
+package com.wazuh.setup;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;


### PR DESCRIPTION
### Description
This PR fixes the setup plugin Java package domain.

`org.wazuh` becomes `com.wazuh`.

### Issues Resolved
NA
