### PR TITLE
Apply rest type endpoint path

### DIFF
--- a/plugins/command-manager/openapi.yml
+++ b/plugins/command-manager/openapi.yml
@@ -26,22 +26,19 @@ components:
     Command:
       type: object
       properties:
-        command:
-          type: object
-          properties:
-            source:
-              type: string
-              example: "Engine"
-            user:
-              type: string
-              example: "user53"
-            target:
-              $ref: '#/components/schemas/Target'
-            action:
-              $ref: '#/components/schemas/Action'
-            timeout:
-              type: integer
-              example: 30
+        source:
+          type: string
+          example: "Engine"
+        user:
+          type: string
+          example: "user53"
+        target:
+          $ref: '#/components/schemas/Target'
+        action:
+          $ref: '#/components/schemas/Action'
+        timeout:
+          type: integer
+          example: 30
     Target:
       type: object
       properties:

--- a/plugins/command-manager/openapi.yml
+++ b/plugins/command-manager/openapi.yml
@@ -1,0 +1,67 @@
+openapi: "3.0.3"
+info:
+  title: Wazuh Indexer Command Manager API
+  version: "1.0"
+servers:
+  - url: http://127.0.0.1:9200/_plugins/_command_manager
+paths:
+  /commands:
+    post:
+      tags:
+        - "commands"
+      summary: Add a new command to the queue.
+      description: Add a new command to the queue.
+      requestBody:
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/Command"
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    Command:
+      type: object
+      properties:
+        command:
+          type: object
+          properties:
+            source:
+              type: string
+              example: "Engine"
+            user:
+              type: string
+              example: "user53"
+            target:
+              $ref: '#/components/schemas/Target'
+            action:
+              $ref: '#/components/schemas/Action'
+            timeout:
+              type: integer
+              example: 30
+    Target:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "target4"
+        type:
+          type: string
+          example: "agent"
+    Action:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "restart"
+        args:
+          type: array
+          items:
+            type: string
+            example: "/path/to/executable/arg6"
+        version:
+          type: string
+          example: "v4"

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
@@ -8,7 +8,7 @@
 package com.wazuh.commandmanager;
 
 import com.wazuh.commandmanager.index.CommandIndex;
-import com.wazuh.commandmanager.rest.action.RestPostCommandAction;
+import com.wazuh.commandmanager.rest.RestPostCommandAction;
 import com.wazuh.commandmanager.utils.httpclient.HttpRestClient;
 import com.wazuh.commandmanager.utils.httpclient.HttpRestClientDemo;
 import org.opensearch.client.Client;

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
@@ -45,7 +45,8 @@ import java.util.function.Supplier;
  * Agents.
  */
 public class CommandManagerPlugin extends Plugin implements ActionPlugin {
-    public static final String COMMAND_MANAGER_BASE_URI = "/_plugins/_commandmanager";
+    public static final String COMMAND_MANAGER_BASE_URI = "/_plugins/_command_manager";
+    public static final String COMMANDS_URI = COMMAND_MANAGER_BASE_URI + "/commands";
     public static final String COMMAND_MANAGER_INDEX_NAME = ".commands";
     public static final String COMMAND_MANAGER_INDEX_TEMPLATE_NAME = "index-template-commands";
 

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/index/CommandIndex.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/index/CommandIndex.java
@@ -73,7 +73,7 @@ public class CommandIndex implements IndexingOperationListener {
             );
         }
 
-        log.info("Indexing command with id:{}", document.getId());
+        log.info("Indexing command with id [{}]", document.getId());
         try {
             IndexRequest request = new IndexRequest()
                     .index(CommandManagerPlugin.COMMAND_MANAGER_INDEX_NAME)
@@ -92,7 +92,7 @@ public class CommandIndex implements IndexingOperationListener {
             );
         } catch (IOException e) {
             log.error(
-                    "Error indexing command with id:{} due to {}", document.getId(), e);
+                    "Error indexing command with id [{}] due to {}", document.getId(), e);
         }
         return future;
     }
@@ -138,14 +138,14 @@ public class CommandIndex implements IndexingOperationListener {
                         .actionGet();
                 if (acknowledgedResponse.isAcknowledged()) {
                     log.info(
-                            "Index template created successfully: {}",
+                            "Index template [{}] created successfully",
                             templateName
                     );
                 }
             });
 
         } catch (IOException e) {
-            log.error("Error reading index template '{}' from filesystem", templateName);
+            log.error("Error reading index template [{}] from filesystem", templateName);
         }
     }
 }

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/index/CommandIndex.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/index/CommandIndex.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ExecutorService;
  */
 public class CommandIndex implements IndexingOperationListener {
 
-    private static final Logger logger = LogManager.getLogger(CommandIndex.class);
+    private static final Logger log = LogManager.getLogger(CommandIndex.class);
 
     private final Client client;
     private final ClusterService clusterService;
@@ -67,13 +67,13 @@ public class CommandIndex implements IndexingOperationListener {
         if (!indexTemplateExists(CommandManagerPlugin.COMMAND_MANAGER_INDEX_TEMPLATE_NAME)) {
             putIndexTemplate(CommandManagerPlugin.COMMAND_MANAGER_INDEX_TEMPLATE_NAME);
         } else {
-            logger.info(
+            log.info(
                     "Index template {} already exists. Skipping creation.",
                     CommandManagerPlugin.COMMAND_MANAGER_INDEX_TEMPLATE_NAME
             );
         }
 
-        logger.debug("Indexing command {}", document);
+        log.info("Indexing command with id:{}", document.getId());
         try {
             IndexRequest request = new IndexRequest()
                     .index(CommandManagerPlugin.COMMAND_MANAGER_INDEX_NAME)
@@ -91,8 +91,8 @@ public class CommandIndex implements IndexingOperationListener {
                     }
             );
         } catch (IOException e) {
-            logger.error(
-                    "Failed to index command with ID {}: {}", document.getId(), e);
+            log.error(
+                    "Error indexing command with id:{} due to {}", document.getId(), e);
         }
         return future;
     }
@@ -108,7 +108,7 @@ public class CommandIndex implements IndexingOperationListener {
                 .state()
                 .metadata()
                 .templates();
-        logger.debug("Existing index templates: {} ", templates);
+        log.debug("Existing index templates: {} ", templates);
 
         return templates.containsKey(template_name);
     }
@@ -137,7 +137,7 @@ public class CommandIndex implements IndexingOperationListener {
                         .putTemplate(putIndexTemplateRequest)
                         .actionGet();
                 if (acknowledgedResponse.isAcknowledged()) {
-                    logger.info(
+                    log.info(
                             "Index template created successfully: {}",
                             templateName
                     );
@@ -145,7 +145,7 @@ public class CommandIndex implements IndexingOperationListener {
             });
 
         } catch (IOException e) {
-            logger.error("Error reading index template from filesystem {}", templateName);
+            log.error("Error reading index template '{}' from filesystem", templateName);
         }
     }
 }

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Command.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Command.java
@@ -15,6 +15,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import reactor.util.annotation.NonNull;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 public class Command implements ToXContentObject {
     public static final String COMMAND = "command";
@@ -64,9 +65,10 @@ public class Command implements ToXContentObject {
      *
      * @param parser XContentParser from the Rest Request
      * @return instance of Command
-     * @throws IOException
+     * @throws IOException              error parsing request content
+     * @throws IllegalArgumentException missing arguments
      */
-    public static Command parse(XContentParser parser) throws IOException {
+    public static Command parse(XContentParser parser) throws IOException, IllegalArgumentException {
         String source = null;
         Target target = null;
         Integer timeout = null;
@@ -99,14 +101,34 @@ public class Command implements ToXContentObject {
             }
         }
 
-        // TODO add proper validation
-        return new Command(
-                source,
-                target,
-                timeout,
-                user,
-                action
-        );
+        ArrayList<String> nullArguments = new ArrayList<>();
+        if (source == null) {
+            nullArguments.add("source");
+        }
+        if (target == null) {
+            nullArguments.add("target");
+        }
+        if (timeout == null) {
+            nullArguments.add("timeout");
+        }
+        if (user == null) {
+            nullArguments.add("user");
+        }
+        if (action == null) {
+            nullArguments.add("action");
+        }
+
+        if (!nullArguments.isEmpty()) {
+            throw new IllegalArgumentException("Missing arguments: " + nullArguments);
+        } else {
+            return new Command(
+                    source,
+                    target,
+                    timeout,
+                    user,
+                    action
+            );
+        }
     }
 
     @Override

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/RestPostCommandAction.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/RestPostCommandAction.java
@@ -5,7 +5,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package com.wazuh.commandmanager.rest.action;
+package com.wazuh.commandmanager.rest;
 
 import com.wazuh.commandmanager.CommandManagerPlugin;
 import com.wazuh.commandmanager.index.CommandIndex;

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
@@ -97,7 +97,7 @@ public class RestPostCommandAction extends BaseRestHandler {
      */
     private RestChannelConsumer handlePost(RestRequest request) throws IOException {
         log.info(
-                "Received {} {} request id:{} from host:{}",
+                "Received {} {} request id [{}] from host [{}]",
                 request.method().name(),
                 request.uri(),
                 request.getRequestId(),
@@ -119,10 +119,10 @@ public class RestPostCommandAction extends BaseRestHandler {
                     .build();
             String payload = document.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).toString();
             SimpleHttpResponse response = httpClient.post(receiverURI, payload, document.getId());
-            log.info("Received response to POST request with code {}", response.getCode());
+            log.info("Received response to POST request with code [{}]", response.getCode());
             log.info("Raw response:\n{}", response.getBodyText());
         } catch (URISyntaxException e) {
-            log.error("Bad URI:{}", e.getMessage());
+            log.error("Bad URI: {}", e.getMessage());
         } catch (Exception e) {
             log.error("Error reading response: {}", e.getMessage());
         }
@@ -138,8 +138,12 @@ public class RestPostCommandAction extends BaseRestHandler {
                             builder.field("result", restStatus.name());
                             builder.endObject();
                             channel.sendResponse(new BytesRestResponse(restStatus, builder));
-                        } catch (Exception e) {
-                            log.error("Error indexing command: ", e);
+                        } catch (IOException e) {
+                            log.error("Error preparing response to [{}] request with id [{}] due to {}",
+                                      request.method().name(),
+                                      request.getRequestId(),
+                                      e.getMessage()
+                            );
                         }
                     }).exceptionally(e -> {
                         channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, e.getMessage()));

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
@@ -10,10 +10,15 @@ package com.wazuh.commandmanager.rest.action;
 import com.wazuh.commandmanager.CommandManagerPlugin;
 import com.wazuh.commandmanager.index.CommandIndex;
 import com.wazuh.commandmanager.model.Document;
+import com.wazuh.commandmanager.utils.httpclient.HttpRestClient;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.core5.net.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.BaseRestHandler;
@@ -21,6 +26,8 @@ import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -36,7 +43,7 @@ import static org.opensearch.rest.RestRequest.Method.POST;
 public class RestPostCommandAction extends BaseRestHandler {
 
     public static final String POST_COMMAND_ACTION_REQUEST_DETAILS = "post_command_action_request_details";
-    private static final Logger logger = LogManager.getLogger(RestPostCommandAction.class);
+    private static final Logger log = LogManager.getLogger(RestPostCommandAction.class);
     private final CommandIndex commandIndex;
 
     /**
@@ -89,11 +96,36 @@ public class RestPostCommandAction extends BaseRestHandler {
      * @throws IOException thrown by the XContentParser methods.
      */
     private RestChannelConsumer handlePost(RestRequest request) throws IOException {
+        log.info(
+                "Received {} {} request id:{} from host:{}",
+                request.method().name(),
+                request.uri(),
+                request.getRequestId(),
+                request.header("Host")
+        );
         // Get request details
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 
         Document document = Document.parse(parser);
+
+        // Commands delivery to the Management API.
+        // Note: needs to be decoupled from the Rest handler (job scheduler task).
+        HttpRestClient httpClient = HttpRestClient.getInstance();
+        try {
+            String uri = "https://httpbin.org/post";
+//            String uri = "https://127.0.0.1:5000";
+            URI receiverURI = new URIBuilder(uri)
+                    .build();
+            String payload = document.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).toString();
+            SimpleHttpResponse response = httpClient.post(receiverURI, payload, document.getId());
+            log.info("Received response to POST request with code {}", response.getCode());
+            log.info("Raw response:\n{}", response.getBodyText());
+        } catch (URISyntaxException e) {
+            log.error("Bad URI:{}", e.getMessage());
+        } catch (Exception e) {
+            log.error("Error reading response: {}", e.getMessage());
+        }
 
         // Send response
         return channel -> {
@@ -107,7 +139,7 @@ public class RestPostCommandAction extends BaseRestHandler {
                             builder.endObject();
                             channel.sendResponse(new BytesRestResponse(restStatus, builder));
                         } catch (Exception e) {
-                            logger.error("Error indexing command: ", e);
+                            log.error("Error indexing command: ", e);
                         }
                     }).exceptionally(e -> {
                         channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, e.getMessage()));

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
@@ -69,11 +69,28 @@ public class RestPostCommandAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(
-            final RestRequest restRequest,
+            final RestRequest request,
             final NodeClient client
     ) throws IOException {
+        switch (request.method()) {
+            case POST:
+                return handlePost(request);
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported HTTP method " + request.method().name());
+        }
+    }
+
+    /**
+     * Handles a POST HTTP request.
+     *
+     * @param request POST HTTP request
+     * @return a response to the request as BytesRestResponse.
+     * @throws IOException thrown by the XContentParser methods.
+     */
+    private RestChannelConsumer handlePost(RestRequest request) throws IOException {
         // Get request details
-        XContentParser parser = restRequest.contentParser();
+        XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 
         Document document = Document.parse(parser);

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
@@ -9,6 +9,8 @@ package com.wazuh.commandmanager.rest.action;
 
 import com.wazuh.commandmanager.CommandManagerPlugin;
 import com.wazuh.commandmanager.index.CommandIndex;
+import com.wazuh.commandmanager.model.Agent;
+import com.wazuh.commandmanager.model.Command;
 import com.wazuh.commandmanager.model.Document;
 import com.wazuh.commandmanager.utils.httpclient.HttpRestClient;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
@@ -107,7 +109,11 @@ public class RestPostCommandAction extends BaseRestHandler {
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 
-        Document document = Document.parse(parser);
+        Command command = Command.parse(parser);
+        Document document = new Document(
+                new Agent(List.of("groups000")), // TODO read agent from .agents index
+                command
+        );
 
         // Commands delivery to the Management API.
         // Note: needs to be decoupled from the Rest handler (job scheduler task).

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/rest/action/RestPostCommandAction.java
@@ -30,7 +30,7 @@ import static org.opensearch.rest.RestRequest.Method.POST;
 
 /**
  * Handles HTTP requests to the POST
- * {@value com.wazuh.commandmanager.CommandManagerPlugin#COMMAND_MANAGER_BASE_URI}
+ * {@value com.wazuh.commandmanager.CommandManagerPlugin#COMMANDS_URI}
  * endpoint.
  */
 public class RestPostCommandAction extends BaseRestHandler {
@@ -61,7 +61,7 @@ public class RestPostCommandAction extends BaseRestHandler {
                         String.format(
                                 Locale.ROOT,
                                 "%s",
-                                CommandManagerPlugin.COMMAND_MANAGER_BASE_URI
+                                CommandManagerPlugin.COMMANDS_URI
                         )
                 )
         );

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/utils/httpclient/HttpRestClient.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/utils/httpclient/HttpRestClient.java
@@ -107,7 +107,7 @@ public class HttpRestClient {
             HttpHost httpHost = HttpHost.create(receiverURI);
 
             log.info(
-                    "Sending payload with id {} to {}",
+                    "Sending payload with id [{}] to [{}]",
                     payloadId,
                     receiverURI
             );
@@ -125,7 +125,7 @@ public class HttpRestClient {
                             SimpleResponseConsumer.create(),
                             new HttpResponseCallback(
                                     httpPostRequest,
-                                    "Failed to execute outgoing POST request with payload id:" + payloadId
+                                    "Failed to execute outgoing POST request with payload id [" + payloadId + "]"
                             )
                     );
 
@@ -137,7 +137,7 @@ public class HttpRestClient {
         } catch (TimeoutException e) {
             log.error("Operation timed out {}", e.getMessage());
         } catch (Exception e) {
-            log.error("Error sending payload with id:{} due to {}", payloadId, e);
+            log.error("Error sending payload with id [{}] due to {}", payloadId, e);
         }
 
         return null;

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/utils/httpclient/HttpRestClient.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/utils/httpclient/HttpRestClient.java
@@ -19,10 +19,12 @@ import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.common.Randomness;
 
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * HTTP Rest client. Currently used to perform
@@ -30,6 +32,8 @@ import java.util.concurrent.Future;
  */
 public class HttpRestClient {
 
+    public static final long TIMEOUT = 4;
+    public static final TimeUnit TIME_UNIT = TimeUnit.SECONDS;
     private static final Logger log = LogManager.getLogger(HttpRestClient.class);
     private static HttpRestClient instance;
     private CloseableHttpAsyncClient httpClient;
@@ -93,39 +97,49 @@ public class HttpRestClient {
     /**
      * Sends a POST request.
      *
-     * @param uri     Well-formed URI
-     * @param payload data to send
-     * @return HTTP response
+     * @param receiverURI Well-formed URI
+     * @param payload     data to send
+     * @param payloadId   payload ID
+     * @return SimpleHttpResponse response
      */
-    public SimpleHttpResponse post(URI uri, String payload) {
-        Long id = Randomness.get().nextLong();
-
+    public SimpleHttpResponse post(URI receiverURI, String payload, String payloadId) {
         try {
-            // Create request
-            HttpHost httpHost = HttpHost.create(uri.getHost());
+            HttpHost httpHost = HttpHost.create(receiverURI);
+
+            log.info(
+                    "Sending payload with id {} to {}",
+                    payloadId,
+                    receiverURI
+            );
 
             SimpleHttpRequest httpPostRequest = SimpleRequestBuilder
                     .post()
                     .setHttpHost(httpHost)
-                    .setPath(uri.getPath())
+                    .setPath(receiverURI.getPath())
                     .setBody(payload, ContentType.APPLICATION_JSON)
                     .build();
 
-            // log request
             Future<SimpleHttpResponse> future =
                     this.httpClient.execute(
                             SimpleRequestProducer.create(httpPostRequest),
                             SimpleResponseConsumer.create(),
                             new HttpResponseCallback(
                                     httpPostRequest,
-                                    "Failed to send data for ID: " + id
+                                    "Failed to execute outgoing POST request with payload id:" + payloadId
                             )
                     );
 
-            return future.get();
+            return future.get(TIMEOUT, TIME_UNIT);
+        } catch (InterruptedException e) {
+            log.error("Operation interrupted {}", e.getMessage());
+        } catch (ExecutionException e) {
+            log.error("Execution failed {}", e.getMessage());
+        } catch (TimeoutException e) {
+            log.error("Operation timed out {}", e.getMessage());
         } catch (Exception e) {
-            log.error("Failed to send data for ID: {}", id);
+            log.error("Error sending payload with id:{} due to {}", payloadId, e);
         }
+
         return null;
     }
 }

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/utils/httpclient/HttpRestClientDemo.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/utils/httpclient/HttpRestClientDemo.java
@@ -35,15 +35,17 @@ public class HttpRestClientDemo {
         AccessController.doPrivileged(
                 (PrivilegedAction<SimpleHttpResponse>) () -> {
                     HttpRestClient httpClient = HttpRestClient.getInstance();
-                    URI host;
                     try {
-                        host = new URIBuilder(endpoint).build();
+                        URI host = new URIBuilder(endpoint).build();
+                        SimpleHttpResponse response = httpClient.post(host, body, "randomId");
+                        log.info("Received response to POST request with code {}", response.getCode());
+                        log.info("Raw response:\n{}", response.getBodyText());
                     } catch (URISyntaxException e) {
-                        throw new RuntimeException(e);
+                        log.error("Bad URI:{}", e.getMessage());
+                    } catch (Exception e) {
+                        log.error("Error reading response: {}", e.getMessage());
                     }
-                    SimpleHttpResponse postResponse = httpClient.post(host, body);
-                    log.info(postResponse.getBodyText());
-                    return postResponse;
+                    return null;
                 }
         );
     }

--- a/plugins/command-manager/src/test/java/com/wazuh/commandmanager/CommandManagerPluginIT.java
+++ b/plugins/command-manager/src/test/java/com/wazuh/commandmanager/CommandManagerPluginIT.java
@@ -10,6 +10,8 @@ package com.wazuh.commandmanager;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.ParseException;
 import org.apache.http.util.EntityUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.plugins.Plugin;
@@ -26,6 +28,8 @@ import static org.hamcrest.Matchers.containsString;
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
 public class CommandManagerPluginIT extends OpenSearchIntegTestCase {
 
+    private static final Logger log = LogManager.getLogger(CommandManagerPluginIT.class);
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.singletonList(CommandManagerPlugin.class);
@@ -35,7 +39,7 @@ public class CommandManagerPluginIT extends OpenSearchIntegTestCase {
         Response response = getRestClient().performRequest(new Request("GET", "/_cat/plugins"));
         String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
-        logger.info("response body: {}", body);
+        log.info("response body: {}", body);
         assertThat(body, containsString("command-manager"));
     }
 }

--- a/plugins/command-manager/src/test/java/com/wazuh/commandmanager/CommandManagerTests.java
+++ b/plugins/command-manager/src/test/java/com/wazuh/commandmanager/CommandManagerTests.java
@@ -27,14 +27,14 @@ public class CommandManagerTests extends OpenSearchTestCase {
             AccessController.doPrivileged(
                     (PrivilegedAction<SimpleHttpResponse>) () -> {
                         this.httpClient = HttpRestClient.getInstance();
-                        URI uri = null;
+                        URI uri;
                         try {
                             uri = new URI("https://httpbin.org/post");
                         } catch (URISyntaxException e) {
                             throw new RuntimeException(e);
                         }
                         String payload = "{\"message\": \"Hello world!\"}";
-                        SimpleHttpResponse postResponse = this.httpClient.post(uri, payload);
+                        SimpleHttpResponse postResponse = this.httpClient.post(uri, payload, "randomId");
 
                         String responseText = postResponse.getBodyText();
                         assertNotEquals(null, postResponse);

--- a/plugins/command-manager/src/yamlRestTest/resources/rest-api-spec/api/_plugins._command_manager.json
+++ b/plugins/command-manager/src/yamlRestTest/resources/rest-api-spec/api/_plugins._command_manager.json
@@ -1,10 +1,10 @@
 {
-  "_plugins._commandmanager": {
+  "_plugins._command_manager": {
     "stability" : "stable",
     "url": {
       "paths": [
         {
-          "path": "/_plugins/_commandmanager",
+          "path": "/_plugins/_command_manager/commands",
           "methods": [
             "POST"
           ]

--- a/plugins/command-manager/src/yamlRestTest/resources/rest-api-spec/test/20_create.yml
+++ b/plugins/command-manager/src/yamlRestTest/resources/rest-api-spec/test/20_create.yml
@@ -3,19 +3,18 @@
     - do:
           _plugins._command_manager:
               body:
-                  command:
-                      source: "Users/Services"
-                      user: "user13"
-                      target: {
-                          id: "target4",
-                          type: "agent"
-                      }
-                      action: {
-                          name: "change_group",
-                          args: [ "/path/to/executable/arg8" ],
-                          version: "v4"
-                      }
-                      timeout: 100
+                  source: "Users/Services"
+                  user: "user13"
+                  target: {
+                      id: "target4",
+                      type: "agent"
+                  }
+                  action: {
+                      name: "change_group",
+                      args: [ "/path/to/executable/arg8" ],
+                      version: "v4"
+                  }
+                  timeout: 100
 
     - set: { _id: document_id }
     - match: { _index: .commands }

--- a/plugins/command-manager/src/yamlRestTest/resources/rest-api-spec/test/20_create.yml
+++ b/plugins/command-manager/src/yamlRestTest/resources/rest-api-spec/test/20_create.yml
@@ -1,7 +1,7 @@
 ---
 "Create command":
     - do:
-          _plugins._commandmanager:
+          _plugins._command_manager:
               body:
                   command:
                       source: "Users/Services"


### PR DESCRIPTION
### Description
This PR includes several improvements to the Command Manager plugin:

- Apply Restful conventions to the API endpoint. The endpoint now includes the resource in the path (`/_plugins/_command-manager/commands`).
- Replace `_commandmanager` with `_command-manager` to improve readability.
- Extract the handling of POST requests to a dedicated method.
- Add API spec in OpenAPI format.
- Rename `logger` to `log` for consistency and simplicity. `log` is a verb, while `logger` is a noun. Using `log.[info|warn|error|debug]()` is better as it explicitly implies the action being done.
- Add timeout to the HttpRestClient.
- More and better logging.
- Implement a test cycle. Commands received through the API are sent back using the HttpRestClient.


![image](https://github.com/user-attachments/assets/ef175bb7-3153-4455-bf26-101fa5506583)


```log
2024-10-16T11:39:11.376+0200 [LIFECYCLE] [class org.gradle.internal.buildevents.TaskExecutionLogger] > Task :run
2024-10-16T11:39:23.171+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,124][INFO ][c.w.c.r.a.RestPostCommandAction] [integTest-0] Received POST /_plugins/_command_manager/commands request id [1] from host [127.0.0.1:9200]
2024-10-16T11:39:23.171+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,130][INFO ][c.w.c.u.h.HttpRestClient ] [integTest-0] Sending payload with id [Im6ylJIBRAPV3wyYQQ15] to [https://httpbin.org/post]
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,259][INFO ][c.w.c.r.a.RestPostCommandAction] [integTest-0] Received response to POST request with code [200]
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,259][INFO ][c.w.c.r.a.RestPostCommandAction] [integTest-0] Raw response:
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] {
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "args": {}, 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "data": "{\"agent\":{\"groups\":[\"groups000\"]},\"command\":{\"source\":\"Engine\",\"user\":\"user53\",\"target\":{\"type\":\"agent\",\"id\":\"target4\"},\"action\":{\"name\":\"restart\",\"args\":[\"/path/to/executable/arg6\",\"/path/to/executable/arg6\"],\"version\":\"v4\"},\"timeout\":30,\"status\":\"PENDING\",\"order_id\":\"IW6ylJIBRAPV3wyYQQ14\",\"request_id\":\"IG6ylJIBRAPV3wyYQQ13\"}}", 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "files": {}, 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "form": {}, 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "headers": {
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     "Content-Type": "application/json; charset=UTF-8", 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     "Host": "httpbin.org", 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     "Transfer-Encoding": "chunked", 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     "User-Agent": "Apache-HttpAsyncClient/5.4 (Java/21.0.4)", 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     "X-Amzn-Trace-Id": "Root=1-670f89cb-5ef2aee502ba60465a48184b"
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   }, 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "json": {
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     "agent": {
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "groups": [
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]         "groups000"
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       ]
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     }, 
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     "command": {
2024-10-16T11:39:23.272+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "action": {
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]         "args": [
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]           "/path/to/executable/arg6", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]           "/path/to/executable/arg6"
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]         ], 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]         "name": "restart", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]         "version": "v4"
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       }, 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "order_id": "IW6ylJIBRAPV3wyYQQ14", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "request_id": "IG6ylJIBRAPV3wyYQQ13", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "source": "Engine", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "status": "PENDING", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "target": {
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]         "id": "target4", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]         "type": "agent"
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       }, 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "timeout": 30, 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]       "user": "user53"
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]     }
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   }, 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "origin": "79.117.251.93", 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask]   "url": "https://httpbin.org/post"
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] }
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] 
2024-10-16T11:39:23.273+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,263][INFO ][c.w.c.i.CommandIndex     ] [integTest-0] Indexing command with id [Im6ylJIBRAPV3wyYQQ15]
2024-10-16T11:39:23.373+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,283][INFO ][o.o.p.PluginsService     ] [integTest-0] PluginService:onIndexModule index:[BMn5uviVSRWOptDJ72Sx8w/YoKeVJ3XTpyKX8saPaqEuA]
2024-10-16T11:39:23.474+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,400][INFO ][o.o.c.m.MetadataIndexTemplateService] [integTest-0] adding template [index-template-commands] for index patterns [.commands*]
2024-10-16T11:39:23.474+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,406][DEBUG][o.o.c.c.PublicationTransportHandler] [integTest-0] received diff cluster state version [3] with uuid [OcaebB72Qh2Ccl9qZdMYfA], diff size [580]
2024-10-16T11:39:23.474+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,440][DEBUG][o.o.c.c.C.CoordinatorPublication] [integTest-0] publication ended successfully: Publication{term=1, version=3}
2024-10-16T11:39:23.474+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,442][INFO ][c.w.c.i.CommandIndex     ] [integTest-0] Index template [index-template-commands] created successfully
2024-10-16T11:39:23.474+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,447][INFO ][o.o.p.PluginsService     ] [integTest-0] PluginService:onIndexModule index:[.commands/Ph8V5qGfR_uDkQuAdqUBrA]
2024-10-16T11:39:23.474+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,458][INFO ][o.o.c.m.MetadataCreateIndexService] [integTest-0] [.commands] creating index, cause [auto(bulk api)], templates [index-template-commands], shards [1]/[0]
2024-10-16T11:39:23.474+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,463][WARN ][o.o.c.r.a.AllocationService] [integTest-0] Falling back to single shard assignment since batch mode disable or multiple custom allocators set
2024-10-16T11:39:23.574+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,477][DEBUG][o.o.c.c.PublicationTransportHandler] [integTest-0] received diff cluster state version [4] with uuid [vn2XtNkqQuqWc1XrYV-CNw], diff size [754]
2024-10-16T11:39:23.574+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,505][INFO ][o.o.p.PluginsService     ] [integTest-0] PluginService:onIndexModule index:[.commands/Ph8V5qGfR_uDkQuAdqUBrA]
2024-10-16T11:39:23.574+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,562][DEBUG][o.o.c.c.C.CoordinatorPublication] [integTest-0] publication ended successfully: Publication{term=1, version=4}
2024-10-16T11:39:23.775+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,719][INFO ][o.o.c.r.a.AllocationService] [integTest-0] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[.commands][0]]]).
2024-10-16T11:39:23.775+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,723][DEBUG][o.o.c.c.PublicationTransportHandler] [integTest-0] received diff cluster state version [5] with uuid [OmFPmkceS5CCyY-Rg1iwrA], diff size [437]
2024-10-16T11:39:23.775+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,763][DEBUG][o.o.c.c.C.CoordinatorPublication] [integTest-0] publication ended successfully: Publication{term=1, version=5}
2024-10-16T11:39:23.775+0200 [LIFECYCLE] [org.opensearch.gradle.testclusters.RunTask] [2024-10-16T11:39:23,765][WARN ][o.o.c.r.a.AllocationService] [integTest-0] Falling back to single shard assignment since batch mode disable or multiple custom allocators set
2024-10-16T11:39:25.208+0200 [LIFECYCLE] [org.gradle.cache.internal.DefaultFileLockManager] 
```

### Issues Resolved
Closes #107 
