### PR TITLE
Initialize Commands Index

### DIFF
--- a/plugins/setup/src/main/java/com/wazuh/setup/index/WazuhIndices.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/WazuhIndices.java
@@ -54,6 +54,7 @@ public class WazuhIndices {
         this.indexTemplates.put("index-template-system", "wazuh-states-inventory-system");
         this.indexTemplates.put("index-template-processes", "wazuh-states-inventory-processes");
         this.indexTemplates.put("index-template-packages", "wazuh-states-inventory-packages");
+        this.indexTemplates.put("index-template-commands", ".commands");
     }
 
     /**

--- a/plugins/setup/src/main/resources/index-template-commands.json
+++ b/plugins/setup/src/main/resources/index-template-commands.json
@@ -1,0 +1,104 @@
+{
+  "index_patterns": [
+    ".commands*"
+  ],
+  "mappings": {
+    "date_detection": false,
+    "dynamic": "strict",
+    "properties": {
+      "agent": {
+        "properties": {
+          "groups": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "command": {
+        "properties": {
+          "action": {
+            "properties": {
+              "args": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "order_id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "request_id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "result": {
+            "properties": {
+              "code": {
+                "type": "short"
+              },
+              "data": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "message": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "source": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "status": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "target": {
+            "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "timeout": {
+            "type": "short"
+          },
+          "user": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  },
+  "order": 1,
+  "settings": {
+    "index": {
+      "hidden": true,
+      "number_of_replicas": "0",
+      "number_of_shards": "1",
+      "query.default_field": [
+        "command.source",
+        "command.target.type",
+        "command.status",
+        "command.action.name"
+      ],
+      "refresh_interval": "5s"
+    }
+  }
+}


### PR DESCRIPTION
### Description
This PR adds the `.commands` index and its associated template to the `setup` plugin's initialization logic, so that the index gets created and the template applied upon cluster initialization.

### Issues Resolved
Resolves #122 
