### PR TITLE
Add generated states-inventory-hotfixes stateful index template to the wazuh-setup plugin

### DIFF
--- a/plugins/setup/src/main/java/com/wazuh/setup/index/WazuhIndices.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/WazuhIndices.java
@@ -55,6 +55,7 @@ public class WazuhIndices {
         this.indexTemplates.put("index-template-processes", "wazuh-states-inventory-processes");
         this.indexTemplates.put("index-template-packages", "wazuh-states-inventory-packages");
         this.indexTemplates.put("index-template-commands", ".commands");
+        this.indexTemplates.put("index-template-hotfixes", "wazuh-states-inventory-hotfixes");
     }
 
     /**

--- a/plugins/setup/src/main/resources/index-template-hotfixes.json
+++ b/plugins/setup/src/main/resources/index-template-hotfixes.json
@@ -1,0 +1,50 @@
+{
+  "index_patterns": [
+    "wazuh-states-inventory-hotfixes*"
+  ],
+  "mappings": {
+    "date_detection": false,
+    "dynamic": "strict",
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "agent": {
+        "properties": {
+          "groups": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "package": {
+        "properties": {
+          "hotfix": {
+            "properties": {
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            },
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "order": 1,
+  "settings": {
+    "index": {
+      "number_of_replicas": "0",
+      "number_of_shards": "1",
+      "query.default_field": [
+        "package.hotfix.name"
+      ],
+      "refresh_interval": "5s"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the wazuh-states-inventory-hotfixes index template to the setup plugin.

Resolves: #141  
