### PR TITLE
Update ports index template adding interface field at top level

### DIFF
--- a/plugins/setup/src/main/resources/index-template-ports.json
+++ b/plugins/setup/src/main/resources/index-template-ports.json
@@ -299,6 +299,14 @@
           }
         }
       },
+      "interface": {
+        "properties": {
+          "state": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
       "network": {
         "properties": {
           "protocol": {


### PR DESCRIPTION
### Description
Update `states-inventory-ports` index template adding missing `interface` field.

### Issues Resolved
Resolves https://github.com/wazuh/wazuh-indexer/issues/580
