### PR TITLE
Allow dynamic fields on wazuh-alerts-5.x index template

### DIFF
--- a/plugins/setup/src/main/resources/index-template-alerts.json
+++ b/plugins/setup/src/main/resources/index-template-alerts.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "date_detection": false,
-    "dynamic": "strict",
+    "dynamic": true,
     "properties": {
       "@timestamp": {
         "type": "date"


### PR DESCRIPTION
### Description
Update `wazuh-alerts-5.x` index template enabling dynamic fields

### Issues Resolved
Resolves #177 
