### PR TITLE
Remove multi-fields and change wildcard to keyword in process template

### DIFF
--- a/plugins/setup/src/main/resources/index-template-processes.json
+++ b/plugins/setup/src/main/resources/index-template-processes.json
@@ -155,11 +155,6 @@
                     "type": "keyword"
                   },
                   "full": {
-                    "fields": {
-                      "text": {
-                        "type": "match_only_text"
-                      }
-                    },
                     "ignore_above": 1024,
                     "type": "keyword"
                   },
@@ -168,11 +163,6 @@
                     "type": "keyword"
                   },
                   "name": {
-                    "fields": {
-                      "text": {
-                        "type": "match_only_text"
-                      }
-                    },
                     "ignore_above": 1024,
                     "type": "keyword"
                   },
@@ -252,12 +242,7 @@
             "type": "keyword"
           },
           "command_line": {
-            "fields": {
-              "text": {
-                "type": "match_only_text"
-              }
-            },
-            "type": "wildcard"
+            "type": "keyword"
           },
           "group": {
             "properties": {
@@ -268,11 +253,6 @@
             }
           },
           "name": {
-            "fields": {
-              "text": {
-                "type": "match_only_text"
-              }
-            },
             "ignore_above": 1024,
             "type": "keyword"
           },


### PR DESCRIPTION
### Description
This PR modifies the `index-template-processes.json` template to avoid the use of multi-fields and the `wildcard` and `match_only_text` types, using `keyword` instead. This works around an issue in OpenSearch Dashboards where these types show up as `unknown`.

### Issues Resolved
Closes https://github.com/wazuh/wazuh-indexer/issues/585
