### PR TITLE
Fix null_pointer_exception when parsing commands with no arguments

### DIFF
--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
@@ -22,6 +22,9 @@ import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
 
+import reactor.util.annotation.NonNull;
+import reactor.util.annotation.Nullable;
+
 /** Command's action fields. */
 public class Action implements ToXContentObject {
     public static final String ACTION = "action";
@@ -38,7 +41,7 @@ public class Action implements ToXContentObject {
      * @param args actual command.
      * @param version version of the action.
      */
-    public Action(String name, Args args, String version) {
+    public Action(@NonNull String name, @Nullable Args args, String version) {
         this.name = name;
         this.args = args;
         this.version = version;
@@ -53,7 +56,7 @@ public class Action implements ToXContentObject {
      */
     public static Action parse(XContentParser parser) throws IOException {
         String name = "";
-        Args args = null;
+        Args args = new Args();
         String version = "";
 
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -82,7 +85,9 @@ public class Action implements ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(ACTION);
         builder.field(NAME, this.name);
-        this.args.toXContent(builder, ToXContentObject.EMPTY_PARAMS);
+        if (this.args != null) {
+            this.args.toXContent(builder, ToXContentObject.EMPTY_PARAMS);
+        }
         builder.field(VERSION, this.version);
         return builder.endObject();
     }
@@ -91,12 +96,12 @@ public class Action implements ToXContentObject {
     public String toString() {
         return "Action{"
                 + "name='"
-                + name
+                + this.name
                 + '\''
                 + ", args="
-                + args
+                + this.args
                 + ", version='"
-                + version
+                + this.version
                 + '\''
                 + '}';
     }

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
@@ -30,13 +30,18 @@ public class Args implements ToXContentObject {
     public static final String ARGS = "args";
     private final Map<String, Object> args;
 
+    /** Parameterless constructor. */
+    public Args() {
+        this.args = new HashMap<>();
+    }
+
     /**
-     * Constructor method
+     * Constructor with parameters.
      *
      * @param args Initializes the args object
      */
     public Args(Map<String, Object> args) {
-        this.args = args;
+        this.args = new HashMap<>(args);
     }
 
     /**


### PR DESCRIPTION
### Description
This PR fixes a bug on the Command Manager where it failed to parse commands with no arguments.


**Command**

```json
{
  "commands": [
    {
      "source": "Users/Services",
      "user": "Management API",
      "target": {
        "id": "c50f378e-83a9-46f6-a31a-27e5f7d690a8",
        "type": "agent"
      },
      "action": {
        "name": "update-group",
        "version": "5.0.0"
      },
      "timeout": 100
    }
  ]
}
```

**Result**

```json
{
  "_index": ".commands",
  "_documents": [
    {
      "_id": "FK0phJQBifi5ekD4oacx"
    }
  ],
  "result": "OK"
}
```

**Command**

```json
{
  "commands": [
    {
      "source": "Users/Services",
      "user": "Management API",
      "target": {
        "id": "c50f378e-83a9-46f6-a31a-27e5f7d690a8",
        "type": "agent"
      },
      "action": {
        "name": "update-group",
        "version": "5.0.0",
        "args": {
          "arg1": "bajwncjn",
          "arg2": 23
        }
      },
      "timeout": 100
    }
  ]
}
```

**Result**

```json
{
  "_index": ".commands",
  "_documents": [
    {
      "_id": "F60rhJQBifi5ekD4tqf4"
    }
  ],
  "result": "OK"
}
```


### Issues Resolved
Closes #231 
