### PR TITLE
Handle timeout exceptions

### DIFF
--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
@@ -80,7 +80,7 @@ public class CommandManagerPlugin extends Plugin implements ActionPlugin, JobSch
     public static final String JOB_INDEX_TEMPLATE_NAME = "index-template-scheduled-commands";
     public static final Integer JOB_PERIOD_MINUTES = 1;
     public static final Integer PAGE_SIZE = 100;
-    public static final Long DEFAULT_TIMEOUT_SECONDS = 20L;
+    public static final Long DEFAULT_TIMEOUT_SECONDS = -1L;
     public static final TimeValue PIT_KEEP_ALIVE_SECONDS = TimeValue.timeValueSeconds(30L);
 
     private static final Logger log = LogManager.getLogger(CommandManagerPlugin.class);

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/CommandManagerPlugin.java
@@ -80,7 +80,7 @@ public class CommandManagerPlugin extends Plugin implements ActionPlugin, JobSch
     public static final String JOB_INDEX_TEMPLATE_NAME = "index-template-scheduled-commands";
     public static final Integer JOB_PERIOD_MINUTES = 1;
     public static final Integer PAGE_SIZE = 100;
-    public static final Long DEFAULT_TIMEOUT_SECONDS = -1L;
+    public static final Long DEFAULT_TIMEOUT_SECONDS = 20L;
     public static final TimeValue PIT_KEEP_ALIVE_SECONDS = TimeValue.timeValueSeconds(30L);
 
     private static final Logger log = LogManager.getLogger(CommandManagerPlugin.class);

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/jobscheduler/SearchThread.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/jobscheduler/SearchThread.java
@@ -18,6 +18,7 @@ package com.wazuh.commandmanager.jobscheduler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.CreatePitRequest;
 import org.opensearch.action.search.CreatePitResponse;
@@ -155,7 +156,7 @@ public class SearchThread implements Runnable {
      * @throws IllegalStateException Raised by {@link ActionFuture#actionGet(long)}.
      */
     public SearchResponse pitQuery(PointInTimeBuilder pointInTimeBuilder, Object[] searchAfter)
-            throws IllegalStateException {
+            throws IllegalStateException, OpenSearchTimeoutException {
         final SearchRequest searchRequest = new SearchRequest(CommandManagerPlugin.INDEX_NAME);
         final TermQueryBuilder termQueryBuilder =
                 QueryBuilders.termQuery(SearchThread.COMMAND_STATUS_FIELD, Status.PENDING);
@@ -205,6 +206,8 @@ public class SearchThread implements Runnable {
             log.error("ArrayIndexOutOfBoundsException retrieving page: {}", e.getMessage());
         } catch (IllegalStateException e) {
             log.error("IllegalStateException retrieving page: {}", e.getMessage());
+        } catch (OpenSearchTimeoutException e) {
+            log.error("Query timed out: {}", e.getMessage());
         } catch (Exception e) {
             log.error("Generic exception retrieving page: {}", e.getMessage());
         }

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/jobscheduler/SearchThread.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/jobscheduler/SearchThread.java
@@ -42,6 +42,7 @@ import java.util.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import com.wazuh.commandmanager.CommandManagerPlugin;
 import com.wazuh.commandmanager.model.*;
@@ -101,9 +102,11 @@ public class SearchThread implements Runnable {
      * delivery timestamps are earlier than the current time
      *
      * @param searchResponse The search results page
-     * @throws IllegalStateException Rethrown from setSentStatus()
+     * @throws IllegalStateException from setFailureStatus()
+     * @throws OpenSearchTimeoutException from setFailureStatus()
      */
-    public void handlePage(SearchResponse searchResponse) throws IllegalStateException {
+    public void handlePage(SearchResponse searchResponse)
+            throws IllegalStateException, OpenSearchTimeoutException {
         SearchHits searchHits = searchResponse.getHits();
 
         final ZonedDateTime current_time = DateUtils.nowWithMillisResolution();
@@ -123,9 +126,11 @@ public class SearchThread implements Runnable {
      *
      * @param hit The page's result we are to update.
      * @throws IllegalStateException Raised by {@link ActionFuture#actionGet(long)}.
+     * @throws OpenSearchTimeoutException Raised by {@link ActionFuture#actionGet(long)}.
      */
     @SuppressWarnings("unchecked")
-    private void setFailureStatus(SearchHit hit) throws IllegalStateException {
+    private void setFailureStatus(SearchHit hit)
+            throws IllegalStateException, OpenSearchTimeoutException {
         final Map<String, Object> commandMap =
                 getNestedObject(
                         hit.getSourceAsMap(),
@@ -143,7 +148,7 @@ public class SearchThread implements Runnable {
                             .id(hit.getId());
             this.client
                     .index(indexRequest)
-                    .actionGet(CommandManagerPlugin.DEFAULT_TIMEOUT_SECONDS * 1000);
+                    .actionGet(CommandManagerPlugin.DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
### Description
This PR adds handling of `TiemoutExceptions` that may be raised by the OpenSearch client.

Also normalizes the use of the `DEFAULT_TIMEOUT_SECONDS` to seconds (sometimes it was converted to millis).

### Issues Resolved
Closes #227
