### PR TITLE
Log settings on plugin's start

### DIFF
--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/settings/PluginSettings.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/settings/PluginSettings.java
@@ -82,6 +82,7 @@ public class PluginSettings {
         this.jobSchedule = JOB_SCHEDULE.get(settings);
         this.jobPageSize = JOB_PAGE_SIZE.get(settings);
         this.jobKeepAlive = JOB_KEEP_ALIVE.get(settings);
+        log.error("Settings loaded: {}", this.toString());
     }
 
     /**
@@ -191,37 +192,15 @@ public class PluginSettings {
 
     @Override
     public String toString() {
-        return "PluginSettings{"
+        return "{"
                 + "timeout="
                 + timeout
-                + ", jobSchedule='"
+                + ", jobSchedule="
                 + jobSchedule
-                + '\''
                 + ", jobPageSize="
                 + jobPageSize
                 + ", jobKeepAlive="
                 + jobKeepAlive
-                + '\''
-                + ", jobIndexTemplate='"
-                + JOB_INDEX_TEMPLATE
-                + '\''
-                + ", apiBaseUri='"
-                + API_BASE_URI
-                + '\''
-                + ", apiCommandsUri='"
-                + API_COMMANDS_ENDPOINT
-                + '\''
-                + ", indexName='"
-                + COMMAND_INDEX
-                + '\''
-                + ", indexTemplate='"
-                + COMMAND_INDEX_TEMPLATE
-                + '\''
-                + ", jobIndex='"
-                + JOB_INDEX
-                + '\''
-                + ", jobType='"
-                + JOB_TYPE
                 + '}';
     }
 }

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/settings/PluginSettings.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/settings/PluginSettings.java
@@ -82,7 +82,7 @@ public class PluginSettings {
         this.jobSchedule = JOB_SCHEDULE.get(settings);
         this.jobPageSize = JOB_PAGE_SIZE.get(settings);
         this.jobKeepAlive = JOB_KEEP_ALIVE.get(settings);
-        log.error("Settings loaded: {}", this.toString());
+        log.debug("Settings loaded: {}", this.toString());
     }
 
     /**


### PR DESCRIPTION
### Description
This PR logs the plugin's settings on start up.

```log
[c.w.c.s.PluginSettings   ] [integTest-0] Settings loaded: {timeout=2, jobSchedule=1, jobPageSize=100, jobKeepAlive=30}
```

### Issues Resolved
Closes #225
