### PR TITLE
Fix commands manager arguments parsing

### DIFF
--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
@@ -16,8 +16,6 @@
  */
 package com.wazuh.commandmanager.model;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -30,7 +28,6 @@ import java.util.Map;
 
 /** Handles the command.action.args object */
 public class Args implements ToXContentObject {
-    private static final Logger log = LogManager.getLogger(Args.class);
 
     public static final String ARGS = "args";
     private final Map<String, Object> args;

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
@@ -97,11 +97,23 @@ public class Args implements ToXContentObject {
                     list = null;
                     isList = false;
                     break;
+                case START_OBJECT:
+                    args.put(fieldName, Args.parse(parser).getArgs());
+                    break;
                 default:
                     break;
             }
         }
         return new Args(args);
+    }
+
+    /**
+     * Required for the parsing of nested objects.
+     *
+     * @return internal args map.
+     */
+    public Map<String, Object> getArgs() {
+        return this.args;
     }
 
     /**


### PR DESCRIPTION
### Description
Change the parsing of `command.acttion.args` so it can receive nested objects.

### Issues Resolved
[244](https://github.com/wazuh/wazuh-indexer-plugins/issues/244)