### PR TITLE
Add control to set-group and fetch-config actions

### DIFF
--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
@@ -54,7 +54,7 @@ public class Action implements ToXContentObject {
      * @return initialized instance of Action.
      * @throws IOException parsing error occurred.
      */
-    public static Action parse(XContentParser parser) throws IOException {
+    public static Action parse(XContentParser parser) throws IOException, IllegalArgumentException {
         String name = "";
         Args args = new Args();
         String version = "";
@@ -67,7 +67,7 @@ public class Action implements ToXContentObject {
                     name = parser.text();
                     break;
                 case Args.ARGS:
-                    args = Args.parse(parser);
+                    args = parseArgs(name, parser);
                     break;
                 case VERSION:
                     version = parser.text();
@@ -104,5 +104,18 @@ public class Action implements ToXContentObject {
                 + this.version
                 + '\''
                 + '}';
+    }
+
+    private static Args parseArgs(String actionName, XContentParser parser)
+            throws IOException, NullPointerException {
+        ActionName actionNameEnum = ActionName.SET_GROUP;
+        if (actionName.contains(actionNameEnum.getName())) {
+            return Args.setGroupParse(parser);
+        }
+        actionNameEnum = ActionName.FETCH_GROUP;
+        if (actionName.contains(actionNameEnum.getName())) {
+            return new Args();
+        }
+        return Args.generalParse(parser);
     }
 }

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
@@ -16,6 +16,8 @@
  */
 package com.wazuh.commandmanager.model;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
@@ -30,6 +32,7 @@ public class Action implements ToXContentObject {
     public static final String ACTION = "action";
     public static final String NAME = "name";
     public static final String VERSION = "version";
+    private static final Logger log = LogManager.getLogger(Action.class);
     private final String name;
     private final Args args;
     private final String version;
@@ -114,6 +117,10 @@ public class Action implements ToXContentObject {
         }
         actionNameEnum = ActionName.FETCH_GROUP;
         if (actionName.contains(actionNameEnum.getName())) {
+            while (parser.currentToken() != XContentParser.Token.END_OBJECT) {
+                //Just move the parser to the end of the object
+                parser.nextToken();
+            }
             return new Args();
         }
         return Args.generalParse(parser);

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/ActionName.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/ActionName.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.commandmanager.model;
+
+import java.util.Locale;
+
+public enum ActionName {
+    SET_GROUP("set-group"),
+    FETCH_GROUP("fetch-group");
+
+    private final String name;
+
+    ActionName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
@@ -107,6 +107,7 @@ public class Args implements ToXContentObject {
                     break;
             }
         }
+        log.info("General parse args. FINISH token {}", parser.currentToken());
         return new Args(args);
     }
 
@@ -134,13 +135,14 @@ public class Args implements ToXContentObject {
                 }
             }
             args.put(fieldName, list);
+
             // to end the object parser
             parser.nextToken();
-            return new Args(args);
-        } else {
-            throw new IllegalArgumentException(
-                    "Incorrect request. An array of agents is expected in args.");
+            if (parser.currentToken() == XContentParser.Token.END_OBJECT) {
+                return new Args(args);
+            }
         }
+            throw new IllegalArgumentException("Incorrect request. An array of agents is expected in args.");
     }
 
     /**


### PR DESCRIPTION
### Description
Create a dedicated parser for set -group and fetch-config commands.

The set-group command accepts an array of strings within action.args, comprising the complete list of groups for this agent. In case of a mismatch on this command, the request will be rejected.

The fetch-config command accepts no arguments. In case of a mismatch on this command, mismatching values are ignored, and the request is accepted.

### Issues Resolved
[248](https://github.com/wazuh/wazuh-indexer-plugins/issues/248)