### PR TITLE
Change alpha1 to alpha0

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "alpha1"
+  "stage": "alpha0"
 }


### PR DESCRIPTION
### Description
The repository's `VERSION.json` file is pointing to stage `alpha1`, when it should be `alpha0`.

### Related Issues
Resolves #276 

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.