### PR TITLE
Changes empty values for null (indexer-plugins)

### DIFF
--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Action.java
@@ -57,7 +57,7 @@ public class Action implements ToXContentObject {
      * @throws IOException parsing error occurred.
      */
     public static Action parse(XContentParser parser) throws IOException, IllegalArgumentException {
-        String name = "";
+        String name = null;
         Args args = new Args();
         String version = null;
 

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Args.java
@@ -56,7 +56,7 @@ public class Args implements ToXContentObject {
     public static Args parse(XContentParser parser) throws IOException {
         Map<String, Object> args = new HashMap<>();
 
-        String fieldName = "";
+        String fieldName = null;
         List<Object> list = null;
         boolean isList = false;
 
@@ -86,9 +86,9 @@ public class Args implements ToXContentObject {
                     break;
                 case VALUE_NULL:
                     if (isList) {
-                        list.add("");
+                        list.add(null);
                     } else {
-                        args.put(fieldName, "");
+                        args.put(fieldName, null);
                     }
                     break;
                 case END_ARRAY:

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Orders.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Orders.java
@@ -96,7 +96,7 @@ public class Orders implements ToXContentObject {
 
         for (Command command : commands) {
             List<Agent> agentList = new ArrayList<>();
-            String queryField = "";
+            String queryField = null;
             Target.Type targetType = command.getTarget().getType();
             String targetId = command.getTarget().getId();
 

--- a/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Target.java
+++ b/plugins/command-manager/src/main/java/com/wazuh/commandmanager/model/Target.java
@@ -112,7 +112,7 @@ public class Target implements ToXContentObject {
      */
     public static Target parse(XContentParser parser) throws IOException {
         Type type = null;
-        String id = "";
+        String id = null;
 
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = parser.currentName();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/GenericDocument.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/GenericDocument.java
@@ -51,7 +51,7 @@ public class GenericDocument implements ToXContentObject {
         Map<String, Object> source = new HashMap<>();
         String id = null;
 
-        String fieldName = "";
+        String fieldName = null;
         List<Object> list = null;
         boolean isList = false;
 
@@ -85,9 +85,9 @@ public class GenericDocument implements ToXContentObject {
                     break;
                 case VALUE_NULL:
                     if (isList) {
-                        list.add("");
+                        list.add(null);
                     } else {
-                        source.put(fieldName, "");
+                        source.put(fieldName, null);
                     }
                     break;
                 case END_ARRAY:

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/ctiapi/Offset.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/ctiapi/Offset.java
@@ -126,7 +126,7 @@ public class Offset implements ToXContentObject {
         String resource = null;
         String type = null;
         Long version = null;
-        Map<String, Object> payload = new HashMap<>();
+        Map<String, Object> payload = null;
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
                 String fieldName = parser.currentName();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/ctiapi/Offset.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/ctiapi/Offset.java
@@ -126,7 +126,7 @@ public class Offset implements ToXContentObject {
         String resource = null;
         String type = null;
         Long version = null;
-        Map<String, Object> payload = null;
+        Map<String, Object> payload = new HashMap<>();
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
                 String fieldName = parser.currentName();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/ctiapi/Offsets.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/ctiapi/Offsets.java
@@ -36,7 +36,7 @@ public class Offsets implements ToXContentObject {
      * @param offsetList a List of the Offset objects, containing a json patch each.
      */
     public Offsets(List<Offset> offsetList) {
-        this.offsetList = offsetList;
+        this.offsetList = (offsetList == null || offsetList.isEmpty()) ? null : offsetList;
     }
 
     /**


### PR DESCRIPTION
### Description
In order to avoid indexing void data, empty arrays and strings such as `""` and `[]` are modified by `null`.

### Issues Resolved
[Management of null values on indices #593](https://github.com/wazuh/wazuh-indexer/issues/593)
