### PR TITLE
Add install instructions for cargo, mdbook and mdbook-mermaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Dependencies
 
 ### Changed
+- Improved mdbook installation instructions [#332](https://github.com/wazuh/wazuh-indexer-plugins/pull/332)
 - Third-party integrations maintenance [(#299)](https://github.com/wazuh/wazuh-indexer-plugins/pull/299)
 - Upgrade to Opensearch 2.19.1 [(#304)](https://github.com/wazuh/wazuh-indexer-plugins/pull/304)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,18 @@ This folder contains the technical documentation for the Wazuh Indexer. The docu
 
 ## Requirements
 
-To work with this documentation, you need **mdBook** installed. For installation instructions, refer to the [mdBook documentation](https://rust-lang.github.io/mdBook/).
+To work with this documentation, you need **mdBook** installed.
+
+- Get the latest `cargo` (hit enter when prompted for a default install)
+  ```bash
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+
+- Install `mdbook` and `mdbook-mermaid`
+  ```bash
+  cargo install mdbook
+  cargo install mdbook-mermaid
+  ```
 
 ## Usage
 


### PR DESCRIPTION
### Description
This PR fixes the docs `README.md` to include `cargo` installation instructions so as to avoid issues with distribution-packaged versions which cannot resolve dependencies properly.

### Issues Resolved
Closes #331 
