### PR TITLE
Change snapshot download directory to Java's temporary folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improve ECS documentation I [(#328)](https://github.com/wazuh/wazuh-indexer-plugins/pull/328)
 - Improve ECS documentation II [(#350)](https://github.com/wazuh/wazuh-indexer-plugins/pull/350)
 - Index RBAC information on startup [(#356)](https://github.com/wazuh/wazuh-indexer-plugins/pull/356)
+- Change snapshot download directory to Java's tmp folder [(#382)](https://github.com/wazuh/wazuh-indexer-plugins/pull/382)
 
 ### Deprecated
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/client/CTIClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/client/CTIClient.java
@@ -54,7 +54,6 @@ public class CTIClient extends HttpClient {
     private static final String CONSUMER_INFO_ENDPOINT =
             "/catalog/contexts/" + PluginSettings.CONTEXT_ID + "/consumers/" + PluginSettings.CONSUMER_ID;
     private static final String CONSUMER_CHANGES_ENDPOINT = CONSUMER_INFO_ENDPOINT + "/changes";
-    public static final String SNAPTHOT_SUFFIX = ".zip";
 
     private static CTIClient INSTANCE;
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotHelper.java
@@ -102,7 +102,7 @@ public class SnapshotHelper implements ClusterStateListener {
                         // Download
                         Path snapshotZip =
                                 this.ctiClient.download(this.contextIndex.getLastSnapshotLink(), this.environment);
-                        Path outputDir = this.environment.resolveRepoFile("");
+                        Path outputDir = Path.of(System.getProperty("java.io.tmpdir"));
 
                         try (DirectoryStream<Path> stream = this.getStream(outputDir)) {
                             this.unzip(snapshotZip, outputDir);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotHelper.java
@@ -102,7 +102,7 @@ public class SnapshotHelper implements ClusterStateListener {
                         // Download
                         Path snapshotZip =
                                 this.ctiClient.download(this.contextIndex.getLastSnapshotLink(), this.environment);
-                        Path outputDir = Path.of(System.getProperty("java.io.tmpdir"));
+                        Path outputDir = this.environment.tmpFile();
 
                         try (DirectoryStream<Path> stream = this.getStream(outputDir)) {
                             this.unzip(snapshotZip, outputDir);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SnapshotHelperTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SnapshotHelperTests.java
@@ -127,7 +127,7 @@ public class SnapshotHelperTests extends OpenSearchTestCase {
         doReturn("http://example.com/file.zip").when(this.contextIndex).getLastSnapshotLink();
         doReturn(snapshotZip).when(this.ctiClient).download(anyString(), any(Environment.class));
         Path outputDir = mock(Path.class);
-        doReturn(outputDir).when(this.environment).resolveRepoFile(anyString());
+        doReturn(outputDir).when(this.environment).tmpFile();
         DirectoryStream<Path> stream = mock(DirectoryStream.class);
         Path jsonPath = mock(Path.class);
         Iterator<Path> iterator = mock(Iterator.class);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/UnzipTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/UnzipTests.java
@@ -94,6 +94,7 @@ public class UnzipTests extends OpenSearchTestCase {
     public void testFileNotFoundException() {
         assertThrows(
                 FileNotFoundException.class,
-                () -> Unzip.unzip(environment.resolveRepoFile("fake.txt"), this.tempDestinationDirectory));
+                () ->
+                        Unzip.unzip(environment.tmpFile().resolve("fake.txt"), this.tempDestinationDirectory));
     }
 }


### PR DESCRIPTION
### Description
This PR fixes the snapshot download logic to use a directory that's available both at `./gradlew run` as well as installed packages.

### Issues Resolved
Closes #381 
