### PR TITLE
Fix flaky integration tests

### DIFF
--- a/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
+++ b/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         # Fetch the base branch to compare against
-        git fetch origin ${{ inputs.base_branch }}:refs/remotes/origin/${{ inputs.base_branch }}
+        git fetch origin/main:refs/remotes/origin/${{ inputs.base_branch }}
 
         # Compare the changes between the current branch and the base branch
         changed_files=$(git diff --name-only origin/${{ inputs.base_branch }})

--- a/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
+++ b/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
@@ -2,8 +2,9 @@ name: "Detect Modified Plugins"
 description: "Detect modified plugins based on changed files in a pull request or push event."
 inputs:
   base_branch:
-    description: 'Base branch to compare.'
-    required: true
+    description: 'Base branch to compare against. Default is "main".'
+    default: 'main'
+    required: false
 outputs:
   projects:
     description: 'List of modified plugins as a JSON array. For example: ["plugin-A", "plugin-B"]'
@@ -17,10 +18,10 @@ runs:
       shell: bash
       run: |
         # Fetch the base branch to compare against
-        git fetch origin main:refs/remotes/origin/main
+        git fetch origin ${{ inputs.base_branch }}:refs/remotes/origin/${{ inputs.base_branch }}
 
         # Compare the changes between the current branch and the base branch
-        changed_files=$(git diff --name-only origin/main)
+        changed_files=$(git diff --name-only origin/${{ inputs.base_branch }})
 
         affected_projects=()
 

--- a/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
+++ b/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
@@ -20,7 +20,7 @@ runs:
         git fetch origin main:refs/remotes/origin/main
 
         # Compare the changes between the current branch and the base branch
-        changed_files=$(git diff --name-only origin/main
+        changed_files=$(git diff --name-only origin/main)
 
         affected_projects=()
 

--- a/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
+++ b/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
@@ -2,7 +2,7 @@ name: "Detect Modified Plugins"
 description: "Detect modified plugins based on changed files in a pull request or push event."
 inputs:
   base_branch:
-    description: "The base branch to compare against (e.g., main or develop)"
+    description: 'Base branch to compare.'
     required: true
 outputs:
   projects:
@@ -17,10 +17,10 @@ runs:
       shell: bash
       run: |
         # Fetch the base branch to compare against
-        git fetch origin ${{ inputs.base_branch }}:refs/remotes/origin/${{ inputs.base_branch }}
+        git fetch origin main:refs/remotes/origin/main
 
         # Compare the changes between the current branch and the base branch
-        changed_files=$(git diff --name-only origin/${{ inputs.base_branch }})
+        changed_files=$(git diff --name-only origin/main
 
         affected_projects=()
 

--- a/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
+++ b/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         # Fetch the base branch to compare against
-        git fetch origin main:refs/remotes/origin/${{ inputs.base_branch }}
+        git fetch origin ${{ inputs.base_branch }}:refs/remotes/origin/${{ inputs.base_branch }}
 
         # Compare the changes between the current branch and the base branch
         changed_files=$(git diff --name-only origin/${{ inputs.base_branch }})

--- a/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
+++ b/.github/actions/5_codeanalysis_detect_modified_plugins/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         # Fetch the base branch to compare against
-        git fetch origin/main:refs/remotes/origin/${{ inputs.base_branch }}
+        git fetch origin main:refs/remotes/origin/${{ inputs.base_branch }}
 
         # Compare the changes between the current branch and the base branch
         changed_files=$(git diff --name-only origin/${{ inputs.base_branch }})

--- a/.github/workflows/5_builderpackage_plugins_onpush.yml
+++ b/.github/workflows/5_builderpackage_plugins_onpush.yml
@@ -28,8 +28,6 @@ jobs:
       - name: Detect modified plugins
         id: detect_changes
         uses: ./.github/actions/5_codeanalysis_detect_modified_plugins
-        with:
-          base_branch: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
   call-build-workflow:
     needs: modified-plugins

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -29,9 +29,7 @@ jobs:
       - name: Detect modified plugins
         id: detect_changes
         uses: ./.github/actions/5_codeanalysis_detect_modified_plugins
-        with:
-          base_branch: ${{ github.event.pull_request.base.ref }}
-
+        
       # Run tests for affected projects
       - name: Run tests for affected projects
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement content update using Json Patch operations [(#362)](https://github.com/wazuh/wazuh-indexer-plugins/pull/362)
 - Implement CTI API client rate limit and enhanced response handling [(#363)](https://github.com/wazuh/wazuh-indexer-plugins/pull/363)
 - Add custom action to list modified plugins [(#388)](https://github.com/wazuh/wazuh-indexer-plugins/pull/388)
-- Implement a mechanism that refresh the index to fix test failures [(#391)](https://github.com/wazuh/wazuh-indexer-plugins/pull/391)
 
 ### Dependencies
 
@@ -48,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix validation of commands by forcing `action.name` to exist before `action.args` [(#260)](https://github.com/wazuh/wazuh-indexer-plugins/issues/260)
 - Fix mentions of `host.ip` and `host.os.full` in agents index template [(#330)](https://github.com/wazuh/wazuh-indexer-plugins/pull/330)
 - Fix workflow to build plugins on push [(#384)](https://github.com/wazuh/wazuh-indexer-plugins/pull/384)
+- Fix flaky integration tests [(#391)](https://github.com/wazuh/wazuh-indexer-plugins/pull/391)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement content update using Json Patch operations [(#362)](https://github.com/wazuh/wazuh-indexer-plugins/pull/362)
 - Implement CTI API client rate limit and enhanced response handling [(#363)](https://github.com/wazuh/wazuh-indexer-plugins/pull/363)
 - Add custom action to list modified plugins [(#388)](https://github.com/wazuh/wazuh-indexer-plugins/pull/388)
+- Implement a mechanism that refresh the index to fix test failures [(#391)](https://github.com/wazuh/wazuh-indexer-plugins/pull/391)
 
 ### Dependencies
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
@@ -99,13 +99,8 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
-        Privileged.doPrivilegedRequest(
-            () -> {
-                RefreshRequest request = new RefreshRequest(contentIndex.INDEX_NAME);
-                this.client.admin().indices().refresh(request).actionGet();
-                return null;
-            }
-        );
+        RefreshRequest request = new RefreshRequest(ContentIndex.INDEX_NAME);
+        this.client.admin().indices().refresh(request).actionGet();
 
         ConsumerInfo updatedConsumer =
                 this.contextIndex.getConsumer(PluginSettings.CONTEXT_ID, PluginSettings.CONSUMER_ID);
@@ -134,13 +129,8 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
-        Privileged.doPrivilegedRequest(
-            () -> {
-                RefreshRequest request = new RefreshRequest(contentIndex.INDEX_NAME);
-                this.client.admin().indices().refresh(request).actionGet();
-                return null;
-            }
-        );
+        RefreshRequest request = new RefreshRequest(ContentIndex.INDEX_NAME);
+        this.client.admin().indices().refresh(request).actionGet();
 
         ConsumerInfo updatedConsumer =
                 this.contextIndex.getConsumer(PluginSettings.CONTEXT_ID, PluginSettings.CONSUMER_ID);
@@ -171,13 +161,9 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
-        Privileged.doPrivilegedRequest(
-            () -> {
-                RefreshRequest request = new RefreshRequest(contentIndex.INDEX_NAME);
-                this.client.admin().indices().refresh(request).actionGet();
-                return null;
-            }
-        );
+        RefreshRequest request = new RefreshRequest(ContentIndex.INDEX_NAME);
+        this.client.admin().indices().refresh(request).actionGet();
+
 
         ConsumerInfo updatedConsumer =
                 this.contextIndex.getConsumer(PluginSettings.CONTEXT_ID, PluginSettings.CONSUMER_ID);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
@@ -18,6 +18,9 @@ package com.wazuh.contentmanager.updater;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
+import com.wazuh.contentmanager.utils.Privileged;
+import org.opensearch.action.admin.indices.refresh.RefreshRequest;
+import org.opensearch.action.admin.indices.refresh.RefreshResponse;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
@@ -27,6 +30,9 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.Before;
 
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,6 +57,7 @@ import static org.mockito.Mockito.*;
 @OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
 public class ContentUpdaterIT extends OpenSearchIntegTestCase {
     long initialOffset = 0L;
+    Client client;
     long lastOffset = 0L;
     String testResource = "test";
     ContentUpdater updater;
@@ -60,7 +67,7 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
 
     @Before
     public void setup() throws Exception {
-        Client client = client();
+        this.client = client();
         this.ctiClient = mock(CTIClient.class);
         this.contextIndex = spy(new ContextIndex(client));
         this.contentIndex = new ContentIndex(client);
@@ -92,7 +99,14 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
-        Thread.sleep(1000);
+        Privileged.doPrivilegedRequest(
+            () -> {
+                RefreshRequest request = new RefreshRequest(contentIndex.INDEX_NAME);
+                this.client.admin().indices().refresh(request).actionGet();
+                return null;
+            }
+        );
+
         ConsumerInfo updatedConsumer =
                 this.contextIndex.getConsumer(PluginSettings.CONTEXT_ID, PluginSettings.CONSUMER_ID);
         // Assert
@@ -120,7 +134,14 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
-        Thread.sleep(1000);
+        Privileged.doPrivilegedRequest(
+            () -> {
+                RefreshRequest request = new RefreshRequest(contentIndex.INDEX_NAME);
+                this.client.admin().indices().refresh(request).actionGet();
+                return null;
+            }
+        );
+
         ConsumerInfo updatedConsumer =
                 this.contextIndex.getConsumer(PluginSettings.CONTEXT_ID, PluginSettings.CONSUMER_ID);
         // Assert
@@ -150,7 +171,14 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
-        Thread.sleep(1000);
+        Privileged.doPrivilegedRequest(
+            () -> {
+                RefreshRequest request = new RefreshRequest(contentIndex.INDEX_NAME);
+                this.client.admin().indices().refresh(request).actionGet();
+                return null;
+            }
+        );
+
         ConsumerInfo updatedConsumer =
                 this.contextIndex.getConsumer(PluginSettings.CONTEXT_ID, PluginSettings.CONSUMER_ID);
         GetResponse getContent =

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
@@ -158,7 +158,6 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         RefreshRequest request = new RefreshRequest(ContentIndex.INDEX_NAME);
         this.client.admin().indices().refresh(request).actionGet();
 
-
         ConsumerInfo updatedConsumer =
                 this.contextIndex.getConsumer(PluginSettings.CONTEXT_ID, PluginSettings.CONSUMER_ID);
         GetResponse getContent =

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
@@ -78,10 +78,8 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
 
     /**
      * Tests whether a Create-type patch is correctly applied to the wazuh-cve index
-     *
-     * @throws InterruptedException Rethrown from Thread.sleep()
      */
-    public void testUpdate_ContentChangesTypeCreate() throws InterruptedException {
+    public void testUpdate_ContentChangesTypeCreate() {
         // Arrange
         long offsetId = 1L;
         Offset createOffset = this.getOffset(offsetId, OperationType.CREATE);
@@ -108,10 +106,8 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
 
     /**
      * Tests whether an update-type patch is correctly applied to the wazuh-cve index
-     *
-     * @throws InterruptedException Rethrown from Thread.sleep()
      */
-    public void testUpdate_ContentChangesTypeUpdate() throws InterruptedException {
+    public void testUpdate_ContentChangesTypeUpdate(){
         // Arrange
         long offsetId = 2L;
         Offset createOffset = this.getOffset(offsetId - 1, OperationType.CREATE);
@@ -140,7 +136,7 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
     /**
      * Tests whether a delete-type patch is correctly applied to the wazuh-cve index
      *
-     * @throws InterruptedException Rethrown from Thread.sleep()
+     * @throws InterruptedException
      * @throws ExecutionException
      * @throws TimeoutException
      */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
@@ -18,9 +18,7 @@ package com.wazuh.contentmanager.updater;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
-import com.wazuh.contentmanager.utils.Privileged;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
-import org.opensearch.action.admin.indices.refresh.RefreshResponse;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.Client;
@@ -30,9 +28,6 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.Before;
 
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/updater/ContentUpdaterIT.java
@@ -99,6 +99,7 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
+
         RefreshRequest request = new RefreshRequest(ContentIndex.INDEX_NAME);
         this.client.admin().indices().refresh(request).actionGet();
 
@@ -129,6 +130,7 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
+
         RefreshRequest request = new RefreshRequest(ContentIndex.INDEX_NAME);
         this.client.admin().indices().refresh(request).actionGet();
 
@@ -161,6 +163,7 @@ public class ContentUpdaterIT extends OpenSearchIntegTestCase {
         when(this.contextIndex.getConsumer(anyString(), anyString())).thenReturn(testConsumer);
         // Act
         boolean updated = this.updater.update();
+
         RefreshRequest request = new RefreshRequest(ContentIndex.INDEX_NAME);
         this.client.admin().indices().refresh(request).actionGet();
 


### PR DESCRIPTION
### Description
This PR solves the issue where the tests were being unstable due to the lack of refresh of the index content, to fix it the index is refreshed instead of waiting a second to refresh it.

### Issues Resolved
Closes [#wazuh-indexer/807](https://github.com/wazuh/wazuh-indexer/issues/807)
