### PR TITLE
Bump third-party integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Content Manager tier 1 final wrap up [#373](https://github.com/wazuh/wazuh-indexer-plugins/pull/373)
 - Refactor Content Manager's code and fix Catalog info indexing [(#317)](https://github.com/wazuh/wazuh-indexer-plugins/pull/317)
 - Improved mdbook installation instructions [#332](https://github.com/wazuh/wazuh-indexer-plugins/pull/332)
-- Third-party integrations maintenance [(#299)](https://github.com/wazuh/wazuh-indexer-plugins/pull/299) [(#374)](https://github.com/wazuh/wazuh-indexer-plugins/pull/374)[(#398)](https://github.com/wazuh/wazuh-indexer-plugins/pull/398)
+- Third-party integrations maintenance [(#299)](https://github.com/wazuh/wazuh-indexer-plugins/pull/299) [(#374)](https://github.com/wazuh/wazuh-indexer-plugins/pull/374) [(#398)](https://github.com/wazuh/wazuh-indexer-plugins/pull/398)
 - Upgrade to Opensearch 2.19.1 [(#304)](https://github.com/wazuh/wazuh-indexer-plugins/pull/304)
 - Add cross-account support for Security Lake integration [(#322)](https://github.com/wazuh/wazuh-indexer-plugins/pull/322)
 - Improve ECS documentation I [(#328)](https://github.com/wazuh/wazuh-indexer-plugins/pull/328)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Content Manager tier 1 final wrap up [#373](https://github.com/wazuh/wazuh-indexer-plugins/pull/373)
 - Refactor Content Manager's code and fix Catalog info indexing [(#317)](https://github.com/wazuh/wazuh-indexer-plugins/pull/317)
 - Improved mdbook installation instructions [#332](https://github.com/wazuh/wazuh-indexer-plugins/pull/332)
-- Third-party integrations maintenance [(#299)](https://github.com/wazuh/wazuh-indexer-plugins/pull/299) [(#374)](https://github.com/wazuh/wazuh-indexer-plugins/pull/374)
+- Third-party integrations maintenance [(#299)](https://github.com/wazuh/wazuh-indexer-plugins/pull/299) [(#374)](https://github.com/wazuh/wazuh-indexer-plugins/pull/374)[(#398)](https://github.com/wazuh/wazuh-indexer-plugins/pull/398)
 - Upgrade to Opensearch 2.19.1 [(#304)](https://github.com/wazuh/wazuh-indexer-plugins/pull/304)
 - Add cross-account support for Security Lake integration [(#322)](https://github.com/wazuh/wazuh-indexer-plugins/pull/322)
 - Improve ECS documentation I [(#328)](https://github.com/wazuh/wazuh-indexer-plugins/pull/328)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -30,4 +30,4 @@ We host development environments to support the following integrations:
 |                | Wazuh  | Logstash | OpenSearch | Elastic | Splunk |
 | -------------- | ------ | -------- | ---------- | ------- | ------ |
 | v1.0           | 4.8.1  | 8.9.0    | 2.14.0     | 8.14.3  | 9.1.4  |
-| Latest version | 4.11.2 | 8.9.0    | 2.19.1     | 8.17.4  | 9.4.1  |
+| Latest version | 4.11.2 | 8.9.0    | 2.19.2     | 8.17.5  | 9.4.1  |

--- a/integrations/docker/.env
+++ b/integrations/docker/.env
@@ -23,10 +23,10 @@ MEM_LIMIT=1073741824
 WAZUH_VERSION=4.11.2
 
 # Wazuh Indexer version (Provisionally using OpenSearch)
-WAZUH_INDEXER_VERSION=2.19.1
+WAZUH_INDEXER_VERSION=2.19.2
 
 # Wazuh Dashboard version (Provisionally using OpenSearch Dashboards)
-WAZUH_DASHBOARD_VERSION=2.19.1
+WAZUH_DASHBOARD_VERSION=2.19.2
 
 # Wazuh certs generator version
 WAZUH_CERTS_GENERATOR_VERSION=0.0.1
@@ -41,4 +41,4 @@ LOGSTASH_OSS_VERSION=8.9.0
 SPLUNK_VERSION=9.4.1
 
 # Version of Elastic products
-STACK_VERSION=8.17.4
+STACK_VERSION=8.17.5


### PR DESCRIPTION
### Description
This PR add maintenance operations to the third party integrations with the Indexer, including:

- Bump OpenSearch version to 2.19.2.
- Bump Elastic version to 8.17.5.

### Related Issues
Resolves #396 

### Check List

- [x] The Docker Compose project starts without errors.
- [x] The data arrives to the destination.
- [x] All the dashboards can be imported successfully.
- [x] All the dashboards are populated with data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).