### PR TITLE
Fix PatchOperation parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix workflow to build plugins on push [(#384)](https://github.com/wazuh/wazuh-indexer-plugins/pull/384)
 - Fix flaky integration tests [(#391)](https://github.com/wazuh/wazuh-indexer-plugins/pull/391)
 - Fix overwrite of content offset on each start [(#401)](https://github.com/wazuh/wazuh-indexer-plugins/pull/401)
+- Fix PatchOperation parse [(#411)](https://github.com/wazuh/wazuh-indexer-plugins/pull/411)
 
 ### Security
 - 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/cti/PatchOperation.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/cti/PatchOperation.java
@@ -73,10 +73,9 @@ public class PatchOperation implements ToXContentObject {
         String path = null;
         String from = null;
         String value = null;
-
         // Make sure we are at the start
         XContentParserUtils.ensureExpectedToken(
-                XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         // Iterate over the object and add each Offset object to changes array
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = parser.currentName(); // Get key

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/client/CTIClientTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/client/CTIClientTests.java
@@ -286,7 +286,6 @@ public class CTIClientTests extends OpenSearchIntegTestCase {
      *     - The {@link CTIClient#sendRequest(Method, String, String, Map, Header, int)} is invoked exactly 1 time.
      * </pre>
      */
-    @AwaitsFix(bugUrl = "https://github.com/wazuh/wazuh-indexer-plugins/issues/409")
     public void testGetChanges_SuccessfulRequest() {
         // Arrange
         SimpleHttpResponse response = new SimpleHttpResponse(HttpStatus.SC_SUCCESS, "OK");


### PR DESCRIPTION
### Description
This PR fixes the error from `PatchOperation.parse` where the token that was being compared was `parser.nextToken()` instead of `parser.currentToken()`.

With that changed, the error is solved.

### Issues Resolved
#409 