### PR TITLE
Clean `wazuh-cve` index on re-initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add custom action to list modified plugins [(#388)](https://github.com/wazuh/wazuh-indexer-plugins/pull/388)
 - Expose settings for the Content Manager plugin [(#395)](https://github.com/wazuh/wazuh-indexer-plugins/pull/395)
 - Add content update to to the Content Manager init process [(#421)](https://github.com/wazuh/wazuh-indexer-plugins/pull/421)
-- Implement clear method to remove all documents from wazuh-cve [(#431)](https://github.com/wazuh/wazuh-indexer-plugins/pull/431)
+- Clean wazuh-cve index on re-initialization [(#431)](https://github.com/wazuh/wazuh-indexer-plugins/pull/431)
 
 ### Dependencies
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add custom action to list modified plugins [(#388)](https://github.com/wazuh/wazuh-indexer-plugins/pull/388)
 - Expose settings for the Content Manager plugin [(#395)](https://github.com/wazuh/wazuh-indexer-plugins/pull/395)
 - Add content update to to the Content Manager init process [(#421)](https://github.com/wazuh/wazuh-indexer-plugins/pull/421)
-- Implement clear method to remove all documents from wazuh-cve [(#427)](https://github.com/wazuh/wazuh-indexer-plugins/pull/431)
+- Implement clear method to remove all documents from wazuh-cve [(#431)](https://github.com/wazuh/wazuh-indexer-plugins/pull/431)
 
 ### Dependencies
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add custom action to list modified plugins [(#388)](https://github.com/wazuh/wazuh-indexer-plugins/pull/388)
 - Expose settings for the Content Manager plugin [(#395)](https://github.com/wazuh/wazuh-indexer-plugins/pull/395)
 - Add content update to to the Content Manager init process [(#421)](https://github.com/wazuh/wazuh-indexer-plugins/pull/421)
+- Implement clear method to remove all documents from wazuh-cve [(#427)](https://github.com/wazuh/wazuh-indexer-plugins/pull/431)
 
 ### Dependencies
 -

--- a/docs/dev/run-tests.md
+++ b/docs/dev/run-tests.md
@@ -16,6 +16,6 @@ To run integration tests, use the `./gradlew integTest` and the `./gradlew yamlr
 
 ### Package testing
 
-For package testing, we conduct smoke tests on the packages using the [GitHub Actions Workflows](https://github.com/wazuh/wazuh-indexer/blob/6.0.0/.github/workflows/5_builderpackage_indexer.yml). These tests consist on installing the packages on a supported operating system. DEB packages are installed in the “Ubuntu 24.04” runner executing the workflow, while RPM packages are installed in a Red Hat 9 Docker container, as there is no RPM compatible runner available in GitHub Actions.
+For package testing, we conduct smoke tests on the packages using the [GitHub Actions Workflows](https://github.com/wazuh/wazuh-indexer/blob/6.0.0/.github/workflows/6_builderpackage_indexer.yml). These tests consist on installing the packages on a supported operating system. DEB packages are installed in the “Ubuntu 24.04” runner executing the workflow, while RPM packages are installed in a Red Hat 9 Docker container, as there is no RPM compatible runner available in GitHub Actions.
 
 As a last note, there is also a **Vagrantfile** and **testing scripts** in the [repository](https://github.com/wazuh/wazuh-indexer-plugins/tree/main/test-tools) to perform some tests on a real wazuh-indexer service running on a virtual machine. Refer to its README.md for more information about how to run these tests.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/index/ContentIndex.java
@@ -35,6 +35,10 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.mapper.StrictDynamicMappingException;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequestBuilder;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -54,10 +58,6 @@ import com.wazuh.contentmanager.model.cti.Operation;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.JsonPatch;
 import com.wazuh.contentmanager.utils.XContentUtils;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.reindex.BulkByScrollResponse;
-import org.opensearch.index.reindex.DeleteByQueryAction;
-import org.opensearch.index.reindex.DeleteByQueryRequestBuilder;
 
 /** Manages operations for a content index. */
 public class ContentIndex {
@@ -314,23 +314,19 @@ public class ContentIndex {
             }
         }
     }
-    /**
-     * Clears all documents from the {@link ContentIndex#INDEX_NAME} index.
-     */
+
+    /** Clears all documents from the {@link ContentIndex#INDEX_NAME} index. */
     public void clear() {
         try {
             DeleteByQueryRequestBuilder deleteByQuery =
                     new DeleteByQueryRequestBuilder(this.client, DeleteByQueryAction.INSTANCE);
-            deleteByQuery
-                    .source(INDEX_NAME)
-                    .filter(QueryBuilders.matchAllQuery());
+            deleteByQuery.source(ContentIndex.INDEX_NAME).filter(QueryBuilders.matchAllQuery());
 
             BulkByScrollResponse response = deleteByQuery.get();
-            log.debug("Delete query removed {} documents", response.getDeleted());
+            log.debug(
+                    "[{}] wiped. {} documents were removed", ContentIndex.INDEX_NAME, response.getDeleted());
         } catch (OpenSearchTimeoutException e) {
-            log.error("Delete query timed out: {}", e.getMessage());
+            log.error("[{}] delete query timed out: {}", ContentIndex.INDEX_NAME, e.getMessage());
         }
     }
-
-
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotManager.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotManager.java
@@ -98,6 +98,9 @@ public class SnapshotManager {
      * a CTI snapshot.
      */
     protected void indexSnapshot(ConsumerInfo consumerInfo) {
+        // Clears the content of the index
+        this.contentIndex.clear();
+
         if (consumerInfo.getOffset() == 0) {
             log.info("Initializing [{}] index from a snapshot", ContentIndex.INDEX_NAME);
             this.privileged.doPrivilegedRequest(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotManager.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SnapshotManager.java
@@ -98,11 +98,10 @@ public class SnapshotManager {
      * a CTI snapshot.
      */
     protected void indexSnapshot(ConsumerInfo consumerInfo) {
-        // Clears the content of the index
-        this.contentIndex.clear();
-
         if (consumerInfo.getOffset() == 0) {
             log.info("Initializing [{}] index from a snapshot", ContentIndex.INDEX_NAME);
+            // Clears the content of the index
+            this.contentIndex.clear();
             this.privileged.doPrivilegedRequest(
                     () -> {
                         // Download snapshot.


### PR DESCRIPTION
### Description
This PR fixes the bug where the content of `wazuh-cve` index was not being cleaned on recovery from snapshot using a `DeleteByQueryRequestBuilder`.

### Issues Resolved
#427 
