### PR TITLE
Fix arguments for the Content Manager's `update` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Upgrade to Opensearch 2.19.2 [(#399)](https://github.com/wazuh/wazuh-indexer-plugins/pull/399)
 - Simplify snapshot initialization process [(#390)](https://github.com/wazuh/wazuh-indexer-plugins/pull/390)
 - Refactor snapshot download [(#413)](https://github.com/wazuh/wazuh-indexer-plugins/pull/413)
+- Modify offset and command index fields [(#441)](https://github.com/wazuh/wazuh-indexer-plugins/pull/441)
 
 ### Deprecated
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Upgrade to Opensearch 2.19.2 [(#399)](https://github.com/wazuh/wazuh-indexer-plugins/pull/399)
 - Simplify snapshot initialization process [(#390)](https://github.com/wazuh/wazuh-indexer-plugins/pull/390)
 - Refactor snapshot download [(#413)](https://github.com/wazuh/wazuh-indexer-plugins/pull/413)
-- Modify offset and command index fields [(#441)](https://github.com/wazuh/wazuh-indexer-plugins/pull/441)
 
 ### Deprecated
 -
@@ -63,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix PatchOperation parse [(#411)](https://github.com/wazuh/wazuh-indexer-plugins/pull/411)
 - Fix unauthorized request to the Command Manager API [(#394)](https://github.com/wazuh/wazuh-indexer-plugins/pull/394)
 - Fix Vagrant test environment certificates [(#424)](https://github.com/wazuh/wazuh-indexer-plugins/pull/424)
+- Fix arguments for the Content Manager's `update` command [(#441)](https://github.com/wazuh/wazuh-indexer-plugins/pull/441)
 
 ### Security
 -

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/index/ContentIndex.java
@@ -86,8 +86,8 @@ public class ContentIndex {
     /**
      * This constructor is only used on tests.
      *
-     * @param client @Client (mocked).
-     * @param pluginSettings @PluginSettings (mocked).
+     * @param client Client (mocked).
+     * @param pluginSettings PluginSettings (mocked).
      */
     public ContentIndex(Client client, PluginSettings pluginSettings) {
         this.pluginSettings = pluginSettings;

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/command/Command.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/model/command/Command.java
@@ -23,6 +23,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
+import com.wazuh.contentmanager.index.ContentIndex;
+
 /** This class represents the model of the posted command to the Command Manager API. */
 public class Command {
     /** Constructs the JSON request body for the command. */
@@ -43,7 +45,7 @@ public class Command {
                     .startObject("action")
                     .field("name", "update")
                     .startObject("args")
-                    .field("index", "content-index")
+                    .field("index", ContentIndex.INDEX_NAME)
                     .field("offset", offset)
                     .endObject()
                     .field("version", "6.0.0") // Dynamic version

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Privileged.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Privileged.java
@@ -42,7 +42,7 @@ public class Privileged {
     public void postUpdateCommand(CommandManagerClient client, ConsumerInfo current) {
         this.doPrivilegedRequest(
                 () -> {
-                    client.post(Command.create(String.valueOf(current.getLastOffset())));
+                    client.post(Command.create(String.valueOf(current.getOffset())));
                     return null;
                 });
     }


### PR DESCRIPTION
### Description
The command for the Command Manager contains invalid data. The offset and index values are wrong, whereas the offset is the latest offset obtained from the CTI and not the latest offset of the indexed data, and the index name is a generic one (wazuh-content).

- offset: now the offset should match the consumer's offset and not the last offset
- index name: now "wazuh-content" is "wazuh-cve" as specified by the ContentIndex.INDEX_NAME

### Issues Resolved
Closes #428 