### PR TITLE
Replace dependabot's directories keys with wildcard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 updates:
   - directories:
-      - "/plugins/setup"
-      - "/plugins/command-manager"
+      - "/plugins/*"
     open-pull-requests-limit: 1
     package-ecosystem: gradle
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - 
 
 ### Changed
-- 
+- Replace dependabot's directories keys with wildcard [(#443)](https://github.com/wazuh/wazuh-indexer-plugins/pull/443)
 
 ### Deprecated
 - 


### PR DESCRIPTION
### Description
This PR adds a wildcard to match every plugin of the repo, removing the maintenance of Dependabot's configuration.

> [!NOTE]
> Port to 6.0.0. 

### Issues Resolved
Closes #442 
