### PR TITLE
Add new scripts for testing purposes

### DIFF
--- a/scripts/opensearch_version.sh
+++ b/scripts/opensearch_version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check if an argument is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <directory_name>"
+  exit 1
+fi
+
+file="plugins/$1/build.gradle"
+
+# Extract the OpenSearch version
+opensearch_version=$(grep "opensearch_version =" "$file" | \
+sed -E 's/.*System.getProperty\("opensearch\.version", "//' | \
+sed -E 's/".*//' | \
+sed -E 's/-SNAPSHOT$//')
+
+echo "$opensearch_version"

--- a/scripts/product_version.sh
+++ b/scripts/product_version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## Check that jq is installed
+if [ ! -e '/usr/bin/jq' ]
+then
+  echo "ERROR: jq command could not be found under /usr/bin"
+  exit 1
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+jq -r .version ../VERSION.json
+
+exit 0


### PR DESCRIPTION
### Description
This PR adds some scripts to the `scripts` folder in order to perform some tests on the package builder workflows

`opensearch_version.sh` is a new script that, using a plugin name as a reference obtains the version of OpenSearch that it is using.
`/opensearch_version.sh` is a migration of 6.0.0, this scripts obtains the Wazuh version of the branch

### Issues Resolved
Resolves: https://github.com/wazuh/wazuh-indexer/issues/934
