### PR TITLE
Reduce risk of `GITHUB_TOKEN` exposure

### DIFF
--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -52,7 +52,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       actions: read
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -50,6 +50,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/5_builderpackage_templates.yml
+++ b/.github/workflows/5_builderpackage_templates.yml
@@ -9,6 +9,9 @@ jobs:
   run-ecs-generator:
     if: github.repository == 'wazuh/wazuh-indexer-plugins'
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
     env:
       output_folder: /tmp/ecs-templates
 

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -8,6 +8,8 @@ jobs:
   verify-changelog:
     if: github.repository == 'wazuh/wazuh-indexer-plugins'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/5_codequality_links.yml
+++ b/.github/workflows/5_codequality_links.yml
@@ -5,7 +5,8 @@ on:
 jobs:
   linkchecker:
     runs-on: ubuntu-24.04
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: lychee Link Checker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improve ECS folder structure [(#473)](https://github.com/wazuh/wazuh-indexer-plugins/pull/473)
 
 ### Security
--
+- Reduce risk of GITHUB_TOKEN exposure [(#484)](https://github.com/wazuh/wazuh-indexer-plugins/pull/484)
 
 [Unreleased 5.0.x]: https://github.com/wazuh/wazuh-indexer-plugins/compare/main...main


### PR DESCRIPTION

### Description
This PR adds permissions to the workflows of main branch that use `GITHUB_TOKEN` to reduce the risk of exposure of the token

### Issues Resolved
Closes https://github.com/wazuh/internal-devel-requests/issues/2507
