### PR TITLE
Migrate WCS changes from 4.x

### DIFF
--- a/ecs/states-fim-files/docs/fields.csv
+++ b/ecs/states-fim-files/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
@@ -15,7 +13,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0,true,file,file.mtime,date,extended,,,Last time the file content was modified.
 8.11.0,true,file,file.owner,keyword,extended,,alice,File owner's username.
 8.11.0,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-8.11.0,true,file,file.path.text,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.11.0,true,file,file.size,long,extended,,16384,File size in bytes.
 8.11.0,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 8.11.0,true,wazuh,wazuh.cluster.name,keyword,custom,,,Wazuh cluster name.

--- a/ecs/states-fim-registries/docs/fields.csv
+++ b/ecs/states-fim-registries/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.

--- a/ecs/states-inventory-hardware/docs/README.md
+++ b/ecs/states-inventory-hardware/docs/README.md
@@ -13,19 +13,20 @@ The detail of the fields can be found in csv file [States inventory hardware Fie
 
 ### Transition table
 
-| Field Name     | Type   | Description                                | Destination Field    | Custom |
-| -------------- | ------ | ------------------------------------------ | -------------------- | ------ |
-| agent_id       | string | Unique ID of the agent.                    | agent.id             | FALSE  |
-| agent_ip       | string | IP address of the agent.                   | agent.host.ip        | TRUE   |
-| agent_name     | string | Name of the agent.                         | agent.name           | FALSE  |
-| agent_version  | string | Agent version.                             | agent.version        | FALSE  |
-| board_serial   | string | Serial number of the motherboard.          | host.serial_number   | TRUE   |
-| cpu_name       | string | Name/model of the CPU.                     | host.cpu.name        | TRUE   |
-| cpu_cores      | long   | Number of CPU cores.                       | host.cpu.cores       | TRUE   |
-| cpu_mhz        | double | CPU clock speed in MHz.                    | host.cpu.speed       | TRUE   |
-| ram_total      | long   | Total RAM available in the system (Bytes). | host.memory.total    | TRUE   |
-| ram_free       | long   | Free RAM available in the system (Bytes).  | host.memory.free     | TRUE   |
-| ram_usage      | long   | RAM usage in Bytes.                        | host.memory.used     | TRUE   |
-| cluster_name   | string | Wazuh cluster name                         | wazuh.cluster.name   | TRUE   |
-| cluster_node   | string | Wazuh cluster node                         | wazuh.cluster.node   | TRUE   |
-| schema_version | string | Wazuh schema version                       | wazuh.schema.version | TRUE   |
+| Field Name     | Type         | Description                           | Destination Field    | Custom |
+| -------------- | ------------ | ------------------------------------- | -------------------- | ------ |
+| agent_id       | string       | Unique ID of the agent.               | agent.id             | FALSE  |
+| agent_ip       | string       | IP address of the agent.              | agent.host.ip        | TRUE   |
+| agent_name     | string       | Name of the agent.                    | agent.name           | FALSE  |
+| agent_version  | string       | Agent version.                        | agent.version        | FALSE  |
+| board_serial   | string       | Serial Number of the device.          | host.serial_number   | TRUE   |
+| cpu_name       | string       | Name/model of the CPU.                | host.cpu.name        | TRUE   |
+| cpu_cores      | long         | Number of CPU cores.                  | host.cpu.cores       | TRUE   |
+| cpu_mhz        | double       | CPU clock speed in MHz.               | host.cpu.speed       | TRUE   |
+| ram_total      | long         | Total memory, in Bytes.               | host.memory.total    | TRUE   |
+| ram_free       | long         | Free memory, in Bytes.                | host.memory.free     | TRUE   |
+| -              | long         | Used memory, in Bytes.                | host.memory.used     | TRUE   |
+| ram_usage      | scaled_float | Percent memory used, between 0 and 1. | host.memory.usage    | TRUE   |
+| cluster_name   | string       | Wazuh cluster name                    | wazuh.cluster.name   | TRUE   |
+| cluster_node   | string       | Wazuh cluster node                    | wazuh.cluster.node   | TRUE   |
+| schema_version | string       | Wazuh schema version                  | wazuh.schema.version | TRUE   |

--- a/ecs/states-inventory-hardware/docs/fields.csv
+++ b/ecs/states-inventory-hardware/docs/fields.csv
@@ -1,20 +1,17 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
 8.11.0,true,agent,agent.name,keyword,core,,foo,Custom name of the agent.
 8.11.0,true,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
-8.11.0,true,host,host.cpu,object,custom,,,CPU related data
-8.11.0,true,host,host.cpu.cores,long,custom,,,Number of CPU cores
-8.11.0,true,host,host.cpu.name,keyword,custom,,,CPU Model name
-8.11.0,true,host,host.cpu.speed,long,custom,,,CPU clock speed
-8.11.0,true,host,host.memory,object,custom,,,Memory related data
-8.11.0,true,host,host.memory.free,long,custom,,,Free memory in MB
-8.11.0,true,host,host.memory.total,long,custom,,,Total memory in MB
-8.11.0,true,host,host.memory.used,long,custom,,,Used memory related data
-8.11.0,true,host,host.serial_number,keyword,custom,,,Serial number of the motherboard
+8.11.0,true,host,host.cpu.cores,short,custom,,8,Number of CPU cores.
+8.11.0,true,host,host.cpu.name,keyword,custom,,Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz,Name/model of the CPU.
+8.11.0,true,host,host.cpu.speed,long,custom,,3600,CPU clock speed in MHz.
+8.11.0,true,host,host.memory.free,long,custom,,87191,"Free memory, in Bytes."
+8.11.0,true,host,host.memory.total,long,custom,,52584,"Total memory, in Bytes."
+8.11.0,true,host,host.memory.usage,scaled_float,custom,,0.75,"Percent memory used, between 0 and 1."
+8.11.0,true,host,host.memory.used,long,custom,,123456,"Used memory, in Bytes."
+8.11.0,true,host,host.serial_number,keyword,custom,,DJGAQS4CW5,Serial Number of the device.
 8.11.0,true,wazuh,wazuh.cluster.name,keyword,custom,,,Wazuh cluster name.
 8.11.0,true,wazuh,wazuh.cluster.node,keyword,custom,,,Wazuh cluster node name.
 8.11.0,true,wazuh,wazuh.schema.version,keyword,custom,,,Wazuh schema version.

--- a/ecs/states-inventory-hardware/event-generator/event_generator.py
+++ b/ecs/states-inventory-hardware/event-generator/event_generator.py
@@ -65,6 +65,7 @@ def generate_random_host(is_root_level=False):
                 "free": random.randint(1000, 100000),
                 "total": random.randint(1000, 100000),
                 "used": random.randint(0, 100),
+                "usage": round(random.random(), 2),
             },
             "serial_number": f"{random.randint(0, 9999)}",
         }

--- a/ecs/states-inventory-hardware/fields/custom/host.yml
+++ b/ecs/states-inventory-hardware/fields/custom/host.yml
@@ -1,52 +1,21 @@
 ---
-- name: host
-  reusable:
-    top_level: true
-    expected:
-      - { at: agent, as: host }
+- name: wazuh
+  title: Wazuh
+  description: >
+    Wazuh Inc. custom fields
   fields:
-    - name: memory
-      description: >
-        Memory related data
-      type: object
-      level: custom
-    - name: memory.total
-      description: >
-        Total memory in MB
-      type: long
-      level: custom
-    - name: memory.free
-      description: >
-        Free memory in MB
-      type: long
-      level: custom
-    - name: memory.used
-      description: >
-        Used memory related data
-      type: long
-      level: custom
-    - name: cpu
-      description: >
-        CPU related data
-      type: object
-      level: custom
-    - name: cpu.name
-      description: >
-        CPU Model name
+    - name: cluster.name
       type: keyword
       level: custom
-    - name: cpu.cores
       description: >
-        Number of CPU cores
-      type: long
-      level: custom
-    - name: cpu.speed
-      description: >
-        CPU clock speed
-      type: long
-      level: custom
-    - name: serial_number
-      description: >
-        Serial number of the motherboard
+        Wazuh cluster name.
+    - name: cluster.node
       type: keyword
       level: custom
+      description: >
+        Wazuh cluster node name.
+    - name: schema.version
+      type: keyword
+      level: custom
+      description: >
+        Wazuh schema version.

--- a/ecs/states-inventory-hardware/fields/subset.yml
+++ b/ecs/states-inventory-hardware/fields/subset.yml
@@ -17,10 +17,7 @@ fields:
   host:
     fields:
       memory:
-        fields:
-          total: {}
-          free: {}
-          used: {}
+        fields: "*"
       cpu:
         fields:
           name: {}

--- a/ecs/states-inventory-hardware/fields/template-settings-legacy.json
+++ b/ecs/states-inventory-hardware/fields/template-settings-legacy.json
@@ -8,7 +8,16 @@
       "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
-        "host.serial_number"
+        "agent.host.architecture",
+        "agent.host.ip",
+        "agent.id",
+        "agent.name",
+        "agent.version",
+        "agent.host.ip",
+        "host.serial_number",
+        "wazuh.cluster.name",
+        "wazuh.cluster.node",
+        "wazuh.schema.version"
       ]
     }
   }

--- a/ecs/states-inventory-hardware/fields/template-settings.json
+++ b/ecs/states-inventory-hardware/fields/template-settings.json
@@ -11,7 +11,16 @@
         "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
-          "host.serial_number"
+          "agent.host.architecture",
+          "agent.host.ip",
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "agent.host.ip",
+          "host.serial_number",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ]
       }
     }

--- a/ecs/states-inventory-hotfixes/docs/fields.csv
+++ b/ecs/states-inventory-hotfixes/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.

--- a/ecs/states-inventory-hotfixes/fields/template-settings-legacy.json
+++ b/ecs/states-inventory-hotfixes/fields/template-settings-legacy.json
@@ -8,7 +8,15 @@
       "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
-        "package.hotfix.name"
+        "agent.host.architecture",
+        "agent.host.ip",
+        "agent.id",
+        "agent.name",
+        "agent.version",
+        "package.hotfix.name",
+        "wazuh.cluster.name",
+        "wazuh.cluster.node",
+        "wazuh.schema.version"
       ]
     }
   }

--- a/ecs/states-inventory-hotfixes/fields/template-settings.json
+++ b/ecs/states-inventory-hotfixes/fields/template-settings.json
@@ -11,7 +11,15 @@
         "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
-          "package.hotfix.name"
+        "agent.host.architecture",
+        "agent.host.ip",
+        "agent.id",
+        "agent.name",
+        "agent.version",
+        "package.hotfix.name",
+        "wazuh.cluster.name",
+        "wazuh.cluster.node",
+        "wazuh.schema.version"
         ]
       }
     }

--- a/ecs/states-inventory-interfaces/docs/fields.csv
+++ b/ecs/states-inventory-interfaces/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
@@ -15,6 +13,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0,true,host,host.network.ingress.drops,long,custom,,,Number of dropped received packets.
 8.11.0,true,host,host.network.ingress.errors,long,custom,,,Number of reception errors.
 8.11.0,true,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
+8.11.0,true,interface,interface.alias,keyword,extended,,outside,Interface alias
+8.11.0,true,interface,interface.mtu,long,custom,,,Maximum transmission unit size.
+8.11.0,true,interface,interface.name,keyword,extended,,eth0,Interface name
+8.11.0,true,interface,interface.state,keyword,custom,,,State of the network interface.
+8.11.0,true,interface,interface.type,keyword,custom,,,Interface type.
 8.11.0,true,wazuh,wazuh.cluster.name,keyword,custom,,,Wazuh cluster name.
 8.11.0,true,wazuh,wazuh.cluster.node,keyword,custom,,,Wazuh cluster node name.
 8.11.0,true,wazuh,wazuh.schema.version,keyword,custom,,,Wazuh schema version.

--- a/ecs/states-inventory-interfaces/fields/custom/interface.yml
+++ b/ecs/states-inventory-interfaces/fields/custom/interface.yml
@@ -1,5 +1,10 @@
 ---
 - name: interface
+  reusable:
+    top_level: true
+    expected:
+      - observer.ingress
+      - observer.egress
   title: Interface
   type: group
   group: 2

--- a/ecs/states-inventory-networks/docs/fields.csv
+++ b/ecs/states-inventory-networks/docs/fields.csv
@@ -1,11 +1,10 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
 8.11.0,true,agent,agent.name,keyword,core,,foo,Custom name of the agent.
 8.11.0,true,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
+8.11.0,true,interface,interface.name,keyword,extended,,eth0,Interface name
 8.11.0,true,network,network.broadcast,ip,custom,,,Broadcast address
 8.11.0,true,network,network.dhcp,boolean,custom,,,DHCP enabled
 8.11.0,true,network,network.ip,ip,custom,,,IP address

--- a/ecs/states-inventory-networks/fields/custom/interface.yml
+++ b/ecs/states-inventory-networks/fields/custom/interface.yml
@@ -1,0 +1,7 @@
+---
+- name: interface
+  reusable:
+    top_level: true
+    expected:
+      - observer.ingress
+      - observer.egress

--- a/ecs/states-inventory-networks/fields/template-settings-legacy.json
+++ b/ecs/states-inventory-networks/fields/template-settings-legacy.json
@@ -8,8 +8,15 @@
       "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
+        "agent.id",
+        "agent.name",
+        "agent.version",
+        "agent.host.ip",
+        "interface.name",
         "network.ip",
-        "network.name"
+        "network.name",
+        "wazuh.cluster.name",
+        "wazuh.cluster.node"
       ]
     }
   }

--- a/ecs/states-inventory-networks/fields/template-settings.json
+++ b/ecs/states-inventory-networks/fields/template-settings.json
@@ -11,8 +11,15 @@
         "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "agent.host.ip",
+          "interface.name",
           "network.ip",
-          "network.name"
+          "network.name",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node"
         ]
       }
     }

--- a/ecs/states-inventory-packages/docs/fields.csv
+++ b/ecs/states-inventory-packages/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.

--- a/ecs/states-inventory-ports/docs/fields.csv
+++ b/ecs/states-inventory-ports/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
@@ -14,7 +12,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0,true,interface,interface.state,keyword,custom,,,State of the network interface.
 8.11.0,true,network,network.transport,keyword,core,,tcp,Protocol Name corresponding to the field `iana_number`.
 8.11.0,true,process,process.name,keyword,extended,,ssh,Process name.
-8.11.0,true,process,process.name.text,keyword,extended,,ssh,Process name.
 8.11.0,true,process,process.pid,long,core,,4242,Process id.
 8.11.0,true,source,source.ip,ip,core,,,IP address of the source.
 8.11.0,true,source,source.port,long,core,,,Port of the source.

--- a/ecs/states-inventory-ports/fields/template-settings-legacy.json
+++ b/ecs/states-inventory-ports/fields/template-settings-legacy.json
@@ -8,10 +8,23 @@
       "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
+        "agent.host.architecture",
+        "agent.host.ip",
         "agent.id",
+        "agent.name",
+        "agent.version",
+        "host.network.egress.queue",
+        "host.network.ingress.queue",
+        "file.inode",
+        "interface.state",
+        "network.transport",
         "process.name",
+        "process.pid",
         "source.ip",
-        "destination.ip"
+        "destination.ip",
+        "wazuh.cluster.name",
+        "wazuh.cluster.node",
+        "wazuh.schema.version"
       ]
     }
   }

--- a/ecs/states-inventory-ports/fields/template-settings.json
+++ b/ecs/states-inventory-ports/fields/template-settings.json
@@ -11,10 +11,23 @@
         "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
+          "agent.host.architecture",
+          "agent.host.ip",
           "agent.id",
+          "agent.name",
+          "agent.version",
+          "host.network.egress.queue",
+          "host.network.ingress.queue",
+          "file.inode",
+          "interface.state",
+          "network.transport",
           "process.name",
+          "process.pid",
           "source.ip",
-          "destination.ip"
+          "destination.ip",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ]
       }
     }

--- a/ecs/states-inventory-processes/docs/fields.csv
+++ b/ecs/states-inventory-processes/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
@@ -9,9 +7,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.11.0,true,process,process.args_count,long,extended,,4,Length of the process.args array.
 8.11.0,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-8.11.0,true,process,process.command_line.text,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.11.0,true,process,process.name,keyword,extended,,ssh,Process name.
-8.11.0,true,process,process.name.text,keyword,extended,,ssh,Process name.
 8.11.0,true,process,process.parent.pid,long,core,,4242,Process id.
 8.11.0,true,process,process.pid,long,core,,4242,Process id.
 8.11.0,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.

--- a/ecs/states-inventory-protocols/docs/fields.csv
+++ b/ecs/states-inventory-protocols/docs/fields.csv
@@ -1,11 +1,10 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
 8.11.0,true,agent,agent.name,keyword,core,,foo,Custom name of the agent.
 8.11.0,true,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
+8.11.0,true,interface,interface.name,keyword,extended,,eth0,Interface name
 8.11.0,true,network,network.dhcp,boolean,custom,,,DHCP enabled
 8.11.0,true,network,network.gateway,ip,custom,,,Gateway address
 8.11.0,true,network,network.metric,long,custom,,,Metric of the network protocol

--- a/ecs/states-inventory-protocols/fields/custom/interface.yml
+++ b/ecs/states-inventory-protocols/fields/custom/interface.yml
@@ -1,0 +1,7 @@
+---
+- name: interface
+  reusable:
+    top_level: true
+    expected:
+      - observer.ingress
+      - observer.egress

--- a/ecs/states-inventory-protocols/fields/template-settings-legacy.json
+++ b/ecs/states-inventory-protocols/fields/template-settings-legacy.json
@@ -8,9 +8,16 @@
       "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
-          "agent.id",
-          "agent.host.ip",
-          "interface.name"
+        "agent.host.architecture",
+        "agent.host.ip",
+        "agent.id",
+        "agent.name",
+        "agent.version",
+        "network.type",
+        "interface.name",
+        "wazuh.cluster.name",
+        "wazuh.cluster.node",
+        "wazuh.schema.version"
       ]
     }
   }

--- a/ecs/states-inventory-protocols/fields/template-settings.json
+++ b/ecs/states-inventory-protocols/fields/template-settings.json
@@ -11,9 +11,16 @@
         "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
-          "agent.id",
+          "agent.host.architecture",
           "agent.host.ip",
-          "interface.name"
+          "agent.id",
+          "agent.name",
+          "agent.version",
+          "network.type",
+          "interface.name",
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ]
       }
     }

--- a/ecs/states-inventory-system/docs/fields.csv
+++ b/ecs/states-inventory-system/docs/fields.csv
@@ -1,6 +1,4 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-8.11.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-8.11.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.11.0,true,agent,agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 8.11.0,true,agent,agent.host.ip,ip,core,array,,Host ip addresses.
 8.11.0,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
@@ -12,14 +10,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0,true,host,host.os.codename,keyword,custom,,,OS codename
 8.11.0,true,host,host.os.distribution.release,keyword,custom,,,Distribution-specific release information
 8.11.0,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-8.11.0,true,host,host.os.full.text,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 8.11.0,true,host,host.os.kernel.name,keyword,custom,,,System kernel name
 8.11.0,true,host,host.os.kernel.release,keyword,custom,,,Kernel release version
 8.11.0,true,host,host.os.kernel.version,keyword,custom,,,Kernel version
 8.11.0,true,host,host.os.major,keyword,custom,,,Major version number
 8.11.0,true,host,host.os.minor,keyword,custom,,,Minor version number
 8.11.0,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-8.11.0,true,host,host.os.name.text,keyword,extended,,Mac OS X,"Operating system name, without the version."
 8.11.0,true,host,host.os.patch,keyword,custom,,,Patch level of the OS
 8.11.0,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 8.11.0,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."

--- a/ecs/states-vulnerabilities/docs/README.md
+++ b/ecs/states-vulnerabilities/docs/README.md
@@ -68,5 +68,3 @@ The detail of the fields can be found in csv file [States vulnerabilities Fields
 | wazuh.cluster.name                | keyword | Wazuh cluster name.                                                                                                 | wazuh.cluster.name                | TRUE   |
 | wazuh.cluster.node                | keyword | Wazuh cluster node name.                                                                                            | wazuh.cluster.node                | TRUE   |
 | wazuh.schema.version              | keyword | Wazuh schema version.                                                                                               | wazuh.schema.version              | TRUE   |
-
-

--- a/ecs/states-vulnerabilities/fields/subset.yml
+++ b/ecs/states-vulnerabilities/fields/subset.yml
@@ -2,7 +2,7 @@
 name: vulnerability_detector
 fields:
   base:
-    fields: 
+    fields:
       tags: []
   agent:
     fields: "*"
@@ -11,7 +11,7 @@ fields:
   host:
     fields:
       os:
-        fields: 
+        fields:
           full: ""
           kernel: ""
           name: ""

--- a/ecs/states-vulnerabilities/fields/template-settings-legacy.json
+++ b/ecs/states-vulnerabilities/fields/template-settings-legacy.json
@@ -1,5 +1,5 @@
 {
-  "index_patterns": ["wazuh-states-vulnerabilities*"],
+  "index_patterns": ["wazuh-states-vulnerabilities-*"],
   "order": 1,
   "settings": {
     "index": {
@@ -9,15 +9,30 @@
       "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
+        "agent.host.architecture",
+        "agent.host.ip",
         "agent.id",
-        "host.os.full",
-        "host.os.version",
+        "agent.name",
+        "agent.version",
+        "package.architecture",
+        "package.category",
+        "package.description",
+        "package.installed",
+        "package.multiarch",
         "package.name",
+        "package.path",
+        "package.priority",
+        "package.size",
+        "package.source",
+        "package.type",
+        "package.vendor",
         "package.version",
         "vulnerability.id",
         "vulnerability.description",
         "vulnerability.severity",
-        "wazuh.cluster.name"
+        "wazuh.cluster.name",
+        "wazuh.cluster.node",
+        "wazuh.schema.version"
       ]
     }
   }

--- a/ecs/states-vulnerabilities/fields/template-settings.json
+++ b/ecs/states-vulnerabilities/fields/template-settings.json
@@ -1,5 +1,5 @@
 {
-  "index_patterns": ["wazuh-states-vulnerabilities*"],
+  "index_patterns": ["wazuh-states-vulnerabilities-*"],
   "priority": 1,
   "template": {
     "settings": {
@@ -10,15 +10,30 @@
         "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
+          "agent.host.architecture",
+          "agent.host.ip",
           "agent.id",
-          "host.os.full",
-          "host.os.version",
+          "agent.name",
+          "agent.version",
+          "package.architecture",
+          "package.category",
+          "package.description",
+          "package.installed",
+          "package.multiarch",
           "package.name",
+          "package.path",
+          "package.priority",
+          "package.size",
+          "package.source",
+          "package.type",
+          "package.vendor",
           "package.version",
           "vulnerability.id",
           "vulnerability.description",
           "vulnerability.severity",
-          "wazuh.cluster.name"
+          "wazuh.cluster.name",
+          "wazuh.cluster.node",
+          "wazuh.schema.version"
         ]
       }
     }


### PR DESCRIPTION
### Description
The Wazuh Common Schema for 4.x is hosted in the wazuh-indexer repository. As a part of the scheduled maintenance actions, we should keep the WCS version hosted in this repository (meant for 5.x) up to date with the latest developments and changes from 4.x

This PR updates the ECS files with the modifications affecting the 4.13.0 ECS.

### Issues Resolved
- https://github.com/wazuh/wazuh-indexer-plugins/issues/482