### PR TITLE
Implement retry mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add repository bumper [(#500)](https://github.com/wazuh/wazuh-indexer-plugins/pull/500)
 - Add documentation for the setup plugin [(#498)](https://github.com/wazuh/wazuh-indexer-plugins/pull/498)
 - Add documentation for default users and roles (RBAC) [(#535)](https://github.com/wazuh/wazuh-indexer-plugins/pull/535)
+- Implement retry mechanism to the initialization plugin [(#541)](https://github.com/wazuh/wazuh-indexer-plugins/pull/541)
 
 ### Dependencies
 -

--- a/docs/ref/configuration/configuration-files.md
+++ b/docs/ref/configuration/configuration-files.md
@@ -1,5 +1,32 @@
 # Configuration Files
 
+## Initialization plugin settings
+
+#### Timeout for the OpenSearch client
+- **Key**: `plugins.setup.timeout`
+- **Type**: Integer
+- **Default**: `30`
+- **Minimum**: `5`
+- **Maximum**: `120`
+- **Description**: Timeout in seconds for index and search operations.
+
+#### Backoff (delay) for the retry mechanism
+- **Key**: `plugins.setup.backoff`
+- **Type**: Integer
+- **Default**: `15`
+- **Minimum**: `5`
+- **Maximum**: `60`
+- **Description**: Delay in seconds for the retry mechanism involving initialization tasks.
+
+### Example
+
+Below, there is an example of custom values for these settings within the `opensearch.yml` file:
+
+```yaml
+plugins.setup.timeout: 60
+plugins.setup.backoff: 30
+```
+
 ## Security - Access Control
 
 Wazuh Indexer uses the [OpenSearch Security plugin](https://docs.opensearch.org/docs/latest/security/) to manage access control and security features.

--- a/docs/ref/getting-started/config-files.md
+++ b/docs/ref/getting-started/config-files.md
@@ -1,1 +1,0 @@
-# Configuration files

--- a/docs/ref/modules/setup/architecture.md
+++ b/docs/ref/modules/setup/architecture.md
@@ -8,6 +8,12 @@ The `SetupPlugin` class holds the list of indices to create. The logic for the c
 
 By design, the plugin will overwrite any existing index template under the same name.
 
+### Retry mechanism
+
+The plugin features a retry mechanism to handle transient faults. In case of a temporal failure (timeouts or similar) during the initialization of the indices, the task is retried after a given amount of time (backoff). If two consecutive faults occur during the initialization of the same index, the initialization process is halted, and the node is shut down. Proper logging is in place to notify administrators before the shutdown occurs.
+
+The backoff time is configurable. Head to [Configuration Files](/ref/configuration/configuration-files.md#initialization-plugin-settings) for more information.
+
 ## Class diagram
 
 ```mermaid

--- a/plugins/setup/build.gradle
+++ b/plugins/setup/build.gradle
@@ -83,12 +83,10 @@ configurations {
 dependencies {
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.23.1"
     implementation "org.slf4j:slf4j-api:1.7.36"
-    //implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
 
-    // Job Scheduler stuff
+    // Job Scheduler & ISM stuff (required for the initialization of ISM policies)
     zipArchive group: 'org.opensearch.plugin', name: 'opensearch-job-scheduler', version: opensearch_build
     zipArchive group: 'org.opensearch.plugin', name: 'opensearch-index-management', version: opensearch_build
-    // implementation "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.opensearch:opensearch-job-scheduler-spi:${opensearch_build}"
 
 }

--- a/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
@@ -19,7 +19,6 @@ package com.wazuh.setup;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
@@ -36,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import com.wazuh.setup.index.Index;
@@ -51,7 +49,6 @@ import com.wazuh.setup.utils.IndexUtils;
  */
 public class SetupPlugin extends Plugin implements ClusterPlugin {
 
-    public static final TimeValue TIMEOUT = new TimeValue(30L, TimeUnit.SECONDS);
     private final List<Index> indices = new ArrayList<>();
 
     /** Default constructor */

--- a/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
@@ -19,6 +19,7 @@ package com.wazuh.setup;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
@@ -41,6 +42,7 @@ import com.wazuh.setup.index.Index;
 import com.wazuh.setup.index.IndexStateManagement;
 import com.wazuh.setup.index.StateIndex;
 import com.wazuh.setup.index.StreamIndex;
+import com.wazuh.setup.settings.PluginSettings;
 import com.wazuh.setup.utils.IndexUtils;
 
 /**
@@ -112,5 +114,10 @@ public class SetupPlugin extends Plugin implements ClusterPlugin {
         if (localNode.isClusterManagerNode()) {
             this.indices.forEach(Index::initialize);
         }
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(PluginSettings.TIMEOUT, PluginSettings.BACKOFF);
     }
 }

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
@@ -18,6 +18,7 @@ package com.wazuh.setup.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.template.put.PutIndexTemplateRequest;
@@ -124,6 +125,8 @@ public abstract class Index implements IndexInitializer {
                         createIndexResponse.index(),
                         createIndexResponse.isAcknowledged());
             }
+        } catch (ResourceAlreadyExistsException e) {
+            log.info("Index {} already exists. Skipping.", index);
         } catch (
                 Exception
                         e) { // TimeoutException may be raised by actionGet(), but we cannot catch that one.
@@ -169,6 +172,8 @@ public abstract class Index implements IndexInitializer {
 
         } catch (IOException e) {
             log.error("Error reading index template from filesystem {}", template);
+        } catch (ResourceAlreadyExistsException e) {
+            log.info("Index template {} already exists. Skipping.", template);
         } catch (
                 Exception
                         e) { // TimeoutException may be raised by actionGet(), but we cannot catch that one.

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.wazuh.setup.SetupPlugin;
+import com.wazuh.setup.settings.PluginSettings;
 import com.wazuh.setup.utils.IndexUtils;
 
 /**
@@ -114,7 +114,11 @@ public abstract class Index implements IndexInitializer {
             if (!this.indexExists(index)) {
                 CreateIndexRequest request = new CreateIndexRequest(index);
                 CreateIndexResponse createIndexResponse =
-                        this.client.admin().indices().create(request).actionGet(SetupPlugin.TIMEOUT);
+                        this.client
+                                .admin()
+                                .indices()
+                                .create(request)
+                                .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
                 log.info(
                         "Index created successfully: {} {}",
                         createIndexResponse.index(),
@@ -130,6 +134,7 @@ public abstract class Index implements IndexInitializer {
             }
             log.warn("Operation to create the index [{}] timed out. Retrying...", index);
             this.retry_index_creation = false;
+            this.indexUtils.sleep(PluginSettings.getBackoff(this.clusterService.getSettings()));
             this.createIndex(index);
         }
     }
@@ -155,7 +160,7 @@ public abstract class Index implements IndexInitializer {
                             .admin()
                             .indices()
                             .putTemplate(putIndexTemplateRequest)
-                            .actionGet(SetupPlugin.TIMEOUT);
+                            .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
 
             log.info(
                     "Index template created successfully: {} {}",
@@ -177,6 +182,7 @@ public abstract class Index implements IndexInitializer {
             }
             log.warn("Operation to create the index template [{}] timed out. Retrying...", template);
             this.retry_template_creation = false;
+            this.indexUtils.sleep(PluginSettings.getBackoff(this.clusterService.getSettings()));
             this.createTemplate(template);
         }
     }

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
@@ -172,12 +172,12 @@ public abstract class Index implements IndexInitializer {
             if (!this.retry_template_creation) {
                 log.error(
                         "Initialization of index template [{}] finally failed. The node will shut down.",
-                        index);
+                        template);
                 throw e;
             }
-            log.warn("Operation to create the index template [{}] timed out. Retrying...", index);
+            log.warn("Operation to create the index template [{}] timed out. Retrying...", template);
             this.retry_template_creation = false;
-            this.createTemplate(index);
+            this.createTemplate(template);
         }
     }
 

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/IndexStateManagement.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/IndexStateManagement.java
@@ -134,6 +134,8 @@ public class IndexStateManagement extends Index {
             }
         } catch (IOException e) {
             log.error("Error reading index template from filesystem {}", this.template);
+        } catch (ResourceAlreadyExistsException e) {
+            log.info("Index {} already exists. Skipping.", index);
         } catch (
                 Exception
                         e) { // TimeoutException may be raised by actionGet(), but we cannot catch that one.

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/StreamIndex.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/StreamIndex.java
@@ -22,7 +22,7 @@ import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 
-import com.wazuh.setup.SetupPlugin;
+import com.wazuh.setup.settings.PluginSettings;
 
 /**
  * Class to represent a Stream index. Stream indices contain time-based events of any kind (alerts,
@@ -59,7 +59,11 @@ public class StreamIndex extends WazuhIndex {
                 CreateIndexRequest request =
                         new CreateIndexRequest(index).alias(new Alias(this.alias).writeIndex(true));
                 CreateIndexResponse createIndexResponse =
-                        this.client.admin().indices().create(request).actionGet(SetupPlugin.TIMEOUT);
+                        this.client
+                                .admin()
+                                .indices()
+                                .create(request)
+                                .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
                 log.info(
                         "Index created successfully: {} {}",
                         createIndexResponse.index(),
@@ -75,6 +79,7 @@ public class StreamIndex extends WazuhIndex {
             }
             log.warn("Operation to create the index [{}] timed out. Retrying...", index);
             this.retry_index_creation = false;
+            this.indexUtils.sleep(PluginSettings.getBackoff(this.clusterService.getSettings()));
             this.createIndex(index);
         }
     }

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/StreamIndex.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/StreamIndex.java
@@ -18,6 +18,7 @@ package com.wazuh.setup.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
@@ -69,6 +70,8 @@ public class StreamIndex extends WazuhIndex {
                         createIndexResponse.index(),
                         createIndexResponse.isAcknowledged());
             }
+        } catch (ResourceAlreadyExistsException e) {
+            log.info("Index {} already exists. Skipping.", index);
         } catch (
                 Exception
                         e) { // TimeoutException may be raised by actionGet(), but we cannot catch that one.

--- a/plugins/setup/src/main/java/com/wazuh/setup/settings/PluginSettings.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/settings/PluginSettings.java
@@ -25,6 +25,9 @@ import java.util.concurrent.TimeUnit;
 /** Settings class for this plugin. */
 public class PluginSettings {
 
+    /** Default constructor. */
+    public PluginSettings() {}
+
     /** Default timeout in seconds for operations involving the OpenSearch client. */
     public static final int DEFAULT_TIMEOUT = 30;
 

--- a/plugins/setup/src/main/java/com/wazuh/setup/settings/PluginSettings.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/settings/PluginSettings.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.setup.settings;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+/** Settings class for this plugin. */
+public class PluginSettings {
+
+    /** Default timeout in seconds for operations involving the OpenSearch client. */
+    public static final int DEFAULT_TIMEOUT = 30;
+
+    /**
+     * Default backoff (delay) time in seconds for the retry mechanism involving initialization tasks.
+     */
+    public static final int DEFAULT_BACKOFF = 15;
+
+    /** Timeout setting definition. */
+    public static final Setting<Integer> TIMEOUT =
+            Setting.intSetting(
+                    "plugins.setup.timeout", DEFAULT_TIMEOUT, 5, 120, Setting.Property.NodeScope);
+
+    /** Backoff setting definition. */
+    public static final Setting<Integer> BACKOFF =
+            Setting.intSetting(
+                    "plugins.setup.backoff", DEFAULT_BACKOFF, 5, 60, Setting.Property.NodeScope);
+
+    /**
+     * {@link PluginSettings#TIMEOUT} getter.
+     *
+     * @param settings settings of this node.
+     * @return returns the value for the {@link PluginSettings#TIMEOUT} in millis.
+     */
+    public static long getTimeout(Settings settings) {
+        return new TimeValue(TIMEOUT.get(settings), TimeUnit.SECONDS).millis();
+    }
+
+    /**
+     * {@link PluginSettings#BACKOFF} getter.
+     *
+     * @param settings settings of this node.
+     * @return returns the value for the {@link PluginSettings#BACKOFF} in millis.
+     */
+    public static long getBackoff(Settings settings) {
+        return new TimeValue(BACKOFF.get(settings), TimeUnit.SECONDS).millis();
+    }
+}

--- a/plugins/setup/src/main/java/com/wazuh/setup/utils/IndexUtils.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/utils/IndexUtils.java
@@ -76,4 +76,17 @@ public class IndexUtils {
     public Map<String, Object> get(Map<String, Object> map, String key) {
         return (Map<String, Object>) map.get(key);
     }
+
+    /**
+     * Utility method to wrap up the call to {@link Thread#sleep(long)} on a try-catch block.
+     *
+     * @param millis sleep interval in milliseconds.
+     */
+    public void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 }

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/IndexStateManagementTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/IndexStateManagementTests.java
@@ -20,6 +20,7 @@ import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.index.IndexRequest;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.wazuh.setup.SetupPlugin;
 import com.wazuh.setup.utils.IndexUtils;
 
 import static org.mockito.Mockito.*;
@@ -53,12 +53,18 @@ public class IndexStateManagementTests extends OpenSearchTestCase {
         this.indicesAdminClient = mock(IndicesAdminClient.class);
         this.indexUtils = mock(IndexUtils.class);
 
+        // Default settings
+        ClusterService clusterService = mock(ClusterService.class);
+        Settings settings = Settings.builder().build();
+        doReturn(settings).when(clusterService).getSettings();
+
         doReturn(adminClient).when(this.client).admin();
         doReturn(this.indicesAdminClient).when(adminClient).indices();
 
         this.ismIndex = spy(new IndexStateManagement(".opendistro-ism-config", "ism-template"));
         this.ismIndex.setClient(this.client);
         this.ismIndex.setIndexUtils(this.indexUtils);
+        this.ismIndex.setClusterService(clusterService);
     }
 
     /**
@@ -88,7 +94,7 @@ public class IndexStateManagementTests extends OpenSearchTestCase {
 
         doReturn(actionFuture).when(this.client).index(any(IndexRequest.class));
 
-        doReturn(createResponse).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
+        doReturn(createResponse).when(actionFuture).actionGet(anyLong());
 
         this.ismIndex.initialize();
 

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/IndexStateManagementTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/IndexStateManagementTests.java
@@ -48,17 +48,17 @@ public class IndexStateManagementTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        client = mock(Client.class);
+        this.client = mock(Client.class);
         AdminClient adminClient = mock(AdminClient.class);
-        indicesAdminClient = mock(IndicesAdminClient.class);
-        indexUtils = mock(IndexUtils.class);
+        this.indicesAdminClient = mock(IndicesAdminClient.class);
+        this.indexUtils = mock(IndexUtils.class);
 
-        doReturn(adminClient).when(client).admin();
-        doReturn(indicesAdminClient).when(adminClient).indices();
+        doReturn(adminClient).when(this.client).admin();
+        doReturn(this.indicesAdminClient).when(adminClient).indices();
 
-        ismIndex = spy(new IndexStateManagement(".opendistro-ism-config", "ism-template"));
-        ismIndex.setClient(client);
-        ismIndex.setIndexUtils(indexUtils);
+        this.ismIndex = spy(new IndexStateManagement(".opendistro-ism-config", "ism-template"));
+        this.ismIndex.setClient(this.client);
+        this.ismIndex.setIndexUtils(this.indexUtils);
     }
 
     /**
@@ -72,28 +72,28 @@ public class IndexStateManagementTests extends OpenSearchTestCase {
         template.put("settings", Settings.builder().build());
         template.put("mappings", Map.of());
 
-        doReturn(false).when(ismIndex).indexExists(".opendistro-ism-config");
-        doReturn(template).when(indexUtils).fromFile("ism-template.json");
-        doReturn(template.get("mappings")).when(indexUtils).get(template, "mappings");
+        doReturn(false).when(this.ismIndex).indexExists(".opendistro-ism-config");
+        doReturn(template).when(this.indexUtils).fromFile("ism-template.json");
+        doReturn(template.get("mappings")).when(this.indexUtils).get(template, "mappings");
 
         CreateIndexResponse createResponse = mock(CreateIndexResponse.class);
         doReturn(".opendistro-ism-config").when(createResponse).index();
 
         ActionFuture actionFuture = mock(ActionFuture.class);
 
-        doReturn(actionFuture).when(indicesAdminClient).create(any(CreateIndexRequest.class));
+        doReturn(actionFuture).when(this.indicesAdminClient).create(any(CreateIndexRequest.class));
 
         Map<String, Object> policyFile = Map.of("policy", "definition");
-        doReturn(policyFile).when(indexUtils).fromFile("wazuh-alerts-rollover-policy.json");
+        doReturn(policyFile).when(this.indexUtils).fromFile("wazuh-alerts-rollover-policy.json");
 
-        doReturn(actionFuture).when(client).index(any(IndexRequest.class));
+        doReturn(actionFuture).when(this.client).index(any(IndexRequest.class));
 
         doReturn(createResponse).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
 
-        ismIndex.initialize();
+        this.ismIndex.initialize();
 
-        verify(indicesAdminClient).create(any(CreateIndexRequest.class));
-        verify(client).index(any(IndexRequest.class));
+        verify(this.indicesAdminClient).create(any(CreateIndexRequest.class));
+        verify(this.client).index(any(IndexRequest.class));
     }
 
     /**
@@ -101,13 +101,13 @@ public class IndexStateManagementTests extends OpenSearchTestCase {
      * index creation.
      */
     public void testIndexAlreadyExists_SkipsCreation() {
-        doReturn(true).when(ismIndex).indexExists(".opendistro-ism-config");
+        doReturn(true).when(this.ismIndex).indexExists(".opendistro-ism-config");
 
-        doReturn(mock(ActionFuture.class)).when(client).index(any(IndexRequest.class));
+        doReturn(mock(ActionFuture.class)).when(this.client).index(any(IndexRequest.class));
 
-        ismIndex.initialize();
+        this.ismIndex.initialize();
 
-        verify(indicesAdminClient, never()).create(any());
+        verify(this.indicesAdminClient, never()).create(any());
     }
 
     /**
@@ -117,12 +117,12 @@ public class IndexStateManagementTests extends OpenSearchTestCase {
      * @throws IOException if there is an error reading the policy file
      */
     public void testPolicyFileMissing_LogsError() throws IOException {
-        doReturn(true).when(ismIndex).indexExists(".opendistro-ism-config");
+        doReturn(true).when(this.ismIndex).indexExists(".opendistro-ism-config");
         doThrow(new IOException("file not found"))
                 .when(indexUtils)
                 .fromFile("wazuh-alerts-rollover-policy.json");
 
-        ismIndex.initialize();
+        this.ismIndex.initialize();
 
         // Verifies that exception is caught and logged
     }
@@ -135,15 +135,15 @@ public class IndexStateManagementTests extends OpenSearchTestCase {
      * @throws IOException if there is an error reading the policy file
      */
     public void testPolicyAlreadyExists_LogsInfo() throws IOException {
-        doReturn(true).when(ismIndex).indexExists(".opendistro-ism-config");
+        doReturn(true).when(this.ismIndex).indexExists(".opendistro-ism-config");
 
         Map<String, Object> policyFile = Map.of("policy", "definition");
         doReturn(policyFile).when(indexUtils).fromFile("wazuh-alerts-rollover-policy.json");
         doThrow(new ResourceAlreadyExistsException("already exists"))
-                .when(client)
+                .when(this.client)
                 .index(any(IndexRequest.class));
 
-        ismIndex.initialize();
+        this.ismIndex.initialize();
 
         // Verifies that exception is caught and logged
     }

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/IndexTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/IndexTests.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.wazuh.setup.SetupPlugin;
 import com.wazuh.setup.utils.IndexUtils;
 
 import static org.mockito.Mockito.*;
@@ -59,6 +58,10 @@ public class IndexTests extends OpenSearchTestCase {
         ClusterState clusterState = mock(ClusterState.class);
         this.indexUtils = mock(IndexUtils.class);
 
+        // Default settings
+        Settings settings = Settings.builder().build();
+        doReturn(settings).when(clusterService).getSettings();
+
         // Concrete implementation of abstract class
         this.index = new Index("test-index", "test-template") {};
         this.index.setClient(client);
@@ -78,7 +81,7 @@ public class IndexTests extends OpenSearchTestCase {
         CreateIndexResponse response = mock(CreateIndexResponse.class);
         doReturn("test-index").when(response).index();
         ActionFuture actionFuture = mock(ActionFuture.class);
-        doReturn(response).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
+        doReturn(response).when(actionFuture).actionGet(anyLong());
         doReturn(actionFuture).when(this.indicesAdminClient).create(any(CreateIndexRequest.class));
 
         this.index.createIndex("test-index");
@@ -112,7 +115,7 @@ public class IndexTests extends OpenSearchTestCase {
 
         AcknowledgedResponse ackResponse = mock(AcknowledgedResponse.class);
         ActionFuture actionFuture = mock(ActionFuture.class);
-        doReturn(ackResponse).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
+        doReturn(ackResponse).when(actionFuture).actionGet(anyLong());
         doReturn(actionFuture)
                 .when(this.indicesAdminClient)
                 .putTemplate(any(PutIndexTemplateRequest.class));

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/IndexTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/IndexTests.java
@@ -16,7 +16,6 @@
  */
 package com.wazuh.setup.index;
 
-import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.template.put.PutIndexTemplateRequest;
@@ -54,46 +53,46 @@ public class IndexTests extends OpenSearchTestCase {
 
         Client client = mock(Client.class);
         AdminClient adminClient = mock(AdminClient.class);
-        indicesAdminClient = mock(IndicesAdminClient.class);
+        this.indicesAdminClient = mock(IndicesAdminClient.class);
         ClusterService clusterService = mock(ClusterService.class);
-        routingTable = mock(RoutingTable.class);
+        this.routingTable = mock(RoutingTable.class);
         ClusterState clusterState = mock(ClusterState.class);
-        indexUtils = mock(IndexUtils.class);
+        this.indexUtils = mock(IndexUtils.class);
 
         // Concrete implementation of abstract class
-        index = new Index("test-index", "test-template") {};
-        index.setClient(client);
-        index.setClusterService(clusterService);
-        index.setIndexUtils(indexUtils);
+        this.index = new Index("test-index", "test-template") {};
+        this.index.setClient(client);
+        this.index.setClusterService(clusterService);
+        this.index.setIndexUtils(indexUtils);
 
         doReturn(adminClient).when(client).admin();
-        doReturn(indicesAdminClient).when(adminClient).indices();
+        doReturn(this.indicesAdminClient).when(adminClient).indices();
         doReturn(clusterState).when(clusterService).state();
-        doReturn(routingTable).when(clusterState).getRoutingTable();
+        doReturn(this.routingTable).when(clusterState).getRoutingTable();
     }
 
     /** Verifies that index creation is attempted when index does not exist. */
     public void testCreateIndexWhenIndexDoesNotExist() {
-        doReturn(false).when(routingTable).hasIndex("test-index");
+        doReturn(false).when(this.routingTable).hasIndex("test-index");
 
         CreateIndexResponse response = mock(CreateIndexResponse.class);
         doReturn("test-index").when(response).index();
         ActionFuture actionFuture = mock(ActionFuture.class);
         doReturn(response).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
-        doReturn(actionFuture).when(indicesAdminClient).create(any(CreateIndexRequest.class));
+        doReturn(actionFuture).when(this.indicesAdminClient).create(any(CreateIndexRequest.class));
 
-        index.createIndex("test-index");
+        this.index.createIndex("test-index");
 
-        verify(indicesAdminClient).create(any(CreateIndexRequest.class));
+        verify(this.indicesAdminClient).create(any(CreateIndexRequest.class));
     }
 
     /** Verifies that index creation is skipped when index already exists. */
     public void testCreateIndexWhenAlreadyExists() {
-        doReturn(true).when(routingTable).hasIndex("test-index");
+        doReturn(true).when(this.routingTable).hasIndex("test-index");
 
-        index.createIndex("test-index");
+        this.index.createIndex("test-index");
 
-        verify(indicesAdminClient, never()).create(any());
+        verify(this.indicesAdminClient, never()).create(any());
     }
 
     /**
@@ -108,16 +107,18 @@ public class IndexTests extends OpenSearchTestCase {
                         "mappings", Map.of(),
                         "index_patterns", List.of("test-*"));
 
-        doReturn(templateMap).when(indexUtils).fromFile("test-template.json");
-        doReturn(templateMap.get("mappings")).when(indexUtils).get(templateMap, "mappings");
+        doReturn(templateMap).when(this.indexUtils).fromFile("test-template.json");
+        doReturn(templateMap.get("mappings")).when(this.indexUtils).get(templateMap, "mappings");
 
         AcknowledgedResponse ackResponse = mock(AcknowledgedResponse.class);
         ActionFuture actionFuture = mock(ActionFuture.class);
         doReturn(ackResponse).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
-        doReturn(actionFuture).when(indicesAdminClient).putTemplate(any(PutIndexTemplateRequest.class));
-        index.createTemplate("test-template");
+        doReturn(actionFuture)
+                .when(this.indicesAdminClient)
+                .putTemplate(any(PutIndexTemplateRequest.class));
+        this.index.createTemplate("test-template");
 
-        verify(indicesAdminClient).putTemplate(any(PutIndexTemplateRequest.class));
+        verify(this.indicesAdminClient).putTemplate(any(PutIndexTemplateRequest.class));
     }
 
     /**
@@ -126,40 +127,16 @@ public class IndexTests extends OpenSearchTestCase {
      * @throws IOException if there is an error reading the template file
      */
     public void testCreateTemplateIOException() throws IOException {
-        doThrow(new IOException("test")).when(indexUtils).fromFile("test-template.json");
+        doThrow(new IOException("test")).when(this.indexUtils).fromFile("test-template.json");
 
-        index.createTemplate("test-template");
+        this.index.createTemplate("test-template");
 
         // Expect error to be logged but not thrown
     }
 
-    /**
-     * Verifies that ResourceAlreadyExistsException while creating template is caught and logged.
-     *
-     * @throws IOException if there is an error reading the template file
-     */
-    public void testCreateTemplateAlreadyExists() throws IOException {
-        Map<String, Object> templateMap =
-                Map.of(
-                        "settings", Settings.builder().build(),
-                        "mappings", Map.of(),
-                        "index_patterns", List.of("test-*"));
-
-        doReturn(templateMap).when(indexUtils).fromFile("test-template.json");
-        doReturn(templateMap.get("mappings")).when(indexUtils).get(templateMap, "mappings");
-
-        doThrow(new ResourceAlreadyExistsException("already exists"))
-                .when(indicesAdminClient)
-                .putTemplate(any(PutIndexTemplateRequest.class));
-
-        index.createTemplate("test-template");
-
-        // Expect log statement but not exception
-    }
-
     /** Verifies that initialize() invokes both createTemplate and createIndex in order. */
     public void testInitializeInvokesTemplateAndIndex() {
-        Index spyIndex = spy(index);
+        Index spyIndex = spy(this.index);
 
         doNothing().when(spyIndex).createTemplate("test-template");
         doNothing().when(spyIndex).createIndex("test-index");
@@ -172,10 +149,10 @@ public class IndexTests extends OpenSearchTestCase {
 
     /** Verifies indexExists() returns true/false depending on cluster state. */
     public void testIndexExists() {
-        doReturn(true).when(routingTable).hasIndex("test-index");
-        assertTrue(index.indexExists("test-index"));
+        doReturn(true).when(this.routingTable).hasIndex("test-index");
+        assertTrue(this.index.indexExists("test-index"));
 
-        doReturn(false).when(routingTable).hasIndex("test-index");
-        assertFalse(index.indexExists("test-index"));
+        doReturn(false).when(this.routingTable).hasIndex("test-index");
+        assertFalse(this.index.indexExists("test-index"));
     }
 }

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/StreamIndexTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/StreamIndexTests.java
@@ -16,7 +16,6 @@
  */
 package com.wazuh.setup.index;
 
-import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
@@ -47,19 +46,19 @@ public class StreamIndexTests extends OpenSearchTestCase {
 
         Client client = mock(Client.class);
         AdminClient adminClient = mock(AdminClient.class);
-        indicesAdminClient = mock(IndicesAdminClient.class);
+        this.indicesAdminClient = mock(IndicesAdminClient.class);
         ClusterService clusterService = mock(ClusterService.class);
-        routingTable = mock(RoutingTable.class);
+        this.routingTable = mock(RoutingTable.class);
         ClusterState clusterState = mock(ClusterState.class);
 
-        streamIndex = new StreamIndex("stream-index", "stream-template", "stream-alias");
-        streamIndex.setClient(client);
-        streamIndex.setClusterService(clusterService);
+        this.streamIndex = new StreamIndex("stream-index", "stream-template", "stream-alias");
+        this.streamIndex.setClient(client);
+        this.streamIndex.setClusterService(clusterService);
 
         doReturn(adminClient).when(client).admin();
-        doReturn(indicesAdminClient).when(adminClient).indices();
+        doReturn(this.indicesAdminClient).when(adminClient).indices();
         doReturn(clusterState).when(clusterService).state();
-        doReturn(routingTable).when(clusterState).getRoutingTable();
+        doReturn(this.routingTable).when(clusterState).getRoutingTable();
     }
 
     /**
@@ -67,17 +66,17 @@ public class StreamIndexTests extends OpenSearchTestCase {
      * exist.
      */
     public void testCreateIndexWithAlias() {
-        doReturn(false).when(routingTable).hasIndex("stream-index");
+        doReturn(false).when(this.routingTable).hasIndex("stream-index");
 
         CreateIndexResponse response = mock(CreateIndexResponse.class);
         doReturn("stream-index").when(response).index();
         ActionFuture actionFuture = mock(ActionFuture.class);
         doReturn(response).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
-        doReturn(actionFuture).when(indicesAdminClient).create(any(CreateIndexRequest.class));
+        doReturn(actionFuture).when(this.indicesAdminClient).create(any(CreateIndexRequest.class));
 
-        streamIndex.createIndex("stream-index");
+        this.streamIndex.createIndex("stream-index");
 
-        verify(indicesAdminClient)
+        verify(this.indicesAdminClient)
                 .create(
                         argThat(
                                 req -> {
@@ -91,24 +90,10 @@ public class StreamIndexTests extends OpenSearchTestCase {
 
     /** Verifies that createIndex skips index creation if the index already exists. */
     public void testCreateIndexWhenAlreadyExists() {
-        doReturn(true).when(routingTable).hasIndex("stream-index");
+        doReturn(true).when(this.routingTable).hasIndex("stream-index");
 
-        streamIndex.createIndex("stream-index");
+        this.streamIndex.createIndex("stream-index");
 
-        verify(indicesAdminClient, never()).create(any());
-    }
-
-    /** Verifies that createIndex handles ResourceAlreadyExistsException gracefully. */
-    public void testCreateIndexAlreadyExistsException() {
-        doReturn(false).when(routingTable).hasIndex("stream-index");
-
-        doThrow(new ResourceAlreadyExistsException("already exists"))
-                .when(indicesAdminClient)
-                .create(any(CreateIndexRequest.class));
-
-        streamIndex.createIndex("stream-index");
-
-        // We expect no exception thrown
-        verify(indicesAdminClient).create(any(CreateIndexRequest.class));
+        verify(this.indicesAdminClient, never()).create(any());
     }
 }

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/StreamIndexTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/StreamIndexTests.java
@@ -23,12 +23,13 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.IndicesAdminClient;
 
-import com.wazuh.setup.SetupPlugin;
+import com.wazuh.setup.utils.IndexUtils;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -51,9 +52,14 @@ public class StreamIndexTests extends OpenSearchTestCase {
         this.routingTable = mock(RoutingTable.class);
         ClusterState clusterState = mock(ClusterState.class);
 
+        // Default settings
+        Settings settings = Settings.builder().build();
+        doReturn(settings).when(clusterService).getSettings();
+
         this.streamIndex = new StreamIndex("stream-index", "stream-template", "stream-alias");
         this.streamIndex.setClient(client);
         this.streamIndex.setClusterService(clusterService);
+        this.streamIndex.setIndexUtils(mock(IndexUtils.class));
 
         doReturn(adminClient).when(client).admin();
         doReturn(this.indicesAdminClient).when(adminClient).indices();
@@ -71,7 +77,7 @@ public class StreamIndexTests extends OpenSearchTestCase {
         CreateIndexResponse response = mock(CreateIndexResponse.class);
         doReturn("stream-index").when(response).index();
         ActionFuture actionFuture = mock(ActionFuture.class);
-        doReturn(response).when(actionFuture).actionGet(SetupPlugin.TIMEOUT);
+        doReturn(response).when(actionFuture).actionGet(anyLong());
         doReturn(actionFuture).when(this.indicesAdminClient).create(any(CreateIndexRequest.class));
 
         this.streamIndex.createIndex("stream-index");


### PR DESCRIPTION
### Description
This PR implements a simple retry mechanism for initialization operations that may temporarily fail (timeouts).

The solution retries the creation once again, finally failing if it doesn't succeed. If this happens, the initial exception (`TimeoutExecption`) is re-thrown to intentionally cause the node to crash.

To test, simply set `SetupPlugin::TIMEOUT` constant to 0 and run the project.
```log
[2025-07-07T17:16:16,900][INFO ][o.o.n.Node               ] [integTest-0] started
[2025-07-07T17:16:16,910][WARN ][c.w.s.i.IndexStateManagement] [integTest-0] Operation to create the index [.opendistro-ism-config] timed out. Retrying...
[2025-07-07T17:16:16,912][ERROR][c.w.s.i.IndexStateManagement] [integTest-0] Initialization of index [.opendistro-ism-config] finally failed. The node will shut down.
[2025-07-07T17:16:16,915][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [integTest-0] uncaught exception in thread [main]
org.opensearch.bootstrap.StartupException: OpenSearchTimeoutException[java.util.concurrent.TimeoutException: Timeout waiting for task.]; nested: TimeoutException[Timeout waiting for task.];
	at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:172) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:159) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138) ~[opensearch-cli-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.cli.Command.main(Command.java:101) ~[opensearch-cli-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:125) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:91) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
Caused by: org.opensearch.OpenSearchTimeoutException: java.util.concurrent.TimeoutException: Timeout waiting for task.
	at org.opensearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:96) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.action.support.AdapterActionFuture.actionGet(AdapterActionFuture.java:79) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.action.support.AdapterActionFuture.actionGet(AdapterActionFuture.java:73) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at com.wazuh.setup.index.IndexStateManagement.createIndex(IndexStateManagement.java:112) ~[?:?]
	at com.wazuh.setup.index.IndexStateManagement.createIndex(IndexStateManagement.java:128) ~[?:?]
	at com.wazuh.setup.index.IndexStateManagement.initialize(IndexStateManagement.java:135) ~[?:?]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) ~[?:?]
	at com.wazuh.setup.SetupPlugin.onNodeStarted(SetupPlugin.java:116) ~[?:?]
	at org.opensearch.node.Node.lambda$start$42(Node.java:1822) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) ~[?:?]
	at org.opensearch.node.Node.start(Node.java:1822) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.Bootstrap.start(Bootstrap.java:340) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:414) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:168) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	... 6 more
Caused by: java.util.concurrent.TimeoutException: Timeout waiting for task.
	at org.opensearch.common.util.concurrent.BaseFuture$Sync.get(BaseFuture.java:257) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.common.util.concurrent.BaseFuture.get(BaseFuture.java:82) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:94) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.action.support.AdapterActionFuture.actionGet(AdapterActionFuture.java:79) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.action.support.AdapterActionFuture.actionGet(AdapterActionFuture.java:73) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at com.wazuh.setup.index.IndexStateManagement.createIndex(IndexStateManagement.java:112) ~[?:?]
	at com.wazuh.setup.index.IndexStateManagement.createIndex(IndexStateManagement.java:128) ~[?:?]
	at com.wazuh.setup.index.IndexStateManagement.initialize(IndexStateManagement.java:135) ~[?:?]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) ~[?:?]
	at com.wazuh.setup.SetupPlugin.onNodeStarted(SetupPlugin.java:116) ~[?:?]
	at org.opensearch.node.Node.lambda$start$42(Node.java:1822) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1597) ~[?:?]
	at org.opensearch.node.Node.start(Node.java:1822) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.Bootstrap.start(Bootstrap.java:340) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.Bootstrap.init(Bootstrap.java:414) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:168) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	... 6 more
[2025-07-07T17:16:16,940][INFO ][o.o.n.Node               ] [integTest-0] stopping ...
[2025-07-07T17:16:16,946][INFO ][o.o.n.Node               ] [integTest-0] stopped
[2025-07-07T17:16:16,946][INFO ][o.o.n.Node               ] [integTest-0] closing ...
[2025-07-07T17:16:16,949][INFO ][o.o.n.Node               ] [integTest-0] closed
```


### Issues Resolved
Resolves #533 
