### PR TITLE
Integrations maintenance [Month 09]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Replace dependabot's directories keys with wildcard [(#443)](https://github.com/wazuh/wazuh-indexer-plugins/pull/443)
 - Adapt setup plugin for 5.x [(#450)](https://github.com/wazuh/wazuh-indexer-plugins/pull/450)
-- Third-party integrations maintenance [(#478)](https://github.com/wazuh/wazuh-indexer-plugins/pull/478) [(#540)](https://github.com/wazuh/wazuh-indexer-plugins/pull/540) [(#548)](https://github.com/wazuh/wazuh-indexer-plugins/pull/548)
+- Third-party integrations maintenance [(#478)](https://github.com/wazuh/wazuh-indexer-plugins/pull/478) [(#540)](https://github.com/wazuh/wazuh-indexer-plugins/pull/540) [(#548)](https://github.com/wazuh/wazuh-indexer-plugins/pull/548) [(#566)](https://github.com/wazuh/wazuh-indexer-plugins/pull/566)
 - Replace and remove deprecated settings [(#476)](https://github.com/wazuh/wazuh-indexer-plugins/pull/476)
 - Migrate WCS changes from 4.x [(#488)](https://github.com/wazuh/wazuh-indexer-plugins/pull/488) [(#552)](https://github.com/wazuh/wazuh-indexer-plugins/pull/552)
 - Implement checksum fields into stateful ECS mappings [(#519)](https://github.com/wazuh/wazuh-indexer-plugins/pull/519)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -30,4 +30,4 @@ We host development environments to support the following integrations:
 |                | Wazuh  | Logstash | OpenSearch | Elastic | Splunk |
 | -------------- | ------ | -------- | ---------- | ------- | ------ |
 | v1.0           | 4.8.1  | 8.9.0    | 2.14.0     | 8.14.3  | 9.1.4  |
-| Latest version | 4.12.0 | 8.9.0    | 3.1.0      | 9.1.0   | 9.4.3  |
+| Latest version | 4.12.0 | 8.9.0    | 3.2.0      | 9.1.3   | 10.0.0 |

--- a/integrations/docker/.env
+++ b/integrations/docker/.env
@@ -32,13 +32,13 @@ WAZUH_DASHBOARD_VERSION=2.19.1
 WAZUH_CERTS_GENERATOR_VERSION=0.0.1
 
 # OpenSearch destination cluster version
-OS_VERSION=3.1.0
+OS_VERSION=3.2.0
 
 # Logstash version:
 LOGSTASH_OSS_VERSION=8.9.0
 
 # Splunk version:
-SPLUNK_VERSION=9.4.3
+SPLUNK_VERSION=10.0.0
 
 # Version of Elastic products
-STACK_VERSION=9.1.0
+STACK_VERSION=9.1.3

--- a/integrations/docker/compose.indexer-splunk.yml
+++ b/integrations/docker/compose.indexer-splunk.yml
@@ -158,6 +158,7 @@ services:
       SPLUNK_HTTP_ENABLESSL: "true"
       SPLUNK_PASSWORD: Password.1234
       SPLUNK_STANDALONE_URL: https://splunk:8080
+      SPLUNK_GENERAL_TERMS: --accept-sgt-current-at-splunk-com
       SPLUNK_START_ARGS: --accept-license
 
   logstash:


### PR DESCRIPTION
### Description
This PR updates our integrations to the latest versions, specifically:
- Splunk 9.4.3 → 10.0.0
 It was necessary to add the option `SPLUNK_GENERAL_TERMS: --accept-sgt-current-at-splunk-com` in order to work under the new major release of splunk.
- Elastic 9.1.0 → 9.1.3
- OpenSearch 3.1.0 → 3.2.0

### Issues Resolved
Closes #562 
