### PR TITLE
Fix draft policy document.id being lost on update

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -188,7 +188,7 @@ public class ContentManagerPlugin extends Plugin
                 // User-generated content endpoints (Logtest)
                 new RestPostLogtestAction(this.engine),
                 // Policy endpoints
-                new RestPutPolicyAction(this.engine),
+                new RestPutPolicyAction(this.spaceService),
                 // Rule endpoints
                 new RestPostRuleAction(),
                 new RestPutRuleAction(),

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Policy.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Policy.java
@@ -42,7 +42,6 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Policy {
     // JSON Key Constants
-    private static final String TYPE_KEY = "type";
     private static final String TITLE_KEY = "title";
     private static final String DATE_KEY = "date";
     private static final String MODIFIED_KEY = "modified";
@@ -53,9 +52,6 @@ public class Policy {
     private static final String DOCUMENTATION_KEY = "documentation";
     private static final String REFERENCES_KEY = "references";
     private static final String ID_KEY = "id";
-
-    @JsonProperty(TYPE_KEY)
-    private String type;
 
     @JsonProperty(TITLE_KEY)
     private String title;
@@ -89,7 +85,6 @@ public class Policy {
 
     /** Default constructor. */
     public Policy() {
-        this.type = "policy";
         this.integrations = new ArrayList<>();
         this.references = new ArrayList<>();
         this.date = null;
@@ -99,7 +94,6 @@ public class Policy {
     /**
      * Constructs a new Policy with the specified parameters.
      *
-     * @param type The type of resource (should be "policy").
      * @param rootDecoder The root decoder identifier.
      * @param integrations List of integration IDs.
      * @param author The author of the policy.
@@ -109,7 +103,7 @@ public class Policy {
      */
     @JsonCreator
     public Policy(
-            @JsonProperty(TYPE_KEY) String type,
+            @JsonProperty(ID_KEY) String id,
             @JsonProperty(TITLE_KEY) String title,
             @JsonProperty(DATE_KEY) String date,
             @JsonProperty(MODIFIED_KEY) String modified,
@@ -119,7 +113,7 @@ public class Policy {
             @JsonProperty(DESCRIPTION_KEY) String description,
             @JsonProperty(DOCUMENTATION_KEY) String documentation,
             @JsonProperty(REFERENCES_KEY) List<String> references) {
-        this.type = type != null ? type : "policy";
+        this.id = id;
         this.title = title;
         this.date = date;
         this.modified = modified;
@@ -139,15 +133,16 @@ public class Policy {
      */
     public static Policy fromPayload(JsonObject payload) {
         Policy policy = new Policy();
+        if (payload.has(ID_KEY) && !payload.get(ID_KEY).isJsonNull()) {
+            policy.setId(payload.get(ID_KEY).getAsString());
+        }
+
         if (payload.has(DATE_KEY) && !payload.get(DATE_KEY).isJsonNull()) {
             policy.setDate(payload.get(DATE_KEY).getAsString());
         }
+
         if (payload.has(MODIFIED_KEY) && !payload.get(MODIFIED_KEY).isJsonNull()) {
             policy.setModified(payload.get(MODIFIED_KEY).getAsString());
-        }
-
-        if (payload.has(TYPE_KEY)) {
-            policy.setType(payload.get(TYPE_KEY).getAsString());
         }
 
         if (payload.has(TITLE_KEY) && !payload.get(TITLE_KEY).isJsonNull()) {
@@ -203,8 +198,8 @@ public class Policy {
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
 
-        if (this.type != null) {
-            map.put(TYPE_KEY, this.type);
+        if (this.id != null) {
+            map.put(ID_KEY, this.id);
         }
         if (this.title != null) {
             map.put(TITLE_KEY, this.title);
@@ -245,8 +240,8 @@ public class Policy {
     public JsonObject toJson() {
         JsonObject jsonObject = new JsonObject();
 
-        if (this.type != null) {
-            jsonObject.addProperty(TYPE_KEY, this.type);
+        if (this.id != null) {
+            jsonObject.addProperty(ID_KEY, this.id);
         }
         if (this.title != null) {
             jsonObject.addProperty(TITLE_KEY, this.title);
@@ -343,24 +338,6 @@ public class Policy {
      */
     public void setModified(String modified) {
         this.modified = modified;
-    }
-
-    /**
-     * Gets the type of this resource.
-     *
-     * @return The resource type (should be "policy").
-     */
-    public String getType() {
-        return this.type;
-    }
-
-    /**
-     * Sets the type of this resource.
-     *
-     * @param type The resource type to set. If null, defaults to "policy".
-     */
-    public void setType(String type) {
-        this.type = type != null ? type : "policy";
     }
 
     /**
@@ -495,13 +472,13 @@ public class Policy {
      * @return The id of the policy document.
      */
     public String getId() {
-        return id;
+        return this.id;
     }
 
     /**
      * Sets the id related to this policy.
      *
-     * @param id The new id of the policy documet.
+     * @param id The new id of the policy document.
      */
     public void setId(String id) {
         this.id = id;
@@ -510,12 +487,15 @@ public class Policy {
     @Override
     public String toString() {
         return "Policy{"
-                + "type='"
-                + this.type
+                + "title='"
+                + this.title
                 + '\''
-                + (this.title != null ? ", title='" + this.title + '\'' : "")
-                + (this.date != null ? ", date='" + this.date + '\'' : "")
-                + (this.modified != null ? ", modified='" + this.modified + '\'' : "")
+                + ", date='"
+                + this.date
+                + '\''
+                + ", modified='"
+                + this.modified
+                + '\''
                 + ", rootDecoder='"
                 + this.rootDecoder
                 + '\''
@@ -532,6 +512,9 @@ public class Policy {
                 + '\''
                 + ", references="
                 + this.references
+                + ", id='"
+                + this.id
+                + '\''
                 + '}';
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/synchronizer/UnifiedConsumerSynchronizer.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/synchronizer/UnifiedConsumerSynchronizer.java
@@ -44,6 +44,7 @@ import com.wazuh.contentmanager.cti.catalog.processor.RuleProcessor;
 import com.wazuh.contentmanager.cti.catalog.service.PolicyHashService;
 import com.wazuh.contentmanager.cti.catalog.utils.HashCalculator;
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
 
 /**
  * Handles synchronization logic for the unified content consumer. Processes rules, decoders, kvdbs,
@@ -169,9 +170,9 @@ public class UnifiedConsumerSynchronizer extends AbstractConsumerSynchronizer {
      * @param indexName The policy index name.
      */
     private void initializeSpaces(String indexName) {
-        initializeSpace(indexName, Space.DRAFT.toString());
-        initializeSpace(indexName, Space.TEST.toString());
-        initializeSpace(indexName, Space.CUSTOM.toString());
+        this.initializeSpace(indexName, Space.DRAFT.toString());
+        this.initializeSpace(indexName, Space.TEST.toString());
+        this.initializeSpace(indexName, Space.CUSTOM.toString());
     }
 
     /**
@@ -185,7 +186,7 @@ public class UnifiedConsumerSynchronizer extends AbstractConsumerSynchronizer {
             // Check if the space document already exists using a search query
             SearchRequest searchRequest = new SearchRequest(indexName);
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-            searchSourceBuilder.query(QueryBuilders.termQuery("space.name", spaceName));
+            searchSourceBuilder.query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName));
             searchSourceBuilder.size(0); // We only care about the count
             searchRequest.source(searchSourceBuilder);
 
@@ -201,31 +202,31 @@ public class UnifiedConsumerSynchronizer extends AbstractConsumerSynchronizer {
                 policy.setId(uuid);
                 policy.setTitle(title);
                 policy.setDescription(title);
-                policy.setAuthor("");
+                policy.setAuthor("Wazuh Inc.");
                 policy.setRootDecoder("");
                 policy.setDocumentation("");
                 policy.setIntegrations(Collections.emptyList());
-                policy.setReferences(Collections.emptyList());
+                policy.setReferences(List.of("https://wazuh.com"));
                 policy.setDate(date);
                 policy.setModified(date);
 
                 // TODO: Study the model policy and delete the extra fields
                 Map<String, Object> docMap = this.mapper.convertValue(policy, Map.class);
-                docMap.remove("type"); // Delete the field type inside the document
+                docMap.remove(Constants.KEY_TYPE); // Delete the field type inside the document
 
                 String docJson = this.mapper.writeValueAsString(docMap);
                 String docHash = HashCalculator.sha256(docJson);
 
                 Map<String, Object> space = new HashMap<>();
-                space.put("name", spaceName);
-                space.put("hash", Map.of("sha256", docHash));
+                space.put(Constants.KEY_NAME, spaceName);
+                space.put(Constants.KEY_HASH, Map.of("sha256", docHash));
 
                 Map<String, Object> source = new HashMap<>();
-                source.put("document", docMap);
-                source.put("space", space);
+                source.put(Constants.KEY_DOCUMENT, docMap);
+                source.put(Constants.KEY_SPACE, space);
                 // TODO: change to usage of method to calculate space hash
-                source.put("hash", Map.of("sha256", docHash));
-                source.put("type", "policy");
+                source.put(Constants.KEY_HASH, Map.of("sha256", docHash));
+                source.put(Constants.KEY_TYPE, Constants.KEY_POLICY);
 
                 IndexRequest request =
                         new IndexRequest(indexName)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/services/RestPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/services/RestPostPromoteAction.java
@@ -18,6 +18,7 @@ package com.wazuh.contentmanager.rest.services;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -158,7 +159,7 @@ public class RestPostPromoteAction extends BaseRestHandler {
         } catch (IllegalArgumentException e) {
             log.warn("Validation error during promotion: {}", e.getMessage());
             return new RestResponse(e.getMessage(), RestStatus.BAD_REQUEST.getStatus());
-        } catch (com.fasterxml.jackson.databind.exc.ValueInstantiationException e) {
+        } catch (ValueInstantiationException e) {
             log.warn("Invalid value in request: {}", e.getMessage());
             // Extract the root cause message for better error reporting
             String message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
@@ -255,7 +256,7 @@ public class RestPostPromoteAction extends BaseRestHandler {
         // Process each resource type
         this.processResourceChanges(
                 changes.getPolicy(),
-                Constants.KEY_POLICIES,
+                Constants.KEY_POLICY,
                 policyToApply,
                 HashSet.newHashSet(0), // Policies cannot be removed.
                 sourceSpace.toString(),

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -37,9 +37,15 @@ import java.util.Map;
 public class Constants {
     // REST API responses. Pattern: <type>_<http_status_code>_<name>. Type is: E for error, S for
     // success.
+    public static final String E_500_UNEXPECTED_INDEX_STATE =
+            "Missing [%s] field for document [%s] in [%s] index.";
+    public static final String E_500_POLICIES_ARE_NULL = "Source or target policies are null.";
+    public static final String E_500_POLICY_ID_IS_NULL_OR_BLANK = "Policy ID is null or blank.";
+    public static final String E_500_POLICY_UPDATE_FAILED = "Failed to update policy.";
     public static final String E_500_ENGINE_INSTANCE_IS_NULL = "Engine instance is null.";
     public static final String E_400_JSON_REQUEST_BODY_IS_REQUIRED = "JSON request body is required.";
     public static final String E_400_INVALID_JSON_CONTENT = "Invalid JSON content.";
+    public static final String E_400_MISSING_FIELD = "Missing [%s] field.";
     public static final String E_400_INVALID_PROMOTION_OPERATION_FOR_POLICY =
             "Only 'update' operation is supported for policy.";
     public static final String E_400_UNPROMOTABLE_SPACE = "Space [%s] cannot be promoted.";
@@ -54,9 +60,8 @@ public class Constants {
     public static final String INDEX_FILTERS = ".engine-filters";
 
     // Resource Types Keys
-    public static final String KEY_POLICIES = "policy";
+    public static final String KEY_POLICY = "policy";
     public static final String KEY_INTEGRATIONS = "integrations";
-    public static final String KEY_INTEGRATION = "integration";
     public static final String KEY_KVDBS = "kvdbs";
     public static final String KEY_RULES = "rules";
     public static final String KEY_DECODERS = "decoders";
@@ -67,15 +72,29 @@ public class Constants {
     public static final String KEY_HASH = "hash";
     public static final String KEY_SPACE = "space";
     public static final String KEY_NAME = "name";
-    ;
+    public static final String KEY_ID = "id";
+    public static final String KEY_DATE = "date";
+
+    // API request content fields
+    public static final String KEY_TYPE = "type";
+    public static final String KEY_RESOURCE = "resource";
+    public static final String KEY_INTEGRATION = "integration";
 
     // Resources Indices Mapping. Output: Key -> Index Name
     public static final Map<String, String> RESOURCE_INDICES =
             Map.of(
-                    KEY_POLICIES, INDEX_POLICIES,
+                    KEY_POLICY, INDEX_POLICIES,
                     KEY_INTEGRATIONS, INDEX_INTEGRATIONS,
                     KEY_RULES, INDEX_RULES,
                     KEY_KVDBS, INDEX_KVDBS,
                     KEY_DECODERS, INDEX_DECODERS,
                     KEY_FILTERS, INDEX_FILTERS);
+
+    // Queries
+    public static final String Q_SPACE_NAME = "space.name";
+
+    // Operations
+    public static final String OP_ADD = "add";
+    public static final String OP_REMOVE = "remove";
+    public static final String OP_UPDATE = "update";
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/model/PolicyTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/model/PolicyTests.java
@@ -57,7 +57,6 @@ public class PolicyTests extends OpenSearchTestCase {
         Policy defaultPolicy = new Policy();
 
         // Assert
-        assertEquals("policy", defaultPolicy.getType());
         assertNotNull(defaultPolicy.getIntegrations());
         assertTrue(defaultPolicy.getIntegrations().isEmpty());
         assertNull(defaultPolicy.getRootDecoder());
@@ -77,7 +76,7 @@ public class PolicyTests extends OpenSearchTestCase {
         // Act
         Policy testPolicy =
                 new Policy(
-                        "policy", // type
+                        "12345",
                         null, // title
                         null, // date
                         null, // modified
@@ -89,7 +88,6 @@ public class PolicyTests extends OpenSearchTestCase {
                         references);
 
         // Assert
-        assertEquals("policy", testPolicy.getType());
         assertEquals("decoder/root/0", testPolicy.getRootDecoder());
         assertEquals(2, testPolicy.getIntegrations().size());
         assertEquals("integration1", testPolicy.getIntegrations().get(0));
@@ -107,7 +105,6 @@ public class PolicyTests extends OpenSearchTestCase {
         Policy testPolicy = new Policy(null, null, null, null, null, null, null, null, null, null);
 
         // Assert
-        assertEquals("policy", testPolicy.getType()); // Defaults to "policy"
         assertNotNull(testPolicy.getIntegrations()); // Defaults to empty list
         assertTrue(testPolicy.getIntegrations().isEmpty());
         assertNull(testPolicy.getRootDecoder());
@@ -125,7 +122,6 @@ public class PolicyTests extends OpenSearchTestCase {
         Policy testPolicy = Policy.fromPayload(payload);
 
         // Assert
-        assertEquals("policy", testPolicy.getType());
         assertEquals("decoder/integrations/0", testPolicy.getRootDecoder());
         assertEquals(2, testPolicy.getIntegrations().size());
         assertEquals("integration/wazuh-core/0", testPolicy.getIntegrations().get(0));
@@ -140,7 +136,6 @@ public class PolicyTests extends OpenSearchTestCase {
     /** Helper method to create a complete JSON payload for testing. */
     private static JsonObject getPayload() {
         JsonObject payload = new JsonObject();
-        payload.addProperty("type", "policy");
         payload.addProperty("root_decoder", "decoder/integrations/0");
 
         JsonArray integrationsArray = new JsonArray();
@@ -167,7 +162,6 @@ public class PolicyTests extends OpenSearchTestCase {
 
         // Assert
         assertNotNull(testPolicy);
-        assertEquals("policy", testPolicy.getType()); // Default constructor sets type to "policy"
         assertNull(testPolicy.getRootDecoder());
         assertNotNull(testPolicy.getIntegrations());
         assertTrue(testPolicy.getIntegrations().isEmpty());
@@ -177,7 +171,6 @@ public class PolicyTests extends OpenSearchTestCase {
     public void testFromPayload_NullValues() {
         // Arrange
         JsonObject payload = new JsonObject();
-        payload.addProperty("type", "policy");
         payload.add("root_decoder", null);
         payload.add("author", null);
 
@@ -185,7 +178,6 @@ public class PolicyTests extends OpenSearchTestCase {
         Policy testPolicy = Policy.fromPayload(payload);
 
         // Assert
-        assertEquals("policy", testPolicy.getType());
         assertNull(testPolicy.getRootDecoder());
         assertNull(testPolicy.getAuthor());
     }
@@ -213,7 +205,6 @@ public class PolicyTests extends OpenSearchTestCase {
     public void testToMap_CompletePolicy() {
         // Arrange
         List<String> integrations = Arrays.asList("int1", "int2");
-        this.policy.setType("policy");
         this.policy.setRootDecoder("decoder/root/0");
         this.policy.setIntegrations(integrations);
         this.policy.setAuthor("Wazuh Inc.");
@@ -225,7 +216,6 @@ public class PolicyTests extends OpenSearchTestCase {
         Map<String, Object> map = this.policy.toMap();
 
         // Assert
-        assertEquals("policy", map.get("type"));
         assertEquals("decoder/root/0", map.get("root_decoder"));
         assertEquals(integrations, map.get("integrations"));
         assertEquals("Wazuh Inc.", map.get("author"));
@@ -243,7 +233,6 @@ public class PolicyTests extends OpenSearchTestCase {
         Map<String, Object> map = minimalPolicy.toMap();
 
         // Assert
-        assertEquals("policy", map.get("type"));
         assertFalse(map.containsKey("root_decoder"));
         assertFalse(map.containsKey("integrations")); // Empty list not included
         assertFalse(map.containsKey("author"));
@@ -253,7 +242,6 @@ public class PolicyTests extends OpenSearchTestCase {
     public void testToJson_CompletePolicy() {
         // Arrange
         List<String> integrations = Arrays.asList("int1", "int2");
-        this.policy.setType("policy");
         this.policy.setRootDecoder("decoder/root/0");
         this.policy.setIntegrations(integrations);
         this.policy.setAuthor("Wazuh Inc.");
@@ -263,7 +251,6 @@ public class PolicyTests extends OpenSearchTestCase {
         JsonObject json = this.policy.toJson();
 
         // Assert
-        assertEquals("policy", json.get("type").getAsString());
         assertEquals("decoder/root/0", json.get("root_decoder").getAsString());
         assertTrue(json.get("integrations").isJsonArray());
         assertEquals(2, json.getAsJsonArray("integrations").size());
@@ -276,14 +263,12 @@ public class PolicyTests extends OpenSearchTestCase {
     /** Test toJson conversion with empty integrations after setting to null. */
     public void testToJson_NullIntegrations() {
         // Arrange
-        this.policy.setType("policy");
         this.policy.setIntegrations(null); // Will be converted to empty list
 
         // Act
         JsonObject json = this.policy.toJson();
 
         // Assert
-        assertEquals("policy", json.get("type").getAsString());
         // Empty list creates an empty array in JSON
         assertTrue(json.has("integrations"));
         assertTrue(json.get("integrations").isJsonArray());
@@ -379,10 +364,6 @@ public class PolicyTests extends OpenSearchTestCase {
 
     /** Test all getters and setters. */
     public void testGettersAndSetters() {
-        // Act & Assert - Type
-        this.policy.setType("custom-type");
-        assertEquals("custom-type", this.policy.getType());
-
         // Root Decoder
         this.policy.setRootDecoder("decoder/test/0");
         assertEquals("decoder/test/0", this.policy.getRootDecoder());
@@ -405,31 +386,10 @@ public class PolicyTests extends OpenSearchTestCase {
         assertEquals("https://references.com", this.policy.getReferences().get(0));
     }
 
-    /** Test toString method. */
-    public void testToString() {
-        // Arrange
-        this.policy.setType("policy");
-        this.policy.setRootDecoder("decoder/root/0");
-        this.policy.addIntegration("integration1");
-        this.policy.setAuthor("Wazuh Inc.");
-
-        // Act
-        String result = this.policy.toString();
-
-        // Assert
-        assertNotNull(result);
-        assertTrue(result.contains("Policy{"));
-        assertTrue(result.contains("type='policy'"));
-        assertTrue(result.contains("rootDecoder='decoder/root/0'"));
-        assertTrue(result.contains("integrations="));
-        assertTrue(result.contains("author='Wazuh Inc.'"));
-    }
-
     /** Test round-trip conversion: toJson -> fromPayload. */
     public void testRoundTrip_JsonConversion() {
         // Arrange
         List<String> integrations = Arrays.asList("int1", "int2");
-        this.policy.setType("policy");
         this.policy.setRootDecoder("decoder/root/0");
         this.policy.setIntegrations(integrations);
         this.policy.setAuthor("Wazuh Inc.");
@@ -440,7 +400,6 @@ public class PolicyTests extends OpenSearchTestCase {
         Policy reconstructed = Policy.fromPayload(json);
 
         // Assert
-        assertEquals(this.policy.getType(), reconstructed.getType());
         assertEquals(this.policy.getRootDecoder(), reconstructed.getRootDecoder());
         assertEquals(this.policy.getIntegrations().size(), reconstructed.getIntegrations().size());
         assertEquals(this.policy.getAuthor(), reconstructed.getAuthor());

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/services/RestGetPromoteActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/services/RestGetPromoteActionTests.java
@@ -24,7 +24,6 @@ import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.test.rest.FakeRestRequest;
-import org.opensearch.transport.client.Client;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -43,14 +42,12 @@ import static org.mockito.Mockito.*;
 public class RestGetPromoteActionTests extends OpenSearchTestCase {
 
     private RestGetPromoteAction action;
-    private Client client;
     private SpaceService spaceService;
 
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        this.client = mock(Client.class);
         this.spaceService = mock(SpaceService.class);
         this.action = new RestGetPromoteAction(this.spaceService);
     }
@@ -245,7 +242,7 @@ public class RestGetPromoteActionTests extends OpenSearchTestCase {
         BytesRestResponse response = restResponse.toBytesRestResponse();
 
         assertEquals(RestStatus.BAD_REQUEST, response.status());
-        assertTrue(response.content().utf8ToString().contains("Invalid space parameter"));
+        assertTrue(response.content().utf8ToString().contains("Unknown space"));
     }
 
     /**
@@ -262,7 +259,7 @@ public class RestGetPromoteActionTests extends OpenSearchTestCase {
         BytesRestResponse response = restResponse.toBytesRestResponse();
 
         assertEquals(RestStatus.BAD_REQUEST, response.status());
-        assertTrue(response.content().utf8ToString().contains("cannot be promoted further"));
+        assertTrue(response.content().utf8ToString().contains("cannot be promoted"));
     }
 
     /**

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/services/RestPostPromoteActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/services/RestPostPromoteActionTests.java
@@ -66,7 +66,7 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         this.spaceService = mock(SpaceService.class);
 
         // Mock space service.
-        when(this.spaceService.getIndexForResourceType(Constants.KEY_POLICIES))
+        when(this.spaceService.getIndexForResourceType(Constants.KEY_POLICY))
                 .thenReturn(Constants.INDEX_POLICIES);
         when(this.spaceService.getIndexForResourceType(Constants.KEY_INTEGRATIONS))
                 .thenReturn(Constants.INDEX_INTEGRATIONS);


### PR DESCRIPTION
### Description
This PR fixes a bug on the update policy endpoint where the inner `document.id` was always lost.

### Issues Resolved
- https://github.com/wazuh/wazuh-indexer-plugins/pull/772#issuecomment-3843407741
