### PR TITLE
Fix `test` space promotion

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/services/RestPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/services/RestPostPromoteAction.java
@@ -366,7 +366,7 @@ public class RestPostPromoteAction extends BaseRestHandler {
             switch (operation) {
                 case ADD -> {
                     // ADD: Resource exists in source space but NOT in target space
-                    Map<String, Object> sourceDoc = this.spaceService.getDocument(indexName, resourceId);
+                    Map<String, Object> sourceDoc = this.spaceService.getDocument(indexName, sourceSpace, resourceId);
                     if (sourceDoc == null) {
                         throw new IOException(
                                 "Resource '"
@@ -393,8 +393,7 @@ public class RestPostPromoteAction extends BaseRestHandler {
                     }
 
                     // Verify it does NOT exist in target space
-                    // We check all docs with same ID regardless of space
-                    Map<String, Object> targetDoc = this.spaceService.getDocument(indexName, resourceId);
+                    Map<String, Object> targetDoc = this.spaceService.getDocument(indexName, targetSpace, resourceId);
                     if (targetDoc != null) {
                         @SuppressWarnings("unchecked")
                         Map<String, String> targetDocSpace =
@@ -421,7 +420,7 @@ public class RestPostPromoteAction extends BaseRestHandler {
                         sourceDoc = this.spaceService.getPolicy(sourceSpace);
                     } else {
                         // UPDATE: Resource exists in BOTH source and target spaces
-                        sourceDoc = this.spaceService.getDocument(indexName, resourceId);
+                        sourceDoc = this.spaceService.getDocument(indexName, sourceSpace, resourceId);
                     }
                     if (sourceDoc == null) {
                         throw new IOException(
@@ -455,7 +454,7 @@ public class RestPostPromoteAction extends BaseRestHandler {
                 case REMOVE -> {
                     // REMOVE: Resource has been removed from source space, exists in target
                     // Verify the resource exists in target space
-                    Map<String, Object> targetDoc = this.spaceService.getDocument(indexName, resourceId);
+                    Map<String, Object> targetDoc = this.spaceService.getDocument(indexName, targetSpace, resourceId);
                     if (targetDoc != null) {
                         @SuppressWarnings("unchecked")
                         Map<String, String> targetDocSpace =

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/services/RestPostPromoteActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/services/RestPostPromoteActionTests.java
@@ -91,7 +91,7 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         mockSpace.put("name", Space.DRAFT.toString());
         mockDocument.put(Constants.KEY_SPACE, mockSpace);
         mockDocument.put(Constants.KEY_DOCUMENT, new HashMap<>());
-        when(this.spaceService.getDocument(anyString(), anyString())).thenReturn(mockDocument);
+        when(this.spaceService.getDocument(anyString(), anyString(), anyString())).thenReturn(mockDocument);
 
         // Mock getResourcesBySpace to return empty maps (target space is empty)
         when(this.spaceService.getResourcesBySpace(anyString(), anyString()))
@@ -154,7 +154,7 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         RestRequest request = this.mockValidRequest();
 
         // Override the default mock to throw an exception simulating index not found
-        when(this.spaceService.getDocument(eq(Constants.INDEX_DECODERS), anyString()))
+        when(this.spaceService.getDocument(eq(Constants.INDEX_DECODERS), anyString(), anyString()))
                 .thenThrow(
                         new org.opensearch.index.IndexNotFoundException("Index [.cti-decoders] not found."));
 
@@ -453,7 +453,7 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         Map<String, Object> mockPolicyDoc = new HashMap<>();
         mockPolicyDoc.put("id", "policy");
         mockPolicy.put(Constants.KEY_DOCUMENT, mockPolicyDoc);
-        when(this.spaceService.getDocument(eq(Constants.INDEX_POLICIES), eq("policy")))
+        when(this.spaceService.getDocument(eq(Constants.INDEX_POLICIES), eq("draft"), eq("policy")))
                 .thenReturn(mockPolicy);
         when(this.spaceService.getPolicy(eq("draft"))).thenReturn(mockPolicy);
 
@@ -463,7 +463,7 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         Map<String, Object> mockIntegrationDoc = new HashMap<>();
         mockIntegrationDoc.put("id", "integration");
         mockIntegration.put(Constants.KEY_DOCUMENT, mockIntegrationDoc);
-        when(this.spaceService.getDocument(eq(Constants.INDEX_INTEGRATIONS), eq("integration")))
+        when(this.spaceService.getDocument(eq(Constants.INDEX_INTEGRATIONS), eq("test"), eq("integration")))
                 .thenReturn(mockIntegration);
 
         // Mock decoder-1 for ADD operation (decoder-1 exists in draft space, not in test)
@@ -472,8 +472,11 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         Map<String, Object> mockDecoder1Doc = new HashMap<>();
         mockDecoder1Doc.put("id", "decoder-1");
         mockDecoder1.put(Constants.KEY_DOCUMENT, mockDecoder1Doc);
-        when(this.spaceService.getDocument(eq(Constants.INDEX_DECODERS), eq("decoder-1")))
+        when(this.spaceService.getDocument(eq(Constants.INDEX_DECODERS), eq("draft"), eq("decoder-1")))
                 .thenReturn(mockDecoder1);
+        // decoder-1 does NOT exist in test space (for ADD operation validation)
+        when(this.spaceService.getDocument(eq(Constants.INDEX_DECODERS), eq("test"), eq("decoder-1")))
+                .thenReturn(null);
 
         // Mock decoder-2 for DELETE operation (decoder-2 exists in test space - target)
         Map<String, Object> mockDecoder2 = new HashMap<>();
@@ -481,7 +484,7 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         Map<String, Object> mockDecoder2Doc = new HashMap<>();
         mockDecoder2Doc.put("id", "decoder-2");
         mockDecoder2.put(Constants.KEY_DOCUMENT, mockDecoder2Doc);
-        when(this.spaceService.getDocument(eq(Constants.INDEX_DECODERS), eq("decoder-2")))
+        when(this.spaceService.getDocument(eq(Constants.INDEX_DECODERS), eq("test"), eq("decoder-2")))
                 .thenReturn(mockDecoder2);
 
         // spotless:off


### PR DESCRIPTION
## Description

Updated the `getDocument` method calls in `RestPostPromoteAction` to include the source and target space parameters, ensuring accurate resource retrieval during promotion operations.

**Changes:**
- Modified `getDocument(indexName, resourceId)` calls to use `getDocument(indexName, space, resourceId)` which searches by `document.id` within the correct space instead of searching by OpenSearch `_id`.
- Adjusted corresponding unit tests in `RestPostPromoteActionTests` to reflect the changes in method signatures and improve test coverage for space-specific document retrieval.

These changes enhance the clarity and correctness of resource management in the content manager.

## Issues Resolved

- https://github.com/wazuh/internal-devel-requests/issues/4115

## Testing

<details>
<summary>Step-by-step manual testing guide</summary>

### 1. Create an integration (save the ID for later)

```json
POST /_plugins/_content_manager/integrations
{
  "type": "integration",
  "resource": {
    "author": "Wazuh Inc.",
    "category": "cloud-services",
    "date": "2025-10-08",
    "description": "This integration supports Azure Functions app logs.",
    "documentation": "test1234",
    "references": [
      "https://wazuh.com"
    ],
    "rules": [],
    "decoders": [],
    "kvdbs": [],
    "title": "azure-functions"
  }
}
```

### 2. Create a root decoder (save the ID for later)

> **Note:** Replace `<INTEGRATION_ID>` with the ID obtained in step 1.

```json
POST /_plugins/_content_manager/decoders
{
  "type": "decoder",
  "integration": "<INTEGRATION_ID>",
  "resource": {
    "enabled": true,
    "metadata": {
      "author": {
        "date": "2025-09-30",
        "name": "Wazuh, Inc."
      },
      "compatibility": "All wazuh events.",
      "description": "Base decoder to process Wazuh message format, parses location part and enriches the events that comes from a Wazuh agent with the host information.",
      "module": "wazuh",
      "references": [
        "https://documentation.wazuh.com/"
      ],
      "title": "Wazuh message decoder",
      "versions": [
        "Wazuh 5.*"
      ]
    },
    "name": "decoder/core-wazuh-message/0",
    "normalize": [
      {
        "map": [
          {
            "@timestamp": "get_date()"
          }
        ]
      }
    ]
  }
}
```

### 3. Get the draft policy and set the root decoder

First, get the draft policy:

```json
GET /.cti-policies/_search
{
  "query": {
    "match": {
      "space.name": "draft"
    }
  }
}
```

Then update the policy with the root decoder and integration:

> **Note:** Replace `<POLICY_ID>`, `<ROOT_DECODER_ID>`, and `<INTEGRATION_ID>` with the actual IDs.

```json
PUT /_plugins/_content_manager/policy
{
  "type": "policy",
  "resource": {
    "date": "2026-02-06",
    "references": [
      "https://wazuh.com"
    ],
    "author": "Wazuh Inc.",
    "documentation": "",
    "modified": "2026-02-09T15:32:24.745765873Z",
    "root_decoder": "<ROOT_DECODER_ID>",
    "description": "Custom policy",
    "id": "<POLICY_ID>",
    "title": "Custom policy",
    "integrations": [
      "<INTEGRATION_ID>"
    ]
  }
}
```

### 4. Get changes to promote

```
GET /_plugins/_content_manager/promote?space=draft
```

### 5. Promote from draft to test

> **Note:** Use the IDs from the response in step 4.

```json
POST /_plugins/_content_manager/promote
{
  "space": "draft",
  "changes": {
    "kvdbs": [],
    "rules": [],
    "decoders": [
      {
        "operation": "add",
        "id": "<ROOT_DECODER_ID>"
      }
    ],
    "filters": [],
    "integrations": [
      {
        "operation": "add",
        "id": "<INTEGRATION_ID>"
      }
    ],
    "policy": [
      {
        "operation": "update",
        "id": "<POLICY_ID>"
      }
    ]
  }
}
```

### 6. Promote from test to custom

Repeat steps 4 and 5, but using `space=test`:

```
GET /_plugins/_content_manager/promote?space=test
```

Then promote:

```json
POST /_plugins/_content_manager/promote
{
  "space": "test",
  "changes": {
    "kvdbs": [],
    "rules": [],
    "decoders": [
      {
        "operation": "add",
        "id": "<ROOT_DECODER_ID>"
      }
    ],
    "filters": [],
    "integrations": [
      {
        "operation": "add",
        "id": "<INTEGRATION_ID>"
      }
    ],
    "policy": [
      {
        "operation": "update",
        "id": "<POLICY_ID>"
      }
    ]
  }
}
```

</details>

