### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/5_codequality_codeql.yml
+++ b/.github/workflows/5_codequality_codeql.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - "plugins/**"
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   branches:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/wazuh/wazuh-indexer-plugins/security/code-scanning/12](https://github.com/wazuh/wazuh-indexer-plugins/security/code-scanning/12)

In general, the fix is to explicitly declare a `permissions` block to restrict the `GITHUB_TOKEN` to the least privileges needed. Since the `analyze` job already defines appropriate permissions, the main gaps are the other jobs (`branches`, `get-version`, `publish-common-utils`, `publish-security-analytics`). The simplest and safest way without changing behavior is to define a workflow‑level `permissions` block with read‑only repo access, which applies to all jobs, and keep the existing `permissions` override on the `analyze` job (so it can still write security events).

Concretely:
- Add a root-level `permissions` section near the top of `.github/workflows/5_codequality_codeql.yml` (e.g., after `on:` or before `jobs:`) with:
  - `contents: read`
  - `actions: read` (optional but consistent with the existing `analyze` job)
- Leave the `permissions` block for `analyze` unchanged so that CodeQL analysis can still upload security alerts (`security-events: write`).
- Do not modify the steps or behavior of any jobs; this only constrains `GITHUB_TOKEN` scopes.

This change addresses CodeQL’s complaint about missing permissions for the job at line 64 because that job will now inherit the restrictive workflow-level permissions instead of broad defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
