### PR TITLE
Reset only STANDARD space on space reset operations

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -41,6 +41,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.transport.client.Client;
@@ -424,6 +425,52 @@ public class ContentIndex {
             log.debug("[{}] wiped and recreated", this.indexName);
         } catch (Exception e) {
             log.error("[{}] clear failed: {}", this.indexName, e.getMessage());
+        }
+    }
+
+    /**
+     * Deletes all documents belonging to the specified space from the index. Unlike {@link #clear()},
+     * this preserves documents in other spaces and does not drop or recreate the index.
+     *
+     * @param spaceName The space name whose documents should be removed (e.g., "standard").
+     */
+    public void clearBySpace(String spaceName) {
+        try {
+            boolean exists = this.client.admin().indices().prepareExists(this.indexName).get().isExists();
+            if (!exists) {
+                log.debug(
+                        "[{}] does not exist, nothing to clear for space [{}]", this.indexName, spaceName);
+                return;
+            }
+
+            SearchRequest searchRequest = new SearchRequest(this.indexName);
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+            sourceBuilder.query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName));
+            sourceBuilder.size(10000);
+            sourceBuilder.fetchSource(false);
+            searchRequest.source(sourceBuilder);
+
+            SearchResponse response = this.client.search(searchRequest).actionGet();
+
+            BulkRequest bulkRequest = new BulkRequest();
+            for (SearchHit hit : response.getHits().getHits()) {
+                bulkRequest.add(new DeleteRequest(this.indexName, hit.getId()));
+            }
+
+            if (bulkRequest.numberOfActions() > 0) {
+                bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                BulkResponse bulkResponse = this.client.bulk(bulkRequest).actionGet();
+                if (bulkResponse.hasFailures()) {
+                    log.error(
+                            "[{}] clearBySpace [{}] had failures: {}",
+                            this.indexName,
+                            spaceName,
+                            bulkResponse.buildFailureMessage());
+                }
+            }
+            log.debug("[{}] cleared documents for space [{}]", this.indexName, spaceName);
+        } catch (Exception e) {
+            log.error("[{}] clearBySpace [{}] failed: {}", this.indexName, spaceName, e.getMessage());
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -332,7 +332,12 @@ public abstract class AbstractConsumerService {
             log.info("Initializing snapshot from link: {}", remoteConsumer.getSnapshotLink());
             SnapshotServiceImpl snapshotService =
                     new SnapshotServiceImpl(
-                            context, consumer, indicesMap, this.consumersIndex, this.environment);
+                            context,
+                            consumer,
+                            indicesMap,
+                            this.consumersIndex,
+                            this.environment,
+                            this.getSnapshotClearSpace());
 
             boolean snapshotSuccess = snapshotService.initialize(remoteConsumer);
             if (snapshotSuccess) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -129,6 +129,18 @@ public abstract class AbstractConsumerService {
     protected abstract String getSnapshotFilename();
 
     /**
+     * Returns the space name to filter by when clearing indices before snapshot loading. When {@code
+     * null}, a full index wipe ({@link ContentIndex#clear()}) is performed. Subclasses managing
+     * shared indices (where documents from multiple spaces coexist) should override this to return a
+     * specific space name (e.g., "standard") so that documents in other spaces are preserved.
+     *
+     * @return The space name to clear, or {@code null} for a full wipe.
+     */
+    protected String getSnapshotClearSpace() {
+        return null;
+    }
+
+    /**
      * Main synchronization entry point. Orchestrates the synchronization process by performing the
      * actual sync and calling onSyncComplete with the result.
      *
@@ -289,7 +301,12 @@ public abstract class AbstractConsumerService {
                 log.info("Local snapshot found at [{}] for consumer [{}]", localSnapshot, consumer);
                 SnapshotServiceImpl snapshotService =
                         new SnapshotServiceImpl(
-                                context, consumer, indicesMap, this.consumersIndex, this.environment);
+                                context,
+                                consumer,
+                                indicesMap,
+                                this.consumersIndex,
+                                this.environment,
+                                this.getSnapshotClearSpace());
 
                 boolean localSuccess = snapshotService.initialize(localSnapshot);
                 if (localSuccess) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
@@ -185,6 +185,17 @@ public class ConsumerRulesetService extends AbstractConsumerService {
     }
 
     /**
+     * Returns the Standard space name so that snapshot loading only clears STANDARD documents,
+     * preserving DRAFT, TEST, and CUSTOM resources in shared indices.
+     *
+     * @return The standard space name.
+     */
+    @Override
+    protected String getSnapshotClearSpace() {
+        return Space.STANDARD.toString();
+    }
+
+    /**
      * Returns the mappings configuration for the indices handled by this synchronizer.
      *
      * @return A map where keys are resource types and values are mapping file paths.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -70,7 +70,13 @@ public class SnapshotServiceImpl implements SnapshotService {
     private long maxOffsetSeen;
 
     /**
-     * Constructs a new SnapshotServiceImpl.
+     * When non-null, only documents belonging to this space are removed before snapshot loading. When
+     * null, the entire index is dropped and recreated.
+     */
+    private final String snapshotClearSpace;
+
+    /**
+     * Constructs a new SnapshotServiceImpl that performs a full index wipe before loading.
      *
      * @param context The context of the snapshot.
      * @param consumer The consumer identifier.
@@ -84,6 +90,27 @@ public class SnapshotServiceImpl implements SnapshotService {
             Map<String, ContentIndex> indicesMap,
             ConsumersIndex consumersIndex,
             Environment environment) {
+        this(context, consumer, indicesMap, consumersIndex, environment, null);
+    }
+
+    /**
+     * Constructs a new SnapshotServiceImpl with a configurable clearing strategy.
+     *
+     * @param context The context of the snapshot.
+     * @param consumer The consumer identifier.
+     * @param indicesMap A map of content types to their corresponding ContentIndex.
+     * @param consumersIndex The consumers index to update consumer state.
+     * @param environment The OpenSearch environment.
+     * @param snapshotClearSpace When non-null, only documents in this space are deleted before
+     *     loading. When null, entire indices are dropped and recreated.
+     */
+    public SnapshotServiceImpl(
+            String context,
+            String consumer,
+            Map<String, ContentIndex> indicesMap,
+            ConsumersIndex consumersIndex,
+            Environment environment,
+            String snapshotClearSpace) {
         this.context = context;
         this.consumer = consumer;
         this.indicesMap = indicesMap;
@@ -91,6 +118,7 @@ public class SnapshotServiceImpl implements SnapshotService {
         this.environment = environment;
         this.pluginSettings = PluginSettings.getInstance();
         this.mapper = new ObjectMapper();
+        this.snapshotClearSpace = snapshotClearSpace;
 
         this.snapshotClient = new SnapshotClient(this.environment);
     }
@@ -102,6 +130,19 @@ public class SnapshotServiceImpl implements SnapshotService {
      */
     public void setSnapshotClient(SnapshotClient client) {
         this.snapshotClient = client;
+    }
+
+    /**
+     * Clears managed indices before snapshot loading. When a space filter is configured, only
+     * documents belonging to that space are removed. Otherwise, entire indices are dropped and
+     * recreated.
+     */
+    private void clearIndices() {
+        if (this.snapshotClearSpace != null) {
+            this.indicesMap.values().forEach(index -> index.clearBySpace(this.snapshotClearSpace));
+        } else {
+            this.indicesMap.values().forEach(ContentIndex::clear);
+        }
     }
 
     /**
@@ -144,7 +185,7 @@ public class SnapshotServiceImpl implements SnapshotService {
             Unzip.unzip(snapshotZip, outputDir);
 
             // 4. Clear indices
-            this.indicesMap.values().forEach(ContentIndex::clear);
+            this.clearIndices();
 
             // 5. Process and Index Files
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(outputDir, "*.json")) {
@@ -348,7 +389,7 @@ public class SnapshotServiceImpl implements SnapshotService {
                     });
 
             // 3. Clear indices
-            this.indicesMap.values().forEach(ContentIndex::clear);
+            this.clearIndices();
 
             // 4. Process and Index Files
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(outputDir, "*.json")) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -118,24 +118,22 @@ public class SpaceService {
         // 1. Fetch current resources to perform external deletions
         Map<String, Map<String, String>> spaceResources = this.getSpaceResources(space.toString());
 
-        // Translate from Standard to Sigma space for SAP resources
-        Space sapSpace = space;
-        if (space == Space.STANDARD) {
-            sapSpace = Space.SIGMA;
-        }
-
         // 2. Delete SAP resources (best-effort)
+        // Note: the space is passed as-is to the SAP service, which internally translates
+        // to the correct SAP source via Space.asSecurityAnalyticsSource() and uses the
+        // space enum value to select the appropriate action (e.g., detector cleanup for
+        // STANDARD, rule action type selection).
         Map<String, String> rules = spaceResources.get(Constants.KEY_RULES);
         if (rules != null) {
             for (String id : rules.keySet()) {
                 try {
-                    securityAnalyticsService.deleteRule(id, sapSpace);
-                    log.debug("Deleted rule [{}] from SAP for space [{}] reset", id, sapSpace);
+                    securityAnalyticsService.deleteRule(id, space);
+                    log.debug("Deleted rule [{}] from SAP for space [{}] reset", id, space);
                 } catch (Exception e) {
                     log.warn(
                             "Failed to delete rule [{}] from SAP during space [{}] reset: {}",
                             id,
-                            sapSpace,
+                            space,
                             e.getMessage());
                 }
             }
@@ -145,13 +143,13 @@ public class SpaceService {
         if (integrations != null) {
             for (String id : integrations.keySet()) {
                 try {
-                    securityAnalyticsService.deleteIntegration(id, sapSpace);
-                    log.debug("Deleted integration [{}] from SAP for space [{}] reset", id, sapSpace);
+                    securityAnalyticsService.deleteIntegration(id, space);
+                    log.debug("Deleted integration [{}] from SAP for space [{}] reset", id, space);
                 } catch (Exception e) {
                     log.warn(
                             "Failed to delete integration [{}] from SAP during space [{}] reset: {}",
                             id,
-                            sapSpace,
+                            space,
                             e.getMessage());
                 }
             }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -521,4 +521,77 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         Assert.assertFalse("initialize should return false for missing file", result);
         verify(this.snapshotClient, never()).downloadFile(anyString());
     }
+
+    /**
+     * Tests that when a snapshot clear space is configured, {@code clearBySpace()} is called instead
+     * of {@code clear()} during local snapshot initialization, preserving documents in other spaces.
+     */
+    public void testInitializeFromPath_UsesSpaceFilteredClear() throws Exception {
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put("kvdb", this.contentIndexMock);
+        indicesMap.put("policy", this.contentIndexMock);
+        indicesMap.put("decoder", this.contentIndexMock);
+        indicesMap.put("rule", this.contentIndexMock);
+        indicesMap.put("reputation", this.contentIndexMock);
+
+        SnapshotServiceImpl filteredService =
+                new SnapshotServiceImpl(
+                        "test-context",
+                        "test-consumer",
+                        indicesMap,
+                        this.consumersIndex,
+                        this.environment,
+                        "standard");
+        filteredService.setSnapshotClient(this.snapshotClient);
+
+        when(this.contentIndexMock.processPayload(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(this.contentIndexMock.getIndexName()).thenReturn(".test-index");
+
+        Path localZip =
+                this.createZipFileWithContent(
+                        "data.json",
+                        "{\"name\": \"123\", \"offset\": 1, \"payload\": {\"type\": \"kvdb\", \"document\": {\"id\": \"123\"}}}");
+
+        filteredService.initialize(localZip);
+
+        verify(this.contentIndexMock, never()).clear();
+        verify(this.contentIndexMock, atLeastOnce()).clearBySpace("standard");
+    }
+
+    /**
+     * Tests that when a snapshot clear space is configured, {@code clearBySpace()} is called instead
+     * of {@code clear()} during remote snapshot initialization.
+     */
+    public void testInitializeRemote_UsesSpaceFilteredClear() throws Exception {
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put("kvdb", this.contentIndexMock);
+
+        SnapshotServiceImpl filteredService =
+                new SnapshotServiceImpl(
+                        "test-context",
+                        "test-consumer",
+                        indicesMap,
+                        this.consumersIndex,
+                        this.environment,
+                        "standard");
+        filteredService.setSnapshotClient(this.snapshotClient);
+
+        when(this.contentIndexMock.processPayload(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(this.contentIndexMock.getIndexName()).thenReturn(".test-index");
+
+        String url = "http://example.com/snapshot.zip";
+        when(this.remoteConsumer.getSnapshotLink()).thenReturn(url);
+        Path zipPath =
+                this.createZipFileWithContent(
+                        "data.json",
+                        "{\"name\": \"123\", \"offset\": 1, \"payload\": {\"type\": \"kvdb\", \"document\": {\"id\": \"123\"}}}");
+        when(this.snapshotClient.downloadFile(url)).thenReturn(zipPath);
+
+        filteredService.initialize(this.remoteConsumer);
+
+        verify(this.contentIndexMock, never()).clear();
+        verify(this.contentIndexMock, atLeastOnce()).clearBySpace("standard");
+    }
 }


### PR DESCRIPTION
### Description
This PR fixes an issue where initializing content from a snapshot after a space reset deletes content from all spaces instead of just from `STANDARD`.

### Issues Resolved
Resolves #973 
