### PR TITLE
Fix 'index not ready' race condition

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -187,19 +187,20 @@ public class ContentManagerPlugin extends Plugin
     public void onNodeStarted(DiscoveryNode localNode) {
         // Only cluster managers are responsible for initialization and the startup sync trigger.
         if (localNode.isClusterManagerNode()) {
-            this.start();
+            this.start(
+                    () -> {
+                        // Trigger update on start if enabled
+                        if (PluginSettings.getInstance().isUpdateOnStart()) {
+                            this.catalogSyncJob.trigger();
+                        } else {
+                            log.info("Skipping catalog sync job trigger");
+                        }
 
-            // Trigger update on start if enabled
-            if (PluginSettings.getInstance().isUpdateOnStart()) {
-                this.catalogSyncJob.trigger();
-            } else {
-                log.info("Skipping catalog sync job trigger");
-            }
-
-            // Schedule the periodic sync job via OpenSearch Job Scheduler (all nodes)
-            this.scheduleCatalogSyncJob();
-            // Schedule the telemetry ping job to ensure it is registered in the system index
-            this.scheduleTelemetryPingJob();
+                        // Schedule the periodic sync job via OpenSearch Job Scheduler (all nodes)
+                        this.scheduleCatalogSyncJob();
+                        // Schedule the telemetry ping job
+                        this.scheduleTelemetryPingJob();
+                    });
         }
     }
 
@@ -261,8 +262,13 @@ public class ContentManagerPlugin extends Plugin
                 new RestDeleteSpaceAction());
     }
 
-    /** Performs initialization tasks for the plugin. */
-    private void start() {
+    /**
+     * Performs initialization tasks for the plugin. Creates the consumers index asynchronously and
+     * invokes the provided callback once the operation completes (whether it succeeds or fails).
+     *
+     * @param onComplete callback to run after index creation completes
+     */
+    private void start(Runnable onComplete) {
         try {
             this.threadPool
                     .generic()
@@ -283,11 +289,13 @@ public class ContentManagerPlugin extends Plugin
                                             ConsumersIndex.INDEX_NAME,
                                             e.getMessage(),
                                             e);
+                                } finally {
+                                    onComplete.run();
                                 }
                             });
         } catch (Exception e) {
-            // Log or handle exception
             log.error("Error initializing snapshot helper: {}", e.getMessage(), e);
+            onComplete.run();
         }
     }
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
@@ -28,11 +28,14 @@ import org.junit.Before;
 import java.lang.reflect.Field;
 import java.util.concurrent.ExecutorService;
 
+import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -48,6 +51,7 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
     @Mock private ThreadPool threadPool;
     @Mock private DiscoveryNode discoveryNode;
     @Mock private CatalogSyncJob catalogSyncJob;
+    @Mock private ConsumersIndex consumersIndex;
 
     /** Sets up the test environment before each test method. */
     @Before
@@ -57,11 +61,20 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
         this.closeable = MockitoAnnotations.openMocks(this);
         this.plugin = new ContentManagerPlugin();
 
-        when(this.threadPool.generic()).thenReturn(mock(ExecutorService.class));
+        ExecutorService mockExecutor = mock(ExecutorService.class);
+        doAnswer(
+                        invocation -> {
+                            ((Runnable) invocation.getArgument(0)).run();
+                            return null;
+                        })
+                .when(mockExecutor)
+                .execute(any(Runnable.class));
+        when(this.threadPool.generic()).thenReturn(mockExecutor);
 
         this.injectField(this.plugin, "client", this.client);
         this.injectField(this.plugin, "threadPool", this.threadPool);
         this.injectField(this.plugin, "catalogSyncJob", this.catalogSyncJob);
+        this.injectField(this.plugin, "consumersIndex", this.consumersIndex);
 
         ContentManagerPluginTests.clearInstance();
     }


### PR DESCRIPTION
### Description
Fix a startup race condition in ContentManagerPlugin where `catalogSyncJob.trigger()` was called immediately after `start()`, without waiting for the `.cti-consumers` index creation to complete.
Since `start()` creates the index asynchronously on `threadPool.generic()`, the sync job would run before the index was ready, producing a `[WARN] Failed to set consumer [public-ruleset-5] status to [updating]: Index not ready` message on every startup.

Refactors `start()` to accept a `Runnable onComplete` callback invoked in a `finally` block after index creation. The catalog sync trigger and job scheduling now only execute once the index operation has completed.

### Issues Resolved
Closes wazuh/wazuh-indexer-security-analytics#109
