### PR TITLE
Fix broken Javadoc link reference in ContentManagerPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix CodeQL reporting security warnings [(#992)](https://github.com/wazuh/wazuh-indexer-plugins/pull/992)
 - Reset spaces in Security Analytics [(#1000)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1000)
 - Fix CodeQL maven caching [(#1007)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1007)
+- Fix broken Javadoc link reference in ContentManagerPlugin [(#1020)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1020)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#484)](https://github.com/wazuh/wazuh-indexer-plugins/pull/484)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -175,8 +175,8 @@ public class ContentManagerPlugin extends Plugin
     }
 
     /**
-     * Triggers the internal {@link #start()} method if the current node is a Cluster Manager to
-     * initialize indices. It also ensures the periodic catalog sync job is scheduled.
+     * Triggers the internal {@link #start(Runnable)} method if the current node is a Cluster Manager
+     * to initialize indices. It also ensures the periodic catalog sync job is scheduled.
      *
      * <p>The startup sync trigger is restricted to the cluster manager node to prevent every node in
      * the cluster from running a concurrent synchronization on startup.


### PR DESCRIPTION
### Description
This PR resolves the broken javadoc link that was causing failures in the build-packages workflow for wazuh-indexer. The fix involves adding the missing `Runnable` argument to the `@link` reference of the `start()`  function.

### Issues Resolved
Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1019


### Validation
Verified that the build-wazuh-plugins (content-manager) workflow now completes successfully (green build).
https://github.com/wazuh/wazuh-indexer/actions/runs/24391967520