### PR TITLE
Fix warnings and errors on Wazuh Cluster logs

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -75,6 +75,7 @@ import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.jobscheduler.jobs.TelemetryPingJob;
 import com.wazuh.contentmanager.rest.service.*;
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.ClusterInfo;
 import com.wazuh.contentmanager.utils.MockEngineService;
 import com.wazuh.contentmanager.utils.MockSecurityAnalyticsService;
 
@@ -302,15 +303,7 @@ public class ContentManagerPlugin extends Plugin
 
     /** Check if the index exists; if not, create it with specific settings. */
     private void ensureJobsIndexExists() {
-        boolean indexExists =
-                this.client
-                        .admin()
-                        .indices()
-                        .prepareExists(CONTENT_MANAGER_JOBS_INDEX_NAME)
-                        .get()
-                        .isExists();
-
-        if (!indexExists) {
+        if (!ClusterInfo.indexExists(this.client, CONTENT_MANAGER_JOBS_INDEX_NAME)) {
             try {
                 Settings settings =
                         Settings.builder().put("index.number_of_replicas", 0).put("index.hidden", true).build();
@@ -330,13 +323,13 @@ public class ContentManagerPlugin extends Plugin
             }
         }
 
-        // Wait for at least yellow status so shards are allocated and ready for reads/writes.
-        this.client
-                .admin()
-                .cluster()
-                .prepareHealth(CONTENT_MANAGER_JOBS_INDEX_NAME)
-                .setWaitForYellowStatus()
-                .get();
+        // Wait for at least yellow status with active shards ready for operations.
+        if (!ClusterInfo.indexStatusCheck(
+                this.client,
+                CONTENT_MANAGER_JOBS_INDEX_NAME,
+                PluginSettings.getInstance().getClientTimeout())) {
+            throw new RuntimeException("Index " + CONTENT_MANAGER_JOBS_INDEX_NAME + " not ready");
+        }
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
@@ -322,6 +323,8 @@ public class ContentManagerPlugin extends Plugin
                         .get();
 
                 log.info("Created job index {}.", CONTENT_MANAGER_JOBS_INDEX_NAME);
+            } catch (ResourceAlreadyExistsException e) {
+                log.info("Index {} already exists. Skipping.", CONTENT_MANAGER_JOBS_INDEX_NAME);
             } catch (Exception e) {
                 log.warn("Could not create index {}: {}", CONTENT_MANAGER_JOBS_INDEX_NAME, e.getMessage());
             }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -317,7 +317,7 @@ public class ContentManagerPlugin extends Plugin
 
                 log.info("Created job index {}.", CONTENT_MANAGER_JOBS_INDEX_NAME);
             } catch (ResourceAlreadyExistsException e) {
-                log.info("Index {} already exists. Skipping.", CONTENT_MANAGER_JOBS_INDEX_NAME);
+                log.debug("Index {} already exists. Skipping.", CONTENT_MANAGER_JOBS_INDEX_NAME);
             } catch (Exception e) {
                 log.warn("Could not create index {}: {}", CONTENT_MANAGER_JOBS_INDEX_NAME, e.getMessage());
             }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImplTests.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import com.wazuh.contentmanager.utils.Constants;
@@ -99,6 +100,7 @@ public class SecurityAnalyticsServiceImplTests extends OpenSearchTestCase {
         // spotless:off
         return MAPPER.readTree(
                 String.format(
+                        Locale.ROOT,
                         """
                         {
                           "id": "integration-1",

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/Index.java
@@ -142,7 +142,7 @@ public abstract class Index implements IndexInitializer {
                         createIndexResponse.isAcknowledged());
             }
         } catch (ResourceAlreadyExistsException e) {
-            log.info("Index {} already exists. Skipping.", index);
+            log.debug("Index {} already exists. Skipping.", index);
         } catch (
                 Exception
                         e) { // TimeoutException may be raised by actionGet(), but we cannot catch that one.

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/IndexStateManagement.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/IndexStateManagement.java
@@ -153,7 +153,7 @@ public class IndexStateManagement extends Index {
                         createIndexResponse.isAcknowledged());
             }
         } catch (ResourceAlreadyExistsException e) {
-            log.info("Index {} already exists. Skipping.", index);
+            log.debug("Index {} already exists. Skipping.", index);
         } catch (IOException e) {
             log.error(
                     "Error reading index template from filesystem [{}]. Caused by: {}",


### PR DESCRIPTION
### Description
This PR aims to fix the WARN/ERROR related to the Content Manager present on the Cluster logs
```
[2026-04-14T11:20:49,355][WARN ][c.w.c.ContentManagerPlugin] [node-1] Could not create index .wazuh-content-manager-jobs: index [.wazuh-content-manager-jobs/FhiwbUsNRqKjYt1klZXVVw] already exists
[2026-04-14T12:10:35,827][ERROR][c.w.c.ContentManagerPlugin] [node-1] Error scheduling Catalog Sync Job: No shard available for [get [.wazuh-content-manager-jobs][wazuh-catalog-sync-job]: routing [null]]
```

### Issues Resolved
Closes wazuh/wazuh-indexer-security-analytics#109
