### PR TITLE
Add documentation about Rule limits for detectors

### DIFF
--- a/docs/ref/modules/content-manager/architecture.md
+++ b/docs/ref/modules/content-manager/architecture.md
@@ -54,6 +54,8 @@ Interfaces with the OpenSearch Security Analytics plugin. Creates, updates, and 
 
 This design allows the same CTI resource to exist across multiple spaces without ID collisions. Association and lookup between CTI and SAP documents is performed by querying `document.id` + `source`.
 
+> **Note:** SAP enforces a maximum of 100 rules per detector. If an integration has more than 100 enabled rules, the detector creation or update request will be rejected. See [Security Analytics — Detector constraints](../security-analytics/index.md#detector-constraints) for details.
+
 ### Space Service
 
 Manages the four content spaces (standard, draft, test, custom). Routes CUD operations to the correct space partitions within system indices. Handles promotion by computing diffs between spaces in the promotion chain (Draft → Test → Custom).
@@ -72,7 +74,7 @@ Job Scheduler triggers
   → Snapshot Service downloads ZIP from CTI API
   → Extracts and bulk-indexes into .cti-rules, .cti-decoders, etc.
   → Updates .cti-consumers with new offset
-  → Security Analytics Service creates detectors
+  → Security Analytics Service creates detectors (max 100 rules per detector)
 ```
 
 ### CTI Sync (Incremental)

--- a/docs/ref/modules/security-analytics/index.md
+++ b/docs/ref/modules/security-analytics/index.md
@@ -4,6 +4,14 @@ The Security Analytics Plugin (SAP) is a fork of the [OpenSearch Security Analyt
 
 SAP runs inside the Wazuh Indexer and operates as an OpenSearch plugin, using the standard OpenSearch transport layer for all internal communication.
 
+## Detector constraints
+
+| Constraint           | Value | Description                                                                                              |
+| -------------------- | ----- | -------------------------------------------------------------------------------------------------------- |
+| Max rules per detector | 100 | Each detector input can reference at most 100 rules (custom or pre-packaged). Requests that exceed this limit are rejected with HTTP 400. |
+
+This limit is enforced at the transport layer (`TransportIndexDetectorAction`) and applies to all detector creation and update paths, including inter-plugin calls from the Content Manager.
+
 ## Wazuh enriched findings
 
 ### What is a finding?


### PR DESCRIPTION
### Description
This PR modifies documentation to mention the limit on the number of rules a detector can be assigned.

### Issues Resolved
Resolves https://github.com/wazuh/wazuh-indexer-security-analytics/issues/111