### PR TITLE
Implement version check CM API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add --set-as-main flag support to repository bumper [(#978)](https://github.com/wazuh/wazuh-indexer-plugins/pull/978)
 - Add SAP findings enrichment documentation [(#988)](https://github.com/wazuh/wazuh-indexer-plugins/pull/988)
 - Implement standard policy load to Engine at space.hash update [(#995)](https://github.com/wazuh/wazuh-indexer-plugins/pull/995)
-
+- Implement version check CM API endpoint [(#1028)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1028)
 
 ### Dependencies
 - Upgrade to Gradle 8.14.3 [(#649)](https://github.com/wazuh/wazuh-indexer-plugins/pull/649)

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -1675,6 +1675,94 @@ curl -sk -u admin:admin -X DELETE \
 | 400  | Invalid space identifier, or attempted to reset a space different from `draft` |
 | 500  | Internal error (e.g., Engine unavailable or deletion failure)                  |
 
+## Version Check
+
+### Check Available Updates
+
+Returns whether there are newer versions of Wazuh available for download. The endpoint reads the current installed version from `VERSION.json` and queries the CTI API for available updates. The response includes the latest available major, minor, and patch updates when available.
+
+**Request**
+- Method: `GET`
+- Path: `/_plugins/_content_manager/version/check`
+
+**Example Request**
+
+```bash
+curl -sk -u admin:admin \
+  "https://192.168.56.6:9200/_plugins/_content_manager/version/check"
+```
+
+**Example Response (updates available)**
+
+```json
+{
+  "message": {
+    "uuid": "bd7f0db0-d094-48ca-b883-7019484ce71f",
+    "last_check_date": "2026-04-14T15:28:41.347387+00:00",
+    "current_version": "v5.0.0",
+    "last_available_major": {
+      "tag": "v6.0.0",
+      "title": "Wazuh v6.0.0",
+      "description": "Major release with new features...",
+      "published_date": "2026-03-01T10:00:00Z",
+      "semver": { "major": 6, "minor": 0, "patch": 0 }
+    },
+    "last_available_minor": {
+      "tag": "v5.1.0",
+      "title": "Wazuh v5.1.0",
+      "description": "Minor improvements and enhancements...",
+      "published_date": "2026-02-15T10:00:00Z",
+      "semver": { "major": 5, "minor": 1, "patch": 0 }
+    },
+    "last_available_patch": {
+      "tag": "v5.0.1",
+      "title": "Wazuh v5.0.1",
+      "description": "Bug fixes and stability improvements...",
+      "published_date": "2026-01-20T10:00:00Z",
+      "semver": { "major": 5, "minor": 0, "patch": 1 }
+    }
+  },
+  "status": 200
+}
+```
+
+**Example Response (no updates)**
+
+```json
+{
+  "message": {
+    "uuid": "bd7f0db0-d094-48ca-b883-7019484ce71f",
+    "last_check_date": "2026-04-14T15:28:41.347387+00:00",
+    "current_version": "v5.0.0",
+    "last_available_major": {},
+    "last_available_minor": {},
+    "last_available_patch": {}
+  },
+  "status": 200
+}
+```
+
+**Example Response (version not found)**
+
+```json
+{
+  "message": "Unable to determine current Wazuh version.",
+  "status": 500
+}
+```
+
+**Status Codes**
+
+| Code | Description                                            |
+| ---- | ------------------------------------------------------ |
+| 200  | Version check completed (may include updates or empty) |
+| 500  | Unable to determine version or internal error          |
+| 502  | CTI API returned an error                              |
+
+> **Note**: Categories with no available updates are represented as empty objects `{}`.
+
+---
+
 ## Documentation Maintenance
 
 To maintain technical consistency, any modification, addition or removal \

--- a/plugins/content-manager/imposter/imposter-config.yml
+++ b/plugins/content-manager/imposter/imposter-config.yml
@@ -26,6 +26,12 @@ resources:
     response:
       scriptFile: scripts/instanceMeResponse.groovy
 
+  # Releases updates endpoint - returns available version updates
+  - path: /api/v1/releases/{tag}/updates
+    method: GET
+    response:
+      scriptFile: scripts/releasesUpdatesResponse.groovy
+
   # Catalog endpoint - conditional responses based on verify parameter
   - path: /api/v1/catalog/contexts/{context}/consumers/{consumer}/changes
     method: GET

--- a/plugins/content-manager/imposter/openapi.yml
+++ b/plugins/content-manager/imposter/openapi.yml
@@ -31,8 +31,8 @@ tags:
     description: CTI Console endpoints
   - name: CTI API
     description: Wazuh CTI resource endpoints
-  - name: CTI Releases
-    description: Wazuh CTI release version endpoints
+  - name: Wazuh Releases
+    description: Wazuh release version endpoints
 
 paths:
   /api/v1/instances/token:
@@ -128,7 +128,7 @@ paths:
         No authentication is required.
       operationId: getReleaseUpdates
       tags:
-        - CTI Releases
+        - Wazuh Releases
       parameters:
         - name: tag
           in: path

--- a/plugins/content-manager/imposter/openapi.yml
+++ b/plugins/content-manager/imposter/openapi.yml
@@ -31,6 +31,8 @@ tags:
     description: CTI Console endpoints
   - name: CTI API
     description: Wazuh CTI resource endpoints
+  - name: CTI Releases
+    description: Wazuh CTI release version endpoints
 
 paths:
   /api/v1/instances/token:
@@ -116,6 +118,37 @@ paths:
           $ref: '#/components/responses/InstanceMeSuccess'
         '401':
           $ref: '#/components/responses/Unauthorized'
+
+  /api/v1/releases/{tag}/updates:
+    get:
+      summary: Get Release Updates
+      description: |
+        Returns available version updates for the given release tag.
+        The response includes arrays of newer major, minor, and patch releases.
+        No authentication is required.
+      operationId: getReleaseUpdates
+      tags:
+        - CTI Releases
+      parameters:
+        - name: tag
+          in: path
+          required: true
+          description: The semver release tag (e.g., "v5.0.0")
+          schema:
+            type: string
+            example: v5.0.0
+      responses:
+        '200':
+          $ref: '#/components/responses/ReleaseUpdatesSuccess'
+        '400':
+          description: Invalid tag format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                errors:
+                  tag: ["is invalid"]
 
   /api/v1/catalog/contexts/{context}/consumers/{consumer}/changes:
     get:
@@ -462,6 +495,66 @@ components:
         - identifier
         - name
 
+    ReleaseUpdatesData:
+      type: object
+      description: Available release updates grouped by category.
+      properties:
+        major:
+          type: array
+          description: Available major version updates.
+          items:
+            $ref: '#/components/schemas/Release'
+        minor:
+          type: array
+          description: Available minor version updates.
+          items:
+            $ref: '#/components/schemas/Release'
+        patch:
+          type: array
+          description: Available patch version updates.
+          items:
+            $ref: '#/components/schemas/Release'
+      required:
+        - major
+        - minor
+        - patch
+
+    Release:
+      type: object
+      description: A single release entry.
+      properties:
+        tag:
+          type: string
+          example: "v5.1.0"
+        title:
+          type: string
+          example: "Wazuh v5.1.0"
+        description:
+          type: string
+          example: "Release notes..."
+        published_date:
+          type: string
+          format: date-time
+          example: "2026-06-15T10:00:00Z"
+        semver:
+          type: object
+          properties:
+            major:
+              type: integer
+              example: 5
+            minor:
+              type: integer
+              example: 1
+            patch:
+              type: integer
+              example: 0
+      required:
+        - tag
+        - title
+        - description
+        - published_date
+        - semver
+
     ErrorResponse:
       type: object
       description: Standard error response.
@@ -527,6 +620,49 @@ components:
                 access_token: https://localhost:8080/api/v1/catalog/contexts/misp/consumer/virustotal/changes?verify=1761383411-kJ9b8w%2BQ7kzRmF
                 issued_token_type: urn:wazuh:params:oauth:token-type:signed_url
                 expires_in: 300
+
+    ReleaseUpdatesSuccess:
+      description: OK - Release updates retrieved successfully.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/ReleaseUpdatesData'
+            required:
+              - data
+          examples:
+            updates_available:
+              summary: Updates available
+              value:
+                data:
+                  major: []
+                  minor:
+                    - tag: "v5.1.0"
+                      title: "Wazuh v5.1.0"
+                      description: "Minor improvements..."
+                      published_date: "2026-06-15T10:00:00Z"
+                      semver:
+                        major: 5
+                        minor: 1
+                        patch: 0
+                  patch:
+                    - tag: "v5.0.1"
+                      title: "Wazuh v5.0.1"
+                      description: "Bug fixes..."
+                      published_date: "2026-05-10T10:00:00Z"
+                      semver:
+                        major: 5
+                        minor: 0
+                        patch: 1
+            no_updates:
+              summary: No updates available
+              value:
+                data:
+                  major: []
+                  minor: []
+                  patch: []
 
     CatalogSuccess:
       description: OK - Catalog changes retrieved successfully.

--- a/plugins/content-manager/imposter/scripts/releasesUpdatesResponse.groovy
+++ b/plugins/content-manager/imposter/scripts/releasesUpdatesResponse.groovy
@@ -1,0 +1,68 @@
+// Releases Updates Response Logic
+// Returns mock release updates based on the version tag in the path.
+// Simulates the CTI API GET /api/v1/releases/:tag/updates endpoint.
+
+def tag = context.request.pathParams['tag']
+
+// Validate tag format (must start with 'v')
+if (!tag || !tag.startsWith('v')) {
+    respond()
+        .withStatusCode(400)
+        .withHeader("Content-Type", "application/json")
+        .withContent('{"errors": {"tag": ["is invalid"]}}')
+    return
+}
+
+// For v5.0.0 — simulate the current version with available updates
+if (tag == 'v5.0.0') {
+    respond()
+        .withStatusCode(200)
+        .withHeader("Content-Type", "application/json")
+        .withContent('''
+{
+  "data": {
+    "major": [
+      {
+        "tag": "v6.0.0",
+        "title": "Wazuh v6.0.0",
+        "description": "The 6.0.0 major release introduces a new architecture and platform improvements.",
+        "published_date": "2026-11-01T10:00:00Z",
+        "semver": { "major": 6, "minor": 0, "patch": 0 }
+      }
+    ],
+    "minor": [
+      {
+        "tag": "v5.1.0",
+        "title": "Wazuh v5.1.0",
+        "description": "The 5.1.0 release includes minor improvements and enhancements.",
+        "published_date": "2026-06-15T10:00:00Z",
+        "semver": { "major": 5, "minor": 1, "patch": 0 }
+      },
+      {
+        "tag": "v5.2.0",
+        "title": "Wazuh v5.2.0",
+        "description": "The 5.2.0 release includes new features and improvements.",
+        "published_date": "2026-09-01T10:00:00Z",
+        "semver": { "major": 5, "minor": 2, "patch": 0 }
+      }
+    ],
+    "patch": [
+      {
+        "tag": "v5.0.1",
+        "title": "Wazuh v5.0.1",
+        "description": "Wazuh version 5.0.1 is a patch update focusing on bug fixes.",
+        "published_date": "2026-05-10T10:00:00Z",
+        "semver": { "major": 5, "minor": 0, "patch": 1 }
+      }
+    ]
+  }
+}
+''')
+    return
+}
+
+// For any other valid tag — simulate no updates available
+respond()
+    .withStatusCode(200)
+    .withHeader("Content-Type", "application/json")
+    .withContent('{"data": {"major": [], "minor": [], "patch": []}}')

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -28,6 +28,8 @@ tags:
     description: Operations for managing CTI subscriptions and credentials
   - name: Content Updates
     description: Operations for triggering content updates
+  - name: Version Check
+    description: Check for available Wazuh version updates
   - name: KVDBs
     description: Manage key-value databases used by content
   - name: Decoders
@@ -149,6 +151,26 @@ paths:
           $ref: "#/components/responses/TooManyRequests"
         "500":
           $ref: "#/components/responses/InternalServerError"
+
+  /version/check:
+    description: Check for available Wazuh version updates
+    get:
+      summary: Check Available Wazuh Updates
+      description: |
+        Returns whether there are newer versions of Wazuh available for download.
+        The check is performed by reading the current installed version from `VERSION.json`
+        and querying the CTI API for available updates. The response includes the latest
+        available major, minor, and patch updates when available.
+      operationId: getVersionCheck
+      tags:
+        - Version Check
+      responses:
+        "200":
+          $ref: "#/components/responses/VersionCheckSuccess"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "502":
+          $ref: "#/components/responses/BadGateway"
 
   # KVDB management endpoints
   /kvdbs:
@@ -997,6 +1019,93 @@ components:
       required:
         - access_token
         - token_type
+
+    # Version check response models
+    VersionCheckData:
+      type: object
+      description: Version check result with cluster metadata and available updates.
+      required:
+        - uuid
+        - last_check_date
+        - current_version
+        - last_available_major
+        - last_available_minor
+        - last_available_patch
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          description: The cluster UUID.
+          example: "bd7f0db0-d094-48ca-b883-7019484ce71f"
+        last_check_date:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of when the check was performed.
+          example: "2026-04-14T15:28:41.347387+00:00"
+        current_version:
+          type: string
+          description: The currently installed Wazuh version tag.
+          example: "v5.0.0"
+        last_available_major:
+          $ref: "#/components/schemas/Release"
+        last_available_minor:
+          $ref: "#/components/schemas/Release"
+        last_available_patch:
+          $ref: "#/components/schemas/Release"
+
+    Release:
+      type: object
+      description: A single release entry from the CTI API.
+      properties:
+        tag:
+          type: string
+          description: Semver release tag.
+          example: "v5.1.0"
+        title:
+          type: string
+          description: Human-readable release title.
+          example: "Wazuh v5.1.0"
+        description:
+          type: string
+          description: Release notes in markdown format.
+          example: "## Manager\r\n\r\n### Added\r\n\r\n- New features..."
+        published_date:
+          type: string
+          format: date-time
+          description: ISO 8601 publication timestamp.
+          example: "2026-02-15T10:00:00Z"
+        semver:
+          $ref: "#/components/schemas/Semver"
+      required:
+        - tag
+        - title
+        - description
+        - published_date
+        - semver
+
+    Semver:
+      type: object
+      description: Semantic version components.
+      properties:
+        major:
+          type: integer
+          format: int32
+          description: Major version number.
+          example: 5
+        minor:
+          type: integer
+          format: int32
+          description: Minor version number.
+          example: 1
+        patch:
+          type: integer
+          format: int32
+          description: Patch version number.
+          example: 0
+      required:
+        - major
+        - minor
+        - patch
 
     # Request body for logtest execution
     LogtestRequest:
@@ -2045,6 +2154,83 @@ components:
               value:
                 message: "Internal Server Error"
                 status: 500
+
+    VersionCheckSuccess:
+      description: Available version updates retrieved successfully.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                $ref: "#/components/schemas/VersionCheckData"
+              status:
+                type: integer
+                example: 200
+            required:
+              - message
+              - status
+          examples:
+            updates_available:
+              summary: Updates available
+              value:
+                message:
+                  uuid: "bd7f0db0-d094-48ca-b883-7019484ce71f"
+                  last_check_date: "2026-04-14T15:28:41.347387+00:00"
+                  current_version: "v5.0.0"
+                  last_available_major:
+                    tag: "v6.0.0"
+                    title: "Wazuh v6.0.0"
+                    description: "Major release with new features..."
+                    published_date: "2026-03-01T10:00:00Z"
+                    semver:
+                      major: 6
+                      minor: 0
+                      patch: 0
+                  last_available_minor:
+                    tag: "v5.1.0"
+                    title: "Wazuh v5.1.0"
+                    description: "Minor improvements and enhancements..."
+                    published_date: "2026-02-15T10:00:00Z"
+                    semver:
+                      major: 5
+                      minor: 1
+                      patch: 0
+                  last_available_patch:
+                    tag: "v5.0.1"
+                    title: "Wazuh v5.0.1"
+                    description: "Bug fixes and stability improvements..."
+                    published_date: "2026-01-20T10:00:00Z"
+                    semver:
+                      major: 5
+                      minor: 0
+                      patch: 1
+                status: 200
+            no_updates:
+              summary: No updates available
+              value:
+                message:
+                  uuid: "bd7f0db0-d094-48ca-b883-7019484ce71f"
+                  last_check_date: "2026-04-14T15:28:41.347387+00:00"
+                  current_version: "v5.0.0"
+                  last_available_major: {}
+                  last_available_minor: {}
+                  last_available_patch: {}
+                status: 200
+
+    BadGateway:
+      description: |
+        Bad Gateway - The CTI API returned an error while checking for updates.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RestResponse"
+          examples:
+            cti_error:
+              summary: CTI API error
+              value:
+                message: "CTI API error"
+                status: 502
 
     # Response body for logtest execution results (pass-through)
     LogtestResponse:

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -96,6 +96,7 @@ public class ContentManagerPlugin extends Plugin
     private EngineService engine;
     private SpaceService spaceService;
     private SecurityAnalyticsService securityAnalyticsService;
+    private Environment environment;
 
     /**
      * Initializes the plugin components, including the CTI console, consumer index helpers, and the
@@ -129,6 +130,7 @@ public class ContentManagerPlugin extends Plugin
             IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<RepositoriesService> repositoriesServiceSupplier) {
         PluginSettings.getInstance(environment.settings());
+        this.environment = environment;
         this.client = client;
         this.threadPool = threadPool;
         this.consumersIndex = new ConsumersIndex(client);
@@ -231,6 +233,8 @@ public class ContentManagerPlugin extends Plugin
                 new RestPostSubscriptionAction(this.ctiConsole),
                 new RestDeleteSubscriptionAction(this.ctiConsole),
                 new RestPostUpdateAction(this.ctiConsole, this.catalogSyncJob),
+                // Version check endpoint
+                new RestGetVersionCheckAction(this.environment),
                 // User-generated content endpoints (Logtest)
                 new RestPostLogtestAction(this.engine),
                 // Policy endpoints

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -97,6 +97,7 @@ public class ContentManagerPlugin extends Plugin
     private SpaceService spaceService;
     private SecurityAnalyticsService securityAnalyticsService;
     private Environment environment;
+    private ClusterService clusterService;
 
     /**
      * Initializes the plugin components, including the CTI console, consumer index helpers, and the
@@ -131,6 +132,7 @@ public class ContentManagerPlugin extends Plugin
             Supplier<RepositoriesService> repositoriesServiceSupplier) {
         PluginSettings.getInstance(environment.settings());
         this.environment = environment;
+        this.clusterService = clusterService;
         this.client = client;
         this.threadPool = threadPool;
         this.consumersIndex = new ConsumersIndex(client);
@@ -234,7 +236,7 @@ public class ContentManagerPlugin extends Plugin
                 new RestDeleteSubscriptionAction(this.ctiConsole),
                 new RestPostUpdateAction(this.ctiConsole, this.catalogSyncJob),
                 // Version check endpoint
-                new RestGetVersionCheckAction(this.environment),
+                new RestGetVersionCheckAction(this.environment, this.clusterService),
                 // User-generated content endpoints (Logtest)
                 new RestPostLogtestAction(this.engine),
                 // Policy endpoints

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, Wazuh Inc.
+ * Copyright (C) 2024-2026, Wazuh Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -152,6 +152,38 @@ public class ApiClient {
                         + toOffset;
 
         SimpleHttpRequest request = SimpleRequestBuilder.get(uri).build();
+
+        final Future<SimpleHttpResponse> future =
+                this.client.execute(
+                        SimpleRequestProducer.create(request),
+                        SimpleResponseConsumer.create(),
+                        new HttpResponseCallback(request, "Outgoing request failed"));
+
+        return future.get(PluginSettings.getInstance().getClientTimeout(), TimeUnit.SECONDS);
+    }
+
+    /**
+     * Constructs the full URI for the releases updates endpoint.
+     *
+     * @param tag The release tag (e.g., "v5.0.0").
+     * @return A string representing the full absolute URL for the releases updates endpoint.
+     */
+    private String buildReleasesUpdatesURI(String tag) {
+        return this.baseUri + "/releases/" + tag + "/updates";
+    }
+
+    /**
+     * Retrieves available release updates for a given version tag from the CTI API.
+     *
+     * @param tag The release tag to query updates for (e.g., "v5.0.0").
+     * @return A {@link SimpleHttpResponse} containing the API response with available updates.
+     * @throws ExecutionException If the computation threw an exception.
+     * @throws InterruptedException If the current thread was interrupted while waiting.
+     * @throws TimeoutException If the wait timed out.
+     */
+    public SimpleHttpResponse getReleaseUpdates(String tag)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        SimpleHttpRequest request = SimpleRequestBuilder.get(this.buildReleasesUpdatesURI(tag)).build();
 
         final Future<SimpleHttpResponse> future =
                 this.client.execute(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Release.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Release.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Represents a single release entry returned by the CTI API's {@code /releases/:tag/updates}
+ * endpoint.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Release implements ToXContentObject {
+    private static final String TAG_KEY = "tag";
+    private static final String TITLE_KEY = "title";
+    private static final String DESCRIPTION_KEY = "description";
+    private static final String PUBLISHED_DATE_KEY = "published_date";
+    private static final String SEMVER_KEY = "semver";
+
+    @JsonProperty(TAG_KEY)
+    private final String tag;
+
+    @JsonProperty(TITLE_KEY)
+    private final String title;
+
+    @JsonProperty(DESCRIPTION_KEY)
+    private final String description;
+
+    @JsonProperty(PUBLISHED_DATE_KEY)
+    private final String publishedDate;
+
+    @JsonProperty(SEMVER_KEY)
+    private final Semver semver;
+
+    /**
+     * Constructs a Release instance.
+     *
+     * @param tag the semver release tag (e.g., "v5.1.0")
+     * @param title the human-readable release title
+     * @param description the release notes in markdown format
+     * @param publishedDate the ISO 8601 publication timestamp
+     * @param semver the parsed semantic version
+     */
+    @JsonCreator
+    public Release(
+            @JsonProperty(TAG_KEY) String tag,
+            @JsonProperty(TITLE_KEY) String title,
+            @JsonProperty(DESCRIPTION_KEY) String description,
+            @JsonProperty(PUBLISHED_DATE_KEY) String publishedDate,
+            @JsonProperty(SEMVER_KEY) Semver semver) {
+        this.tag = tag;
+        this.title = title;
+        this.description = description;
+        this.publishedDate = publishedDate;
+        this.semver = semver;
+    }
+
+    /**
+     * Returns the semver release tag.
+     *
+     * @return the tag string
+     */
+    public String getTag() {
+        return this.tag;
+    }
+
+    /**
+     * Returns the release title.
+     *
+     * @return the title string
+     */
+    public String getTitle() {
+        return this.title;
+    }
+
+    /**
+     * Returns the release description.
+     *
+     * @return the description string
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /**
+     * Returns the publication date.
+     *
+     * @return the published date string in ISO 8601 format
+     */
+    public String getPublishedDate() {
+        return this.publishedDate;
+    }
+
+    /**
+     * Returns the parsed semantic version.
+     *
+     * @return the Semver instance
+     */
+    public Semver getSemver() {
+        return this.semver;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(TAG_KEY, this.tag);
+        builder.field(TITLE_KEY, this.title);
+        builder.field(DESCRIPTION_KEY, this.description);
+        builder.field(PUBLISHED_DATE_KEY, this.publishedDate);
+        if (this.semver != null) {
+            builder.field(SEMVER_KEY);
+            this.semver.toXContent(builder, params);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    /** Represents the semantic version components of a release. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Semver implements ToXContentObject {
+        private static final String MAJOR_KEY = "major";
+        private static final String MINOR_KEY = "minor";
+        private static final String PATCH_KEY = "patch";
+
+        @JsonProperty(MAJOR_KEY)
+        private final int major;
+
+        @JsonProperty(MINOR_KEY)
+        private final int minor;
+
+        @JsonProperty(PATCH_KEY)
+        private final int patch;
+
+        /**
+         * Constructs a Semver instance.
+         *
+         * @param major the major version number
+         * @param minor the minor version number
+         * @param patch the patch version number
+         */
+        @JsonCreator
+        public Semver(
+                @JsonProperty(MAJOR_KEY) int major,
+                @JsonProperty(MINOR_KEY) int minor,
+                @JsonProperty(PATCH_KEY) int patch) {
+            this.major = major;
+            this.minor = minor;
+            this.patch = patch;
+        }
+
+        /**
+         * @return the major version number
+         */
+        public int getMajor() {
+            return this.major;
+        }
+
+        /**
+         * @return the minor version number
+         */
+        public int getMinor() {
+            return this.minor;
+        }
+
+        /**
+         * @return the patch version number
+         */
+        public int getPatch() {
+            return this.patch;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(MAJOR_KEY, this.major);
+            builder.field(MINOR_KEY, this.minor);
+            builder.field(PATCH_KEY, this.patch);
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/model/VersionCheckResponse.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/model/VersionCheckResponse.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.model;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BytesRestResponse;
+
+import java.io.IOException;
+
+import com.wazuh.contentmanager.cti.catalog.model.Release;
+
+/**
+ * Response model for the version check endpoint. Produces a JSON response with the latest available
+ * updates grouped by major, minor, and patch categories.
+ *
+ * <p>Example response:
+ *
+ * <pre>{@code
+ * {
+ *   "data": {
+ *     "last_available_major": { ... },
+ *     "last_available_minor": { ... },
+ *     "last_available_patch": { ... }
+ *   },
+ *   "status": 200
+ * }
+ * }</pre>
+ */
+public class VersionCheckResponse implements ToXContent {
+    private static final String DATA_KEY = "data";
+    private static final String STATUS_KEY = "status";
+    private static final String LAST_AVAILABLE_MAJOR_KEY = "last_available_major";
+    private static final String LAST_AVAILABLE_MINOR_KEY = "last_available_minor";
+    private static final String LAST_AVAILABLE_PATCH_KEY = "last_available_patch";
+
+    private final Release lastAvailableMajor;
+    private final Release lastAvailableMinor;
+    private final Release lastAvailablePatch;
+    private final int status;
+
+    /**
+     * Constructs a VersionCheckResponse.
+     *
+     * @param lastAvailableMajor the latest major version update, or null if none
+     * @param lastAvailableMinor the latest minor version update, or null if none
+     * @param lastAvailablePatch the latest patch version update, or null if none
+     * @param status the HTTP status code
+     */
+    public VersionCheckResponse(
+            Release lastAvailableMajor,
+            Release lastAvailableMinor,
+            Release lastAvailablePatch,
+            int status) {
+        this.lastAvailableMajor = lastAvailableMajor;
+        this.lastAvailableMinor = lastAvailableMinor;
+        this.lastAvailablePatch = lastAvailablePatch;
+        this.status = status;
+    }
+
+    /**
+     * Serializes this response into an {@link XContentBuilder} using JSON format.
+     *
+     * @return an {@link XContentBuilder} containing the JSON representation
+     * @throws IOException if an I/O error occurs while building the content
+     */
+    public XContentBuilder toXContent() throws IOException {
+        return this.toXContent(XContentFactory.jsonBuilder(), null);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+
+        builder.startObject(DATA_KEY);
+        if (this.lastAvailableMajor != null) {
+            builder.field(LAST_AVAILABLE_MAJOR_KEY);
+            this.lastAvailableMajor.toXContent(builder, params);
+        }
+        if (this.lastAvailableMinor != null) {
+            builder.field(LAST_AVAILABLE_MINOR_KEY);
+            this.lastAvailableMinor.toXContent(builder, params);
+        }
+        if (this.lastAvailablePatch != null) {
+            builder.field(LAST_AVAILABLE_PATCH_KEY);
+            this.lastAvailablePatch.toXContent(builder, params);
+        }
+        builder.endObject();
+
+        builder.field(STATUS_KEY, this.status);
+
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Converts this response to a {@link BytesRestResponse}.
+     *
+     * @return a BytesRestResponse ready to be sent
+     */
+    public BytesRestResponse toBytesRestResponse() {
+        try {
+            return new BytesRestResponse(RestStatus.fromCode(this.status), this.toXContent());
+        } catch (IOException e) {
+            return new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/model/VersionCheckResponse.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/model/VersionCheckResponse.java
@@ -27,29 +27,38 @@ import java.io.IOException;
 import com.wazuh.contentmanager.cti.catalog.model.Release;
 
 /**
- * Response model for the version check endpoint. Produces a JSON response with the latest available
- * updates grouped by major, minor, and patch categories.
+ * Response model for the version check endpoint. Produces a JSON response following the Wazuh
+ * Manager's format with {@code message} and {@code status} top-level fields.
  *
  * <p>Example response:
  *
  * <pre>{@code
  * {
- *   "data": {
- *     "last_available_major": { ... },
- *     "last_available_minor": { ... },
- *     "last_available_patch": { ... }
+ *   "message": {
+ *     "uuid": "bd7f0db0-...",
+ *     "last_check_date": "2026-04-14T15:28:41.347387+00:00",
+ *     "current_version": "v5.0.0",
+ *     "last_available_major": {},
+ *     "last_available_minor": {},
+ *     "last_available_patch": { "tag": "v5.0.1", ... }
  *   },
  *   "status": 200
  * }
  * }</pre>
  */
 public class VersionCheckResponse implements ToXContent {
-    private static final String DATA_KEY = "data";
+    private static final String MESSAGE_KEY = "message";
     private static final String STATUS_KEY = "status";
+    private static final String UUID_KEY = "uuid";
+    private static final String LAST_CHECK_DATE_KEY = "last_check_date";
+    private static final String CURRENT_VERSION_KEY = "current_version";
     private static final String LAST_AVAILABLE_MAJOR_KEY = "last_available_major";
     private static final String LAST_AVAILABLE_MINOR_KEY = "last_available_minor";
     private static final String LAST_AVAILABLE_PATCH_KEY = "last_available_patch";
 
+    private final String uuid;
+    private final String lastCheckDate;
+    private final String currentVersion;
     private final Release lastAvailableMajor;
     private final Release lastAvailableMinor;
     private final Release lastAvailablePatch;
@@ -58,16 +67,25 @@ public class VersionCheckResponse implements ToXContent {
     /**
      * Constructs a VersionCheckResponse.
      *
+     * @param uuid the cluster UUID
+     * @param lastCheckDate the ISO 8601 timestamp of when the check was performed
+     * @param currentVersion the current installed Wazuh version tag (e.g., "v5.0.0")
      * @param lastAvailableMajor the latest major version update, or null if none
      * @param lastAvailableMinor the latest minor version update, or null if none
      * @param lastAvailablePatch the latest patch version update, or null if none
      * @param status the HTTP status code
      */
     public VersionCheckResponse(
+            String uuid,
+            String lastCheckDate,
+            String currentVersion,
             Release lastAvailableMajor,
             Release lastAvailableMinor,
             Release lastAvailablePatch,
             int status) {
+        this.uuid = uuid;
+        this.lastCheckDate = lastCheckDate;
+        this.currentVersion = currentVersion;
         this.lastAvailableMajor = lastAvailableMajor;
         this.lastAvailableMinor = lastAvailableMinor;
         this.lastAvailablePatch = lastAvailablePatch;
@@ -88,25 +106,41 @@ public class VersionCheckResponse implements ToXContent {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
 
-        builder.startObject(DATA_KEY);
-        if (this.lastAvailableMajor != null) {
-            builder.field(LAST_AVAILABLE_MAJOR_KEY);
-            this.lastAvailableMajor.toXContent(builder, params);
-        }
-        if (this.lastAvailableMinor != null) {
-            builder.field(LAST_AVAILABLE_MINOR_KEY);
-            this.lastAvailableMinor.toXContent(builder, params);
-        }
-        if (this.lastAvailablePatch != null) {
-            builder.field(LAST_AVAILABLE_PATCH_KEY);
-            this.lastAvailablePatch.toXContent(builder, params);
-        }
+        builder.startObject(MESSAGE_KEY);
+        builder.field(UUID_KEY, this.uuid);
+        builder.field(LAST_CHECK_DATE_KEY, this.lastCheckDate);
+        builder.field(CURRENT_VERSION_KEY, this.currentVersion);
+
+        writeReleaseOrEmpty(builder, LAST_AVAILABLE_MAJOR_KEY, this.lastAvailableMajor, params);
+        writeReleaseOrEmpty(builder, LAST_AVAILABLE_MINOR_KEY, this.lastAvailableMinor, params);
+        writeReleaseOrEmpty(builder, LAST_AVAILABLE_PATCH_KEY, this.lastAvailablePatch, params);
+
         builder.endObject();
 
         builder.field(STATUS_KEY, this.status);
 
         builder.endObject();
         return builder;
+    }
+
+    /**
+     * Writes a release field as a full object if present, or as an empty object if null.
+     *
+     * @param builder the XContent builder
+     * @param fieldName the JSON field name
+     * @param release the release, or null
+     * @param params serialization parameters
+     * @throws IOException if an I/O error occurs
+     */
+    private static void writeReleaseOrEmpty(
+            XContentBuilder builder, String fieldName, Release release, Params params)
+            throws IOException {
+        if (release != null) {
+            builder.field(fieldName);
+            release.toXContent(builder, params);
+        } else {
+            builder.startObject(fieldName).endObject();
+        }
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckAction.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.env.Environment;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.NamedRoute;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.wazuh.contentmanager.ContentManagerPlugin;
+import com.wazuh.contentmanager.cti.catalog.client.ApiClient;
+import com.wazuh.contentmanager.cti.catalog.model.Release;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import com.wazuh.contentmanager.rest.model.VersionCheckResponse;
+import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+/**
+ * GET /_plugins/_content_manager/version/check
+ *
+ * <p>Returns available Wazuh version updates by querying the CTI API. The response includes the
+ * latest available major, minor, and patch updates.
+ *
+ * <p>Possible HTTP responses:
+ *
+ * <ul>
+ *   <li>200 OK: Updates retrieved successfully
+ *   <li>500 Internal Server Error: Unable to determine version or unexpected error
+ *   <li>502 Bad Gateway: CTI API returned an error
+ * </ul>
+ */
+public class RestGetVersionCheckAction extends BaseRestHandler {
+    private static final Logger log = LogManager.getLogger(RestGetVersionCheckAction.class);
+    private static final String ENDPOINT_NAME = "content_manager_version_check_get";
+    private static final String ENDPOINT_UNIQUE_NAME = "plugin:content_manager/version_check_get";
+
+    private final Environment environment;
+    private final ApiClient apiClient;
+    private final ObjectMapper mapper;
+
+    /**
+     * Constructs a new RestGetVersionCheckAction.
+     *
+     * @param environment the node environment for reading VERSION.json
+     */
+    public RestGetVersionCheckAction(Environment environment) {
+        this.environment = environment;
+        this.apiClient = new ApiClient();
+        this.mapper = new ObjectMapper();
+    }
+
+    /**
+     * Package-private constructor for dependency injection during unit tests.
+     *
+     * @param environment the node environment
+     * @param apiClient the API client (can be mocked)
+     */
+    RestGetVersionCheckAction(Environment environment, ApiClient apiClient) {
+        this.environment = environment;
+        this.apiClient = apiClient;
+        this.mapper = new ObjectMapper();
+    }
+
+    @Override
+    public String getName() {
+        return ENDPOINT_NAME;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+                new NamedRoute.Builder()
+                        .path(PluginSettings.VERSION_CHECK_URI)
+                        .method(GET)
+                        .uniqueName(ENDPOINT_UNIQUE_NAME)
+                        .build());
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> channel.sendResponse(this.handleRequest());
+    }
+
+    /**
+     * Executes the version check operation.
+     *
+     * @return a BytesRestResponse containing the available updates or error
+     * @throws IOException if an I/O error occurs while building the response
+     */
+    public BytesRestResponse handleRequest() throws IOException {
+        try {
+            String version = ContentManagerPlugin.getVersion(this.environment);
+            if (version == null || version.isBlank()) {
+                log.error(Constants.E_500_VERSION_NOT_FOUND);
+                return new RestResponse(
+                                Constants.E_500_VERSION_NOT_FOUND, RestStatus.INTERNAL_SERVER_ERROR.getStatus())
+                        .toBytesRestResponse();
+            }
+
+            String tag = "v" + version;
+            SimpleHttpResponse ctiResponse = this.apiClient.getReleaseUpdates(tag);
+
+            int ctiStatusCode = ctiResponse.getCode();
+            if (ctiStatusCode < 200 || ctiStatusCode >= 300) {
+                log.error(
+                        "CTI API returned error for version check: status={}, body={}",
+                        ctiStatusCode,
+                        ctiResponse.getBodyText());
+                RestStatus status =
+                        RestStatus.fromCode(ctiStatusCode) != null
+                                ? RestStatus.fromCode(ctiStatusCode)
+                                : RestStatus.BAD_GATEWAY;
+                return new RestResponse(ctiResponse.getBodyText(), status.getStatus())
+                        .parseMessageAsJson()
+                        .toBytesRestResponse();
+            }
+
+            JsonNode root = this.mapper.readTree(ctiResponse.getBodyText());
+            JsonNode data = root.get("data");
+
+            Release lastMajor = getLastRelease(data, "major");
+            Release lastMinor = getLastRelease(data, "minor");
+            Release lastPatch = getLastRelease(data, "patch");
+
+            return new VersionCheckResponse(lastMajor, lastMinor, lastPatch, RestStatus.OK.getStatus())
+                    .toBytesRestResponse();
+
+        } catch (Exception e) {
+            log.error("Unexpected error during version check: {}", e.getMessage(), e);
+            return new RestResponse(
+                            e.getMessage() != null
+                                    ? e.getMessage()
+                                    : "An unexpected error occurred while processing your request.",
+                            RestStatus.INTERNAL_SERVER_ERROR.getStatus())
+                    .toBytesRestResponse();
+        }
+    }
+
+    /**
+     * Extracts the last (most recent) release from a category array in the CTI response.
+     *
+     * @param data the "data" node from the CTI API response
+     * @param category the category name ("major", "minor", or "patch")
+     * @return the last Release in the array, or null if the array is empty or missing
+     */
+    private Release getLastRelease(JsonNode data, String category) {
+        if (data == null || !data.has(category)) {
+            return null;
+        }
+        JsonNode array = data.get(category);
+        if (!array.isArray() || array.isEmpty()) {
+            return null;
+        }
+        try {
+            List<Release> releases =
+                    this.mapper.readValue(array.toString(), new TypeReference<List<Release>>() {});
+            return releases.get(releases.size() - 1);
+        } catch (Exception e) {
+            log.warn("Failed to parse {} releases: {}", category, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckAction.java
@@ -34,6 +34,7 @@ import org.opensearch.transport.client.node.NodeClient;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -161,7 +162,8 @@ public class RestGetVersionCheckAction extends BaseRestHandler {
             Release lastPatch = getLastRelease(data, "patch");
 
             String uuid = this.clusterService.state().metadata().clusterUUID();
-            String lastCheckDate = OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            String lastCheckDate =
+                    OffsetDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
             return new VersionCheckResponse(
                             uuid, lastCheckDate, tag, lastMajor, lastMinor, lastPatch, RestStatus.OK.getStatus())
@@ -170,10 +172,7 @@ public class RestGetVersionCheckAction extends BaseRestHandler {
         } catch (Exception e) {
             log.error("Unexpected error during version check: {}", e.getMessage(), e);
             return new RestResponse(
-                            e.getMessage() != null
-                                    ? e.getMessage()
-                                    : "An unexpected error occurred while processing your request.",
-                            RestStatus.INTERNAL_SERVER_ERROR.getStatus())
+                            Constants.E_500_CTI_UNREACHABLE, RestStatus.INTERNAL_SERVER_ERROR.getStatus())
                     .toBytesRestResponse();
         }
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckAction.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.env.Environment;
 import org.opensearch.rest.BaseRestHandler;
@@ -32,6 +33,8 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.transport.client.node.NodeClient;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import com.wazuh.contentmanager.ContentManagerPlugin;
@@ -64,6 +67,7 @@ public class RestGetVersionCheckAction extends BaseRestHandler {
     private static final String ENDPOINT_UNIQUE_NAME = "plugin:content_manager/version_check_get";
 
     private final Environment environment;
+    private final ClusterService clusterService;
     private final ApiClient apiClient;
     private final ObjectMapper mapper;
 
@@ -71,9 +75,11 @@ public class RestGetVersionCheckAction extends BaseRestHandler {
      * Constructs a new RestGetVersionCheckAction.
      *
      * @param environment the node environment for reading VERSION.json
+     * @param clusterService the cluster service for retrieving the cluster UUID
      */
-    public RestGetVersionCheckAction(Environment environment) {
+    public RestGetVersionCheckAction(Environment environment, ClusterService clusterService) {
         this.environment = environment;
+        this.clusterService = clusterService;
         this.apiClient = new ApiClient();
         this.mapper = new ObjectMapper();
     }
@@ -82,10 +88,13 @@ public class RestGetVersionCheckAction extends BaseRestHandler {
      * Package-private constructor for dependency injection during unit tests.
      *
      * @param environment the node environment
+     * @param clusterService the cluster service
      * @param apiClient the API client (can be mocked)
      */
-    RestGetVersionCheckAction(Environment environment, ApiClient apiClient) {
+    RestGetVersionCheckAction(
+            Environment environment, ClusterService clusterService, ApiClient apiClient) {
         this.environment = environment;
+        this.clusterService = clusterService;
         this.apiClient = apiClient;
         this.mapper = new ObjectMapper();
     }
@@ -151,7 +160,11 @@ public class RestGetVersionCheckAction extends BaseRestHandler {
             Release lastMinor = getLastRelease(data, "minor");
             Release lastPatch = getLastRelease(data, "patch");
 
-            return new VersionCheckResponse(lastMajor, lastMinor, lastPatch, RestStatus.OK.getStatus())
+            String uuid = this.clusterService.state().metadata().clusterUUID();
+            String lastCheckDate = OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+            return new VersionCheckResponse(
+                            uuid, lastCheckDate, tag, lastMajor, lastMinor, lastPatch, RestStatus.OK.getStatus())
                     .toBytesRestResponse();
 
         } catch (Exception e) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -40,6 +40,7 @@ public class PluginSettings {
     public static final String POLICY_URI = PLUGINS_BASE_URI + "/policy";
     public static final String FILTERS_URI = PLUGINS_BASE_URI + "/filters";
     public static final String SPACE_URI = PLUGINS_BASE_URI + "/space";
+    public static final String VERSION_CHECK_URI = PLUGINS_BASE_URI + "/version/check";
 
     /** Settings default values */
     private static final int DEFAULT_MAX_ITEMS_PER_BULK = 999;

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -64,6 +64,7 @@ public class Constants {
     public static final String E_500_INTERNAL_SERVER_ERROR = "Internal Server Error.";
     public static final String E_500_SECURITY_ANALYTICS_ERROR = "Error in Security Analytics.";
     public static final String E_500_MISSING_DRAFT_POLICY = "Draft policy not found.";
+    public static final String E_500_VERSION_NOT_FOUND = "Unable to determine current Wazuh version.";
 
     // Log messages
     public static final String I_LOG_SUCCESS = "{} {} successfully (id={})";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -65,6 +65,8 @@ public class Constants {
     public static final String E_500_SECURITY_ANALYTICS_ERROR = "Error in Security Analytics.";
     public static final String E_500_MISSING_DRAFT_POLICY = "Draft policy not found.";
     public static final String E_500_VERSION_NOT_FOUND = "Unable to determine current Wazuh version.";
+    public static final String E_500_CTI_UNREACHABLE =
+            "Unable to reach the CTI API to check for updates.";
 
     // Log messages
     public static final String I_LOG_SUCCESS = "{} {} successfully (id={})";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckActionTests.java
@@ -18,6 +18,9 @@ package com.wazuh.contentmanager.rest.service;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.env.Environment;
@@ -46,7 +49,9 @@ import static org.mockito.Mockito.when;
  * API endpoint responsible for checking available Wazuh version updates.
  */
 public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
+    private static final String TEST_UUID = "test-cluster-uuid-1234";
     private ApiClient apiClient;
+    private ClusterService clusterService;
     private RestGetVersionCheckAction action;
 
     /** Initialize PluginSettings singleton before all tests. */
@@ -64,6 +69,13 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.apiClient = mock(ApiClient.class);
+        this.clusterService = mock(ClusterService.class);
+
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        when(this.clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.clusterUUID()).thenReturn(TEST_UUID);
     }
 
     /**
@@ -84,12 +96,12 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Test successful version check with updates available in all categories. Expected: 200 with
-     * last_available_major, last_available_minor, last_available_patch.
+     * Test successful version check with updates available. Expected: 200 with message containing
+     * uuid, current_version, last_check_date, and release fields.
      */
     public void testHandleRequest200() throws Exception {
         Environment env = createEnvironmentWithVersion("5.0.0");
-        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+        this.action = new RestGetVersionCheckAction(env, this.clusterService, this.apiClient);
 
         // spotless:off
         String ctiResponseBody = "{\"data\":{" +
@@ -106,6 +118,11 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
         String body = response.content().utf8ToString();
 
         Assert.assertEquals(RestStatus.OK, response.status());
+        Assert.assertTrue(body.contains("\"uuid\""));
+        Assert.assertTrue(body.contains(TEST_UUID));
+        Assert.assertTrue(body.contains("\"current_version\""));
+        Assert.assertTrue(body.contains("v5.0.0"));
+        Assert.assertTrue(body.contains("\"last_check_date\""));
         Assert.assertTrue(body.contains("last_available_major"));
         Assert.assertTrue(body.contains("v6.0.0"));
         Assert.assertTrue(body.contains("last_available_minor"));
@@ -115,11 +132,12 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
     }
 
     /**
-     * Test successful version check with empty update arrays. Expected: 200 with empty data object.
+     * Test successful version check with empty update arrays. Expected: 200 with empty objects for
+     * each category.
      */
     public void testHandleRequest200EmptyArrays() throws Exception {
         Environment env = createEnvironmentWithVersion("5.0.0");
-        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+        this.action = new RestGetVersionCheckAction(env, this.clusterService, this.apiClient);
 
         String ctiResponseBody = "{\"data\":{\"major\":[],\"minor\":[],\"patch\":[]}}";
         SimpleHttpResponse ctiResponse = SimpleHttpResponse.create(200, ctiResponseBody, null);
@@ -129,15 +147,15 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
         String body = response.content().utf8ToString();
 
         Assert.assertEquals(RestStatus.OK, response.status());
-        Assert.assertFalse(body.contains("last_available_major"));
-        Assert.assertFalse(body.contains("last_available_minor"));
-        Assert.assertFalse(body.contains("last_available_patch"));
+        Assert.assertTrue(body.contains("last_available_major"));
+        Assert.assertTrue(body.contains("last_available_minor"));
+        Assert.assertTrue(body.contains("last_available_patch"));
     }
 
     /** Test when VERSION.json is missing. Expected: 500 with version not found message. */
     public void testHandleRequestVersionNotFound() throws Exception {
         Environment env = createEnvironmentWithVersion(null);
-        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+        this.action = new RestGetVersionCheckAction(env, this.clusterService, this.apiClient);
 
         BytesRestResponse response = this.action.handleRequest();
         String body = response.content().utf8ToString();
@@ -149,7 +167,7 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
     /** Test when the CTI API returns an error. Expected: error status forwarded. */
     public void testHandleRequestCtiError() throws Exception {
         Environment env = createEnvironmentWithVersion("5.0.0");
-        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+        this.action = new RestGetVersionCheckAction(env, this.clusterService, this.apiClient);
 
         String errorBody = "{\"errors\":{\"tag\":[\"is invalid\"]}}";
         SimpleHttpResponse ctiResponse = SimpleHttpResponse.create(400, errorBody, null);
@@ -163,7 +181,7 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
     /** Test when the API client throws an exception. Expected: 500. */
     public void testHandleRequestException() throws Exception {
         Environment env = createEnvironmentWithVersion("5.0.0");
-        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+        this.action = new RestGetVersionCheckAction(env, this.clusterService, this.apiClient);
 
         when(this.apiClient.getReleaseUpdates(anyString()))
                 .thenThrow(new ExecutionException("Connection refused", new RuntimeException()));
@@ -179,7 +197,7 @@ public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
      */
     public void testHandleRequestReturnsLastRelease() throws Exception {
         Environment env = createEnvironmentWithVersion("5.0.0");
-        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+        this.action = new RestGetVersionCheckAction(env, this.clusterService, this.apiClient);
 
         // spotless:off
         String ctiResponseBody = "{\"data\":{" +

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetVersionCheckActionTests.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.env.Environment;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+
+import com.wazuh.contentmanager.cti.catalog.client.ApiClient;
+import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link RestGetVersionCheckAction} class. This test suite validates the REST
+ * API endpoint responsible for checking available Wazuh version updates.
+ */
+public class RestGetVersionCheckActionTests extends OpenSearchTestCase {
+    private ApiClient apiClient;
+    private RestGetVersionCheckAction action;
+
+    /** Initialize PluginSettings singleton before all tests. */
+    @BeforeClass
+    public static void setUpClass() {
+        try {
+            PluginSettings.getInstance(Settings.EMPTY);
+        } catch (Exception e) {
+            // Already initialized
+        }
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.apiClient = mock(ApiClient.class);
+    }
+
+    /**
+     * Creates a temporary Environment with a VERSION.json containing the given version.
+     *
+     * @param version the version string to write (e.g., "5.0.0"), or null to skip file creation
+     * @return an Environment pointing to the temp directory
+     * @throws IOException if writing the file fails
+     */
+    private Environment createEnvironmentWithVersion(String version) throws IOException {
+        Path tempDir = LuceneTestCase.createTempDir();
+        if (version != null) {
+            String json = "{\"version\": \"" + version + "\"}";
+            Files.writeString(tempDir.resolve("VERSION.json"), json, StandardCharsets.UTF_8);
+        }
+        Settings settings = Settings.builder().put("path.home", tempDir.toString()).build();
+        return new Environment(settings, tempDir);
+    }
+
+    /**
+     * Test successful version check with updates available in all categories. Expected: 200 with
+     * last_available_major, last_available_minor, last_available_patch.
+     */
+    public void testHandleRequest200() throws Exception {
+        Environment env = createEnvironmentWithVersion("5.0.0");
+        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+
+        // spotless:off
+        String ctiResponseBody = "{\"data\":{" +
+                "\"major\":[{\"tag\":\"v6.0.0\",\"title\":\"Wazuh v6.0.0\",\"description\":\"Major release\",\"published_date\":\"2026-03-01T10:00:00Z\",\"semver\":{\"major\":6,\"minor\":0,\"patch\":0}}]," +
+                "\"minor\":[{\"tag\":\"v5.1.0\",\"title\":\"Wazuh v5.1.0\",\"description\":\"Minor release\",\"published_date\":\"2026-02-15T10:00:00Z\",\"semver\":{\"major\":5,\"minor\":1,\"patch\":0}}]," +
+                "\"patch\":[{\"tag\":\"v5.0.1\",\"title\":\"Wazuh v5.0.1\",\"description\":\"Patch release\",\"published_date\":\"2026-01-20T10:00:00Z\",\"semver\":{\"major\":5,\"minor\":0,\"patch\":1}}]" +
+                "}}";
+        // spotless:on
+
+        SimpleHttpResponse ctiResponse = SimpleHttpResponse.create(200, ctiResponseBody, null);
+        when(this.apiClient.getReleaseUpdates("v5.0.0")).thenReturn(ctiResponse);
+
+        BytesRestResponse response = this.action.handleRequest();
+        String body = response.content().utf8ToString();
+
+        Assert.assertEquals(RestStatus.OK, response.status());
+        Assert.assertTrue(body.contains("last_available_major"));
+        Assert.assertTrue(body.contains("v6.0.0"));
+        Assert.assertTrue(body.contains("last_available_minor"));
+        Assert.assertTrue(body.contains("v5.1.0"));
+        Assert.assertTrue(body.contains("last_available_patch"));
+        Assert.assertTrue(body.contains("v5.0.1"));
+    }
+
+    /**
+     * Test successful version check with empty update arrays. Expected: 200 with empty data object.
+     */
+    public void testHandleRequest200EmptyArrays() throws Exception {
+        Environment env = createEnvironmentWithVersion("5.0.0");
+        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+
+        String ctiResponseBody = "{\"data\":{\"major\":[],\"minor\":[],\"patch\":[]}}";
+        SimpleHttpResponse ctiResponse = SimpleHttpResponse.create(200, ctiResponseBody, null);
+        when(this.apiClient.getReleaseUpdates("v5.0.0")).thenReturn(ctiResponse);
+
+        BytesRestResponse response = this.action.handleRequest();
+        String body = response.content().utf8ToString();
+
+        Assert.assertEquals(RestStatus.OK, response.status());
+        Assert.assertFalse(body.contains("last_available_major"));
+        Assert.assertFalse(body.contains("last_available_minor"));
+        Assert.assertFalse(body.contains("last_available_patch"));
+    }
+
+    /** Test when VERSION.json is missing. Expected: 500 with version not found message. */
+    public void testHandleRequestVersionNotFound() throws Exception {
+        Environment env = createEnvironmentWithVersion(null);
+        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+
+        BytesRestResponse response = this.action.handleRequest();
+        String body = response.content().utf8ToString();
+
+        Assert.assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
+        Assert.assertTrue(body.contains(Constants.E_500_VERSION_NOT_FOUND));
+    }
+
+    /** Test when the CTI API returns an error. Expected: error status forwarded. */
+    public void testHandleRequestCtiError() throws Exception {
+        Environment env = createEnvironmentWithVersion("5.0.0");
+        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+
+        String errorBody = "{\"errors\":{\"tag\":[\"is invalid\"]}}";
+        SimpleHttpResponse ctiResponse = SimpleHttpResponse.create(400, errorBody, null);
+        when(this.apiClient.getReleaseUpdates("v5.0.0")).thenReturn(ctiResponse);
+
+        BytesRestResponse response = this.action.handleRequest();
+
+        Assert.assertEquals(RestStatus.BAD_REQUEST, response.status());
+    }
+
+    /** Test when the API client throws an exception. Expected: 500. */
+    public void testHandleRequestException() throws Exception {
+        Environment env = createEnvironmentWithVersion("5.0.0");
+        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+
+        when(this.apiClient.getReleaseUpdates(anyString()))
+                .thenThrow(new ExecutionException("Connection refused", new RuntimeException()));
+
+        BytesRestResponse response = this.action.handleRequest();
+
+        Assert.assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
+    }
+
+    /**
+     * Test that when multiple releases exist in a category, the last one is returned. Expected: 200
+     * with the last release from the array.
+     */
+    public void testHandleRequestReturnsLastRelease() throws Exception {
+        Environment env = createEnvironmentWithVersion("5.0.0");
+        this.action = new RestGetVersionCheckAction(env, this.apiClient);
+
+        // spotless:off
+        String ctiResponseBody = "{\"data\":{" +
+                "\"major\":[]," +
+                "\"minor\":[" +
+                    "{\"tag\":\"v5.1.0\",\"title\":\"Wazuh v5.1.0\",\"description\":\"First minor\",\"published_date\":\"2026-01-01T00:00:00Z\",\"semver\":{\"major\":5,\"minor\":1,\"patch\":0}}," +
+                    "{\"tag\":\"v5.2.0\",\"title\":\"Wazuh v5.2.0\",\"description\":\"Second minor\",\"published_date\":\"2026-02-01T00:00:00Z\",\"semver\":{\"major\":5,\"minor\":2,\"patch\":0}}" +
+                "]," +
+                "\"patch\":[]" +
+                "}}";
+        // spotless:on
+
+        SimpleHttpResponse ctiResponse = SimpleHttpResponse.create(200, ctiResponseBody, null);
+        when(this.apiClient.getReleaseUpdates("v5.0.0")).thenReturn(ctiResponse);
+
+        BytesRestResponse response = this.action.handleRequest();
+        String body = response.content().utf8ToString();
+
+        Assert.assertEquals(RestStatus.OK, response.status());
+        Assert.assertTrue(body.contains("v5.2.0"));
+        Assert.assertFalse(body.contains("v5.1.0"));
+    }
+}


### PR DESCRIPTION
### Description

Implement a new Content Manager REST endpoint `GET /_plugins/_content_manager/version/check` that returns whether newer Wazuh versions are available for download.

The endpoint reads the current installed version from `VERSION.json`, queries the CTI API at `GET /api/v1/releases/v{version}/updates`, and transforms the response to return the latest available update for each category (major, minor, patch). This mirrors the Wazuh Manager's `GET /cluster/version/check` endpoint, adapted to the Content Manager plugin conventions.

**Changes:**
- Add `getReleaseUpdates(tag)` method to the catalog `ApiClient`, reusing the existing HTTP client infrastructure and configurable CTI base URL.
- Create `Release` model (Jackson POJO + `ToXContent`) with nested `Semver` for CTI release objects.
- Create `VersionCheckResponse` model producing the `{message: {uuid, last_check_date, current_version, last_available_major, last_available_minor, last_available_patch}, status}` response envelope.
- Create `RestGetVersionCheckAction` handler extending `BaseRestHandler`.
- Register the handler in `ContentManagerPlugin.getRestHandlers()`.
- Add `VERSION_CHECK_URI` constant and `E_500_VERSION_NOT_FOUND` error constant.
- Update `openapi.yml`, API documentation, and imposter mock.

**Response format (200):**
```json
{
  "message": {
    "uuid": "bd7f0db0-d094-48ca-b883-7019484ce71f",
    "last_check_date": "2026-04-14T15:28:41.347387+00:00",
    "current_version": "v5.0.0",
    "last_available_major": { "tag": "v6.0.0", "title": "...", "semver": { ... } },
    "last_available_minor": { "tag": "v5.1.0", "title": "...", "semver": { ... } },
    "last_available_patch": { "tag": "v5.0.1", "title": "...", "semver": { ... } }
  },
  "status": 200
}
```

Categories with no available updates are represented as empty objects `{}`.

#### Validations

- **With imposter mock**
  
  1. Start the imposter mock server:
     ```bash
     cd plugins/content-manager/imposter && ./imposter.sh up
     ```
  
  2. Configure the plugin to point to the mock CTI API (in `opensearch.yml`):
     ```yaml
     plugins.content_manager.cti.api: "https://localhost:8443/api/v1"
     ```
      > In my case, since im running imposter in my local system and the cluster on a Vagrant vm, I replaced `localhost` to `192.168.56.1`
  
  3. Start the cluster:
  
  4. **Happy path**  call the endpoint and verify it returns all three update categories populated, along with `uuid`, `current_version`, and `last_check_date`:
        ```JSON
        GET _plugins/_content_manager/version/check
        ```
        `result` 
        ```JSON
        {
          "message": {
            "uuid": "0M_sXRQeQK62xiMeXLlyLQ",
            "last_check_date": "2026-04-15T16:19:12.418161876Z",
            "current_version": "v5.0.0",
            "last_available_major": {
              "tag": "v6.0.0",
              "title": "Wazuh v6.0.0",
              "description": "The 6.0.0 major release introduces a new architecture and platform improvements.",
              "published_date": "2026-11-01T10:00:00Z",
              "semver": {
                "major": 6,
                "minor": 0,
                "patch": 0
              }
            },
            "last_available_minor": {
              "tag": "v5.2.0",
              "title": "Wazuh v5.2.0",
              "description": "The 5.2.0 release includes new features and improvements.",
              "published_date": "2026-09-01T10:00:00Z",
              "semver": {
                "major": 5,
                "minor": 2,
                "patch": 0
              }
            },
            "last_available_patch": {
              "tag": "v5.0.1",
              "title": "Wazuh v5.0.1",
              "description": "Wazuh version 5.0.1 is a patch update focusing on bug fixes.",
              "published_date": "2026-05-10T10:00:00Z",
              "semver": {
                "major": 5,
                "minor": 0,
                "patch": 1
              }
            }
          },
          "status": 200
        }
        ```
  5. **No updates** — if the installed version doesn't match `v5.0.0` in the mock, verify empty objects are returned:
     Expected: `200` with `last_available_major: {}`, `last_available_minor: {}`, `last_available_patch: {}`.
  
  6. **CTI unavailable** stop the imposter mock and call the endpoint again:
       ```JSON
       GET /_plugins/_content_manager/version/check
       ```
        `result`
        ```JSON
        {
          "message": "Unable to reach the CTI API to check for updates.",
          "status": 500
        }
      ```

- **Against real CTI API**

    1. Configure the plugin to use the real CTI API:
       ```yaml
       plugins.content_manager.cti.api: "https://cti.wazuh.com/api/v1"
       ```
    
    2. Ensure `VERSION.json` exists at `$path.home/VERSION.json` and call the endpoint:
        ```JSON
        GET /_plugins/_content_manager/version/check
        ```
        `result`      
        ```JSON
        {
          "message": {
            "uuid": "0M_sXRQeQK62xiMeXLlyLQ",
            "last_check_date": "2026-04-15T16:14:05.220481711Z",
            "current_version": "v5.0.0",
            "last_available_major": {},
            "last_available_minor": {},
            "last_available_patch": {}
          },
          "status": 200
        }
        ```

### Issues Resolved
Closes #1010
