### PR TITLE
Set `indicator.confidence` as a type short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Set mapping to `strict_allow_templates` for stateless main events [(#960)](https://github.com/wazuh/wazuh-indexer-plugins/pull/960)
 - Update context and consumers [(#986)](https://github.com/wazuh/wazuh-indexer-plugins/pull/986)
 - Create detectors using only rules enabled [(#1017)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1017)
+- Set indicator.confidence as type short [(#1030)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1030)
 
 ### Deprecated
 -

--- a/plugins/content-manager/src/main/resources/mappings/cti-ioc-mappings.json
+++ b/plugins/content-manager/src/main/resources/mappings/cti-ioc-mappings.json
@@ -91,6 +91,9 @@
         }
       }
     },
+    "offset": {
+      "type": "unsigned_long"
+    },
     "type_hashes": {
       "type": "object"
     }

--- a/plugins/content-manager/src/main/resources/mappings/cti-ioc-mappings.json
+++ b/plugins/content-manager/src/main/resources/mappings/cti-ioc-mappings.json
@@ -25,7 +25,7 @@
     "document": {
       "properties": {
         "confidence": {
-          "type": "long"
+          "type": "short"
         },
         "feed": {
           "properties": {
@@ -90,9 +90,6 @@
           "type": "keyword"
         }
       }
-    },
-    "offset": {
-      "type": "unsigned_long"
     },
     "type_hashes": {
       "type": "object"

--- a/plugins/setup/src/main/resources/templates/content/ioc.json
+++ b/plugins/setup/src/main/resources/templates/content/ioc.json
@@ -59,7 +59,7 @@
         "document": {
           "properties": {
             "confidence": {
-              "type": "long"
+              "type": "short"
             },
             "feed": {
               "properties": {

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -2269,8 +2269,7 @@
           "wcs_enrichments_indicator_confidence": {
             "path_match": "enrichments.indicator.confidence",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "short"
             }
           }
         },

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -1294,8 +1294,7 @@
             "indicator": {
               "properties": {
                 "confidence": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "short"
                 },
                 "feed": {
                   "properties": {

--- a/wcs/content/ioc/docs/fields.csv
+++ b/wcs/content/ioc/docs/fields.csv
@@ -1,6 +1,6 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,base,type_hashes,object,custom,,,A dynamic object containing the hash values for each IoC type.
-9.1.0,true,document,document.confidence,long,custom,,85,"Confidence level or score for the IoC, typically representing the reliability of the indicator."
+9.1.0,true,document,document.confidence,short,custom,,85,"Confidence level or score for the IoC, typically representing the reliability of the indicator."
 9.1.0,true,document,document.feed.name,keyword,custom,,AlienVault OTX,Name of the threat intelligence feed that provided this IoC.
 9.1.0,true,document,document.first_seen,date,custom,,2024-01-15T08:30:00.000Z,The date and time when the IoC was first observed or reported.
 9.1.0,true,document,document.id,keyword,custom,,ioc-12345-abcde,Unique identifier for the IoC document.

--- a/wcs/content/ioc/fields/custom/document.yml
+++ b/wcs/content/ioc/fields/custom/document.yml
@@ -5,7 +5,7 @@
     IoC Document custom fields
   fields:
     - name: confidence
-      type: long
+      type: short
       level: custom
       description: >
         Confidence level or score for the IoC, typically representing the reliability of the indicator.

--- a/wcs/stateless/events/findings/docs/fields.csv
+++ b/wcs/stateless/events/findings/docs/fields.csv
@@ -259,7 +259,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.subject,keyword,extended,,Please see this important message.,The subject of the email message.
 9.1.0,true,email,email.to.address,keyword,extended,array,user1@example.com,Email address of recipient
 9.1.0,true,email,email.x_mailer,keyword,extended,,Spambot v2.5,Application that drafted email.
-9.1.0,true,enrichments,enrichments.indicator.confidence,keyword,custom,,,Indicator confidence rating.
+9.1.0,true,enrichments,enrichments.indicator.confidence,short,custom,,,Indicator confidence rating.
 9.1.0,true,enrichments,enrichments.indicator.feed.name,keyword,custom,,,Name of the feed that supplied the indicator.
 9.1.0,true,enrichments,enrichments.indicator.first_seen,date,custom,,,Date/time indicator was first reported.
 9.1.0,true,enrichments,enrichments.indicator.id,keyword,custom,,,"Unique identifier for the enrichment data, such as a hash of the indicator data or a unique ID from the provider."

--- a/wcs/stateless/events/findings/docs/wcs_flat.yml
+++ b/wcs/stateless/events/findings/docs/wcs_flat.yml
@@ -3376,7 +3376,7 @@ enrichments.indicator.confidence:
   name: indicator.confidence
   normalize: []
   short: Indicator confidence rating.
-  type: keyword
+  type: short
 enrichments.indicator.feed.name:
   dashed_name: enrichments-indicator-feed-name
   description: Name of the feed that supplied the indicator.

--- a/wcs/stateless/events/findings/docs/wcs_flat.yml
+++ b/wcs/stateless/events/findings/docs/wcs_flat.yml
@@ -3371,7 +3371,6 @@ enrichments.indicator.confidence:
   dashed_name: enrichments-indicator-confidence
   description: Indicator confidence rating.
   flat_name: enrichments.indicator.confidence
-  ignore_above: 1024
   level: custom
   name: indicator.confidence
   normalize: []

--- a/wcs/stateless/events/main/docs/fields.csv
+++ b/wcs/stateless/events/main/docs/fields.csv
@@ -259,7 +259,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.subject,keyword,extended,,Please see this important message.,The subject of the email message.
 9.1.0,true,email,email.to.address,keyword,extended,array,user1@example.com,Email address of recipient
 9.1.0,true,email,email.x_mailer,keyword,extended,,Spambot v2.5,Application that drafted email.
-9.1.0,true,enrichments,enrichments.indicator.confidence,keyword,custom,,,Indicator confidence rating.
+9.1.0,true,enrichments,enrichments.indicator.confidence,short,custom,,,Indicator confidence rating.
 9.1.0,true,enrichments,enrichments.indicator.feed.name,keyword,custom,,,Name of the feed that supplied the indicator.
 9.1.0,true,enrichments,enrichments.indicator.first_seen,date,custom,,,Date/time indicator was first reported.
 9.1.0,true,enrichments,enrichments.indicator.id,keyword,custom,,,"Unique identifier for the enrichment data, such as a hash of the indicator data or a unique ID from the provider."

--- a/wcs/stateless/events/main/docs/wcs_flat.yml
+++ b/wcs/stateless/events/main/docs/wcs_flat.yml
@@ -3376,7 +3376,7 @@ enrichments.indicator.confidence:
   name: indicator.confidence
   normalize: []
   short: Indicator confidence rating.
-  type: keyword
+  type: short
 enrichments.indicator.feed.name:
   dashed_name: enrichments-indicator-feed-name
   description: Name of the feed that supplied the indicator.

--- a/wcs/stateless/events/main/docs/wcs_flat.yml
+++ b/wcs/stateless/events/main/docs/wcs_flat.yml
@@ -3371,7 +3371,6 @@ enrichments.indicator.confidence:
   dashed_name: enrichments-indicator-confidence
   description: Indicator confidence rating.
   flat_name: enrichments.indicator.confidence
-  ignore_above: 1024
   level: custom
   name: indicator.confidence
   normalize: []

--- a/wcs/stateless/events/main/fields/custom/enrichments.yml
+++ b/wcs/stateless/events/main/fields/custom/enrichments.yml
@@ -27,7 +27,7 @@
       description: >
         Date/time indicator was last reported.
     - name: indicator.confidence
-      type: keyword
+      type: short
       level: custom
       description: >
         Indicator confidence rating.


### PR DESCRIPTION
### Description
This PR modifies the `confidence` field across indices to use `short` instead of `long` or `keyword`.

### Issues Resolved
Resolves #1022 
