### PR TITLE
Add ruletesting extended endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add SAP findings enrichment documentation [(#988)](https://github.com/wazuh/wazuh-indexer-plugins/pull/988)
 - Implement standard policy load to Engine at space.hash update [(#995)](https://github.com/wazuh/wazuh-indexer-plugins/pull/995)
 - Add documentation for Wazuh Alerting plugin [(#980)](https://github.com/wazuh/wazuh-indexer-plugins/pull/980)
+- Add ruletesting extended endpoints [(#1040)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1040)
 
 
 ### Dependencies

--- a/docs/dev/plugins/content-manager-logtest.md
+++ b/docs/dev/plugins/content-manager-logtest.md
@@ -5,11 +5,13 @@
 The logtest flow involves three layers:
 
 ```
-RestPostLogtestAction  →  LogtestService  →  EngineService + SecurityAnalyticsService
-       (REST)              (Orchestration)       (External services)
+RestPostLogtestAction               →  LogtestService  →  EngineService + SecurityAnalyticsService
+RestPostLogtestNormalizationAction  →       ↑                    ↑
+RestPostLogtestDetectionAction      →       ↑                    ↑
+       (REST handlers)                (Orchestration)       (External services)
 ```
 
-### RestPostLogtestAction
+### RestPostLogtestAction (combined)
 
 **Path**: `rest/service/RestPostLogtestAction.java`
 
@@ -24,11 +26,41 @@ The REST handler for `POST /_plugins/_content_manager/logtest`. Responsibilities
 
 The handler does **not** interact with indices or external services directly, all business logic is in the service.
 
+### RestPostLogtestNormalizationAction
+
+**Path**: `rest/service/RestPostLogtestNormalizationAction.java`
+
+The REST handler for `POST /_plugins/_content_manager/logtest/normalization`. Responsibilities:
+
+1. Validates the request has content and is valid JSON.
+2. Validates the required field `space`.
+3. Validates that `space` is `"test"` or `"standard"`.
+4. Strips the `integration` field if present (not used for normalization).
+5. Delegates to `LogtestService.executeNormalization(enginePayload)`.
+
+### RestPostLogtestDetectionAction
+
+**Path**: `rest/service/RestPostLogtestDetectionAction.java`
+
+The REST handler for `POST /_plugins/_content_manager/logtest/detection`. Responsibilities:
+
+1. Validates the request has content and is valid JSON.
+2. Validates the required fields `space`, `integration`, and `input`.
+3. Validates that `space` is `"test"` or `"standard"`.
+4. Validates that `input` is a JSON object (not a string or array).
+5. Delegates to `LogtestService.executeDetection(integrationId, space, inputEvent)`.
+
 ### LogtestService
 
 **Path**: `cti/catalog/service/LogtestService.java`
 
-The orchestrator. Executes the full logtest flow:
+The orchestrator. Provides three public entry points:
+
+- **`executeLogtest()`** — Full combined flow (normalization + detection)
+- **`executeNormalization()`** — Engine-only: forwards payload to `EngineService.logtest()` and returns the response directly with `parseMessageAsJson()`
+- **`executeDetection()`** — SAP-only: looks up integration, fetches rule IDs/bodies, evaluates via `SecurityAnalyticsService.evaluateRules()`, and returns the SAP result
+
+The full logtest flow:
 
 1. **No-integration shortcut** — If `integrationId` is `null`, delegates to `executeEngineOnly()`: runs the Engine normalization and returns the result with `detection.status: "skipped"` and `reason: "No integration provided"`. Steps 2–5 below are skipped.
 2. **Integration lookup** — Queries `.cti-integrations` for a document matching `document.id == integrationId` and `space.name == space`. Returns 400 if not found.
@@ -75,7 +107,7 @@ Match results use a nested `rule` object per match entry:
 Client request
     │
     ▼
-RestPostLogtestAction
+RestPostLogtestAction (combined)
     │  validates request
     │  strips "integration" field
     ▼
@@ -106,6 +138,29 @@ LogtestService.executeLogtest(integrationId, space, payload)
             { normalization: {...}, detection: {...} }
 ```
 
+### Split Endpoints
+
+In addition to the combined flow, there are two dedicated endpoints that execute normalization and detection independently:
+
+```
+RestPostLogtestNormalizationAction           RestPostLogtestDetectionAction
+    │  validates: space                          │  validates: space, integration, input
+    │  strips integration field                  │
+    ▼                                            ▼
+LogtestService.executeNormalization(payload)  LogtestService.executeDetection(id, space, input)
+    │                                            │
+    └──► engineService.logtest(payload)          ├──► client.prepareSearch(".cti-integrations")
+         → returns engine response directly      │       → finds integration
+                                                 ├──► extractRuleIds() + fetchRuleBodies()
+                                                 │       → fetches rule content from .cti-rules
+                                                 └──► securityAnalytics.evaluateRules(inputJson, ruleBodies)
+                                                         → returns SAP result directly
+```
+
+**Key differences from the combined endpoint:**
+- **Normalization** returns the raw Engine response (no detection wrapper). The `integration` field is stripped if present but has no effect on behavior.
+- **Detection** accepts a pre-normalized event as the `input` JSON object. It does not call the Engine — it goes straight to integration lookup → rule fetch → SAP evaluation.
+
 ## Index Dependencies
 
 | Index | Usage | Query |
@@ -121,7 +176,9 @@ Both indices must exist and have `document.id` mapped as `keyword` for term quer
 
 | Test class | Covers |
 | --- | --- |
-| `RestPostLogtestActionTests` | Request validation (empty body, invalid JSON, missing fields, wrong space, delegation to service) |
+| `RestPostLogtestActionTests` | Request validation for combined endpoint (empty body, invalid JSON, missing fields, wrong space, delegation to service) |
+| `RestPostLogtestNormalizationActionTests` | Request validation for normalization endpoint (empty body, invalid JSON, missing space, invalid space, delegation, integration stripping) |
+| `RestPostLogtestDetectionActionTests` | Request validation for detection endpoint (empty body, invalid JSON, missing fields, invalid space, non-object input, delegation) |
 | `LogtestServiceTests` | Orchestration logic (integration lookup, engine errors, rule fetching, SAP evaluation, response structure) |
 | `EventMatcherTests` | Sigma rule evaluation (field matching, wildcards, numerics, booleans, nulls, AND/OR/NOT conditions) |
 
@@ -139,8 +196,8 @@ Integration tests extend `ContentManagerRestTestCase` and run against a real Ope
 ### Supporting a new validation field
 
 1. Add the field constant to `Constants.java`.
-2. Add validation logic in `RestPostLogtestAction.handleRequest()`.
-3. Add unit test in `RestPostLogtestActionTests`.
+2. Add validation logic in the relevant handler(s): `RestPostLogtestAction`, `RestPostLogtestNormalizationAction`, and/or `RestPostLogtestDetectionAction`.
+3. Add unit tests in the corresponding test classes.
 4. Add integration test in `LogtestIT`.
 
 ### Supporting a new Engine response field

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -386,6 +386,231 @@ curl -sk -u admin:admin -X POST \
 
 ---
 
+### Normalization Only
+
+Sends a log event to the Wazuh Engine for decoding and normalization without performing Sigma rule detection. Use this to validate that decoders correctly parse events before testing detection rules.
+
+> **Note**: A testing policy must be loaded in the Engine for normalization to execute successfully.
+
+**Request**
+- Method: `POST`
+- Path: `/_plugins/_content_manager/logtest/normalization`
+
+**Request Body**
+
+| Field            | Type    | Required | Description                                          |
+| ---------------- | ------- | -------- | ---------------------------------------------------- |
+| `space`          | String  | Yes      | `"test"` or `"standard"`                             |
+| `queue`          | Integer | No       | Queue number for logtest execution                   |
+| `location`       | String  | No       | Log file path or logical source location             |
+| `input`          | String  | No       | Raw log event to normalize                           |
+| `metadata`       | Object  | No       | Optional metadata passed to the Engine               |
+| `trace_level`    | String  | No       | Trace verbosity: `NONE`, `ASSET_ONLY`, or `ALL`      |
+
+**Example Request**
+
+```bash
+curl -sk -u admin:admin -X POST \
+  "https://192.168.56.6:9200/_plugins/_content_manager/logtest/normalization" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "space": "test",
+    "queue": 1,
+    "location": "/var/log/cassandra/system.log",
+    "metadata": {},
+    "trace_level": "NONE",
+    "input": "INFO  [CompactionExecutor-3] 2025-11-30 14:23:45 CassandraDaemon.java:250 - Some message - 7500 - 4"
+  }'
+```
+
+**Example Response**
+
+```json
+{
+  "status": 200,
+  "message": {
+    "output": {
+      "log": {
+        "level": "INFO",
+        "origin": {
+          "file": {
+            "name": "CassandraDaemon.java",
+            "line": 250
+          }
+        }
+      },
+      "wazuh": {
+        "space": { "name": "test" },
+        "protocol": { "location": "/var/log/cassandra/system.log", "queue": 1 },
+        "integration": {
+          "decoders": ["decoder/cassandra-default/0"],
+          "name": "my-integration",
+          "category": "other"
+        }
+      },
+      "message": "Some message",
+      "event": {
+        "duration": 7500,
+        "category": ["database"],
+        "kind": "event",
+        "severity": 4
+      },
+      "source": { "ip": "10.42.3.15" },
+      "process": {
+        "thread": { "name": "CompactionExecutor-3" }
+      }
+    },
+    "asset_traces": [],
+    "validation": {
+      "valid": true,
+      "errors": []
+    }
+  }
+}
+```
+
+**Response Fields**
+
+| Field                              | Type    | Description                                     |
+| ---------------------------------- | ------- | ----------------------------------------------- |
+| `message.output`                   | Object  | Engine normalized event output                  |
+| `message.asset_traces`             | Array   | List of decoders that processed the event       |
+| `message.validation`               | Object  | Validation result (`valid`, `errors`)            |
+
+**Status Codes**
+
+| Code | Description                                        |
+| ---- | -------------------------------------------------- |
+| 200  | Normalization executed successfully                |
+| 400  | Missing/invalid fields                             |
+| 500  | Engine socket communication error or internal error|
+
+---
+
+### Detection Only
+
+Evaluates an already-normalized event against the Sigma rules of a given integration via the Security Analytics Plugin (SAP). This endpoint does **not** call the Wazuh Engine — the normalized event must be provided directly in the `input` field.
+
+Use this after obtaining a normalized event from the `/logtest/normalization` endpoint, or when you already have a normalized event and want to test different integrations' rules against it.
+
+> **Note**: The integration must exist in the specified space. The `input` field must be a JSON object (the normalized event), not a raw log string.
+
+**Request**
+- Method: `POST`
+- Path: `/_plugins/_content_manager/logtest/detection`
+
+**Request Body**
+
+| Field            | Type    | Required | Description                                          |
+| ---------------- | ------- | -------- | ---------------------------------------------------- |
+| `space`          | String  | Yes      | `"test"` or `"standard"`                             |
+| `integration`    | String  | Yes      | UUID of the integration whose rules to evaluate      |
+| `input`          | Object  | Yes      | Normalized event object to evaluate rules against    |
+
+**Example Request**
+
+```bash
+curl -sk -u admin:admin -X POST \
+  "https://192.168.56.6:9200/_plugins/_content_manager/logtest/detection" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "space": "test",
+    "integration": "d3f3b0b8-4e25-4273-83ef-56a62003bcf7",
+    "input": {
+      "event": {
+        "duration": 7500,
+        "category": ["database"],
+        "kind": "event",
+        "severity": 4,
+        "type": ["info"]
+      },
+      "source": { "ip": "10.42.3.15" },
+      "process": {
+        "thread": { "name": "CompactionExecutor-3" },
+        "command_line": "/query tables"
+      },
+      "log": {
+        "origin": {
+          "file": { "name": "CassandraDaemon.java", "line": 250 }
+        }
+      }
+    }
+  }'
+```
+
+**Example Response (matches found)**
+
+```json
+{
+  "status": 200,
+  "message": {
+    "status": "success",
+    "rules_evaluated": 12,
+    "rules_matched": 6,
+    "matches": [
+      {
+        "rule": {
+          "id": "4e52f215-bccc-4c0f-a37c-70606022be8e",
+          "title": "TEST: Numeric gte+lt only",
+          "level": "high",
+          "tags": ["attack.execution", "attack.t1059"]
+        },
+        "matched_conditions": [
+          "event.duration matched '>= 5000'",
+          "event.severity matched '< 10'"
+        ]
+      },
+      {
+        "rule": {
+          "id": "1d489ded-7523-4329-8cd0-ebb21865a318",
+          "title": "TEST: Exact match event.kind=event",
+          "level": "low",
+          "tags": ["attack.execution", "attack.t1059"]
+        },
+        "matched_conditions": [
+          "event.kind matched 'event'"
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Example Response (no rules in integration)**
+
+```json
+{
+  "status": 200,
+  "message": {
+    "status": "success",
+    "rules_evaluated": 0,
+    "rules_matched": 0,
+    "matches": []
+  }
+}
+```
+
+**Response Fields**
+
+| Field                                  | Type    | Description                                     |
+| -------------------------------------- | ------- | ----------------------------------------------- |
+| `message.status`                       | String  | `"success"` or `"error"`                        |
+| `message.rules_evaluated`              | Integer | Number of Sigma rules evaluated                 |
+| `message.rules_matched`                | Integer | Number of rules that matched                    |
+| `message.matches`                      | Array   | List of matched rules with details              |
+| `message.matches[].rule`               | Object  | Rule metadata: `id`, `title`, `level`, `tags`   |
+| `message.matches[].matched_conditions` | Array   | Human-readable descriptions of matched conditions|
+
+**Status Codes**
+
+| Code | Description                                        |
+| ---- | -------------------------------------------------- |
+| 200  | Detection executed (check `message.status`)        |
+| 400  | Missing/invalid fields or integration not found    |
+| 500  | Internal error                                     |
+
+---
+
 ## Policy
 
 ### Update Policy

--- a/docs/ref/modules/content-manager/rule-testing.md
+++ b/docs/ref/modules/content-manager/rule-testing.md
@@ -290,6 +290,102 @@ Content in the custom space is picked up by the Wazuh Engine and actively used f
 
 ---
 
+## Split Endpoints: Normalization and Detection
+
+In addition to the combined logtest endpoint, you can run normalization and detection as separate steps. This is useful for:
+
+- **Debugging decoders** without noise from detection results.
+- **Testing multiple integrations** against the same normalized event without re-running the Engine each time.
+- **Iterating on rules** without waiting for normalization on each call.
+
+### Normalization Only
+
+```bash
+curl -sk -u admin:admin -X POST \
+  "https://localhost:9200/_plugins/_content_manager/logtest/normalization" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "space": "test",
+    "queue": 1,
+    "location": "/var/log/auth.log",
+    "input": "Dec 19 12:00:00 host sshd[12345]: Failed password for root from 10.0.0.1 port 54321 ssh2",
+    "trace_level": "ALL"
+  }'
+```
+
+The response contains only the Engine's normalized output (no detection section):
+
+```json
+{
+  "status": 200,
+  "message": {
+    "output": {
+      "event": {
+        "category": ["authentication"],
+        "kind": "event",
+        "outcome": "failure"
+      },
+      "source": { "ip": "10.0.0.1" },
+      "user": { "name": "root" }
+    },
+    "asset_traces": ["decoder/sshd-auth/0"],
+    "validation": { "valid": true, "errors": [] }
+  }
+}
+```
+
+### Detection Only
+
+Take the normalized event (the `output` object from normalization) and pass it as `input` along with the integration ID:
+
+```bash
+curl -sk -u admin:admin -X POST \
+  "https://localhost:9200/_plugins/_content_manager/logtest/detection" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "space": "test",
+    "integration": "a0b448c8-3d3c-47d4-b7b9-cbc3c175f509",
+    "input": {
+      "event": {
+        "category": ["authentication"],
+        "kind": "event",
+        "outcome": "failure"
+      },
+      "source": { "ip": "10.0.0.1" },
+      "user": { "name": "root" }
+    }
+  }'
+```
+
+The response contains only the detection result:
+
+```json
+{
+  "status": 200,
+  "message": {
+    "status": "success",
+    "rules_evaluated": 1,
+    "rules_matched": 1,
+    "matches": [
+      {
+        "rule": {
+          "id": "85bba177-a2e9-4468-9d59-26f4798906c9",
+          "title": "SSH Failed Password Attempt",
+          "level": "medium",
+          "tags": ["attack.credential-access", "attack.t1110.001"]
+        },
+        "matched_conditions": [
+          "event.category matched 'authentication'",
+          "event.outcome matched 'failure'"
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
 ## Quick Reference
 
 | Action | Endpoint | Method |
@@ -300,6 +396,8 @@ Content in the custom space is picked up by the Wazuh Engine and actively used f
 | Update rule | `/_plugins/_content_manager/rules/{id}` | PUT |
 | Preview promotion | `/_plugins/_content_manager/promote?space={space}` | GET |
 | Execute promotion | `/_plugins/_content_manager/promote` | POST |
-| Run logtest | `/_plugins/_content_manager/logtest` | POST |
+| Run logtest (combined) | `/_plugins/_content_manager/logtest` | POST |
+| Normalization only | `/_plugins/_content_manager/logtest/normalization` | POST |
+| Detection only | `/_plugins/_content_manager/logtest/detection` | POST |
 
 For full endpoint details, see the [API Reference](api.md). For Sigma rule format details, see [Sigma Rules](sigma-rules.md).

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -829,6 +829,94 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /logtest/normalization:
+    post:
+      tags: [Logtest]
+      summary: Execute normalization only
+      description: |
+        Sends a log event to the Wazuh Engine for decoding and normalization without
+        performing Sigma rule detection. This is useful for validating that decoders
+        correctly parse and normalize events before testing detection rules.
+
+        The response contains the Engine's normalized output directly, including the
+        decoded fields, asset traces, and validation results.
+      operationId: executeLogtestNormalization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogtestNormalizationRequest"
+            examples:
+              basic:
+                summary: Normalize a Cassandra log event
+                value:
+                  space: "test"
+                  queue: 1
+                  location: "/var/log/cassandra/system.log"
+                  metadata: {}
+                  trace_level: "NONE"
+                  input: "INFO  [CompactionExecutor-3] 2025-11-30 14:23:45 CassandraDaemon.java:250 - Some message - 7500 - 4"
+      responses:
+        "200":
+          $ref: "#/components/responses/LogtestNormalizationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /logtest/detection:
+    post:
+      tags: [Logtest]
+      summary: Execute detection only
+      description: |
+        Evaluates an already-normalized event against the Sigma rules of a given
+        integration via the Security Analytics Plugin (SAP). This endpoint does **not**
+        call the Wazuh Engine — the caller must provide the normalized event object
+        directly in the `input` field.
+
+        Use this endpoint after obtaining a normalized event from the
+        `/logtest/normalization` endpoint, or when you already have a normalized event
+        and want to test different integrations' rules against it.
+
+        The integration must exist in the specified space (`test` or `standard`).
+      operationId: executeLogtestDetection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogtestDetectionRequest"
+            examples:
+              basic:
+                summary: Detect rules against a normalized event
+                value:
+                  space: "test"
+                  integration: "d3f3b0b8-4e25-4273-83ef-56a62003bcf7"
+                  input:
+                    event:
+                      category: ["database"]
+                      kind: "event"
+                      severity: 4
+                      duration: 7500
+                    source:
+                      ip: "10.42.3.15"
+                    process:
+                      thread:
+                        name: "CompactionExecutor-3"
+                    log:
+                      origin:
+                        file:
+                          name: "CassandraDaemon.java"
+                          line: 250
+      responses:
+        "200":
+          $ref: "#/components/responses/LogtestDetectionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   # Promotion endpoints: move content from draft/test into next space
   /promote:
     get:
@@ -1082,6 +1170,89 @@ components:
             - FULL
           description: Trace verbosity level
           example: "NONE"
+
+    # Request body for normalization-only logtest
+    LogtestNormalizationRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - space
+      properties:
+        space:
+          type: string
+          enum:
+            - test
+            - standard
+          description: Space context for the normalization. Must be `"test"` or `"standard"`.
+          example: "test"
+
+        queue:
+          type: integer
+          minimum: 0
+          description: Queue number used for logtest execution
+          example: 1
+
+        location:
+          type: string
+          description: Log file path or logical source location
+          example: "/var/log/cassandra/system.log"
+
+        input:
+          type: string
+          description: Raw log event to be normalized
+          example: "INFO  [CompactionExecutor-3] 2025-11-30 14:23:45 CassandraDaemon.java:250 - Some message"
+
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Optional metadata passed to the Engine
+          example: {}
+
+        trace_level:
+          type: string
+          enum:
+            - NONE
+            - BASIC
+            - FULL
+          description: Trace verbosity level
+          example: "NONE"
+
+    # Request body for detection-only logtest
+    LogtestDetectionRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - space
+        - integration
+        - input
+      properties:
+        space:
+          type: string
+          enum:
+            - test
+            - standard
+          description: Space where the integration exists. Must be `"test"` or `"standard"`.
+          example: "test"
+
+        integration:
+          type: string
+          format: uuid
+          description: ID of the integration whose rules will be evaluated against the input event.
+          example: "d3f3b0b8-4e25-4273-83ef-56a62003bcf7"
+
+        input:
+          type: object
+          additionalProperties: true
+          description: |
+            Normalized event object to evaluate Sigma rules against. This is typically the
+            `output` field from a previous normalization response.
+          example:
+            event:
+              category: ["database"]
+              kind: "event"
+              severity: 4
+            source:
+              ip: "10.42.3.15"
 
     # Response body showing differences during promotion preview
     PolicyDiff:
@@ -2080,6 +2251,157 @@ components:
               value:
                 message: "Internal Server Error"
                 status: 500
+
+    # Response body for normalization-only logtest
+    LogtestNormalizationResponse:
+      description: Engine normalization result containing the decoded event.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                description: HTTP status code.
+                example: 200
+              message:
+                type: object
+                properties:
+                  output:
+                    type: object
+                    additionalProperties: true
+                    description: Normalized event output from the Engine (Wazuh Common Schema format).
+                  asset_traces:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                    description: Asset trace information generated during normalization.
+                  validation:
+                    type: object
+                    properties:
+                      valid:
+                        type: boolean
+                        description: Indicates if the event passed engine validation.
+                      errors:
+                        type: array
+                        items:
+                          type: string
+                        description: List of validation errors if the event is invalid.
+          examples:
+            success:
+              summary: Successful normalization
+              value:
+                status: 200
+                message:
+                  output:
+                    log:
+                      level: "INFO"
+                      origin:
+                        file:
+                          name: "CassandraDaemon.java"
+                          line: 250
+                    wazuh:
+                      space:
+                        name: "test"
+                      integration:
+                        decoders: ["decoder/cassandra-default/0"]
+                        name: "my-integration"
+                        category: "other"
+                    message: "Some message"
+                    event:
+                      duration: 7500
+                      category: ["database"]
+                      kind: "event"
+                      severity: 4
+                  asset_traces: []
+                  validation:
+                    valid: true
+                    errors: []
+
+    # Response body for detection-only logtest
+    LogtestDetectionResponse:
+      description: Security Analytics detection result with matched Sigma rules.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                description: HTTP status code.
+                example: 200
+              message:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [success, error]
+                    example: "success"
+                  rules_evaluated:
+                    type: integer
+                    example: 12
+                  rules_matched:
+                    type: integer
+                    example: 6
+                  matches:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        rule:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            title:
+                              type: string
+                            level:
+                              type: string
+                              enum: [informational, low, medium, high, critical]
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                        matched_conditions:
+                          type: array
+                          items:
+                            type: string
+          examples:
+            with_matches:
+              summary: Detection with matched rules
+              value:
+                status: 200
+                message:
+                  status: "success"
+                  rules_evaluated: 12
+                  rules_matched: 2
+                  matches:
+                    - rule:
+                        id: "4e52f215-bccc-4c0f-a37c-70606022be8e"
+                        title: "Numeric gte+lt condition"
+                        level: "high"
+                        tags: ["attack.execution", "attack.t1059"]
+                      matched_conditions:
+                        - "event.duration matched '>= 5000'"
+                        - "event.severity matched '< 10'"
+                    - rule:
+                        id: "1d489ded-7523-4329-8cd0-ebb21865a318"
+                        title: "Exact match event.kind=event"
+                        level: "low"
+                        tags: ["attack.execution", "attack.t1059"]
+                      matched_conditions:
+                        - "event.kind matched 'event'"
+            no_matches:
+              summary: No rules matched
+              value:
+                status: 200
+                message:
+                  status: "success"
+                  rules_evaluated: 5
+                  rules_matched: 0
+                  matches: []
 
     # Response body for logtest execution results (combined engine + SA)
     LogtestResponse:

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -240,6 +240,8 @@ public class ContentManagerPlugin extends Plugin
                 new RestPostUpdateAction(this.ctiConsole, this.catalogSyncJob),
                 // User-generated content endpoints
                 new RestPostLogtestAction(this.logtestService),
+                new RestPostLogtestNormalizationAction(this.logtestService),
+                new RestPostLogtestDetectionAction(this.logtestService),
                 // Policy endpoints
                 new RestPutPolicyAction(this.spaceService, this.engine),
                 // Rule endpoints

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
@@ -157,6 +157,94 @@ public class LogtestService {
     }
 
     /**
+     * Executes engine normalization only, returning the engine's response directly.
+     *
+     * @param enginePayload the payload to send to the Engine
+     * @return a {@link RestResponse} with the engine normalization result
+     */
+    public RestResponse executeNormalization(ObjectNode enginePayload) {
+        try {
+            RestResponse engineResponse = this.engine.logtest(enginePayload);
+            return engineResponse.parseMessageAsJson();
+        } catch (Exception e) {
+            log.error("Engine normalization failed: {}", e.getMessage());
+            return new RestResponse(
+                    Constants.E_500_INTERNAL_SERVER_ERROR, RestStatus.INTERNAL_SERVER_ERROR.getStatus());
+        }
+    }
+
+    /**
+     * Executes detection only: looks up integration, fetches rules, evaluates via SAP.
+     *
+     * @param integrationId the integration document ID to look up
+     * @param space the space to search in (test or standard)
+     * @param inputEvent the normalized event JSON object to evaluate
+     * @return a {@link RestResponse} with the SAP detection result
+     */
+    public RestResponse executeDetection(String integrationId, Space space, JsonNode inputEvent) {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // 1. Look up integration
+        SearchResponse integrationSearchResponse;
+        try {
+            integrationSearchResponse =
+                    this.client
+                            .prepareSearch(Constants.INDEX_INTEGRATIONS)
+                            .setSource(
+                                    new SearchSourceBuilder()
+                                            .query(
+                                                    QueryBuilders.boolQuery()
+                                                            .must(QueryBuilders.termQuery(Constants.Q_DOCUMENT_ID, integrationId))
+                                                            .must(
+                                                                    QueryBuilders.termQuery(
+                                                                            Constants.Q_SPACE_NAME, space.toString())))
+                                            .size(1))
+                            .get();
+        } catch (Exception e) {
+            log.error("Failed to look up integration [{}]: {}", integrationId, e.getMessage());
+            return new RestResponse(
+                    Constants.E_500_INTERNAL_SERVER_ERROR, RestStatus.INTERNAL_SERVER_ERROR.getStatus());
+        }
+
+        if (Objects.requireNonNull(integrationSearchResponse.getHits().getTotalHits()).value() == 0) {
+            return new RestResponse(
+                    String.format(Locale.ROOT, Constants.E_400_INTEGRATION_NOT_FOUND, integrationId, space),
+                    RestStatus.BAD_REQUEST.getStatus());
+        }
+
+        // 2. Fetch rule IDs from integration
+        Map<String, Object> integrationSource =
+                integrationSearchResponse.getHits().getAt(0).getSourceAsMap();
+        List<String> ruleIds = extractRuleIds(integrationSource);
+        List<String> ruleBodies =
+                ruleIds.isEmpty() ? List.of() : fetchRuleBodies(integrationId, ruleIds, space);
+
+        // 3. Convert input event to JSON string for SAP
+        String eventJson = inputEvent.toString();
+
+        // 4. Evaluate rules
+        Map<String, Object> sapResult;
+        if (ruleBodies.isEmpty()) {
+            sapResult = createEmptySapResult();
+        } else {
+            String saResultJson = this.securityAnalytics.evaluateRules(eventJson, ruleBodies);
+            try {
+                sapResult = mapper.readValue(saResultJson, Map.class);
+            } catch (Exception e) {
+                sapResult = createErrorSapResult();
+            }
+        }
+
+        try {
+            String json = mapper.writeValueAsString(sapResult);
+            return new RestResponse(json, RestStatus.OK.getStatus()).parseMessageAsJson();
+        } catch (Exception e) {
+            return new RestResponse(
+                    Constants.E_500_INTERNAL_SERVER_ERROR, RestStatus.INTERNAL_SERVER_ERROR.getStatus());
+        }
+    }
+
+    /**
      * Sends the event payload to the Wazuh Engine and builds the engine result map.
      *
      * <p>On success, the normalized event JSON is stored under the internal key {@code

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestDetectionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestDetectionAction.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.NamedRoute;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import com.wazuh.contentmanager.rest.utils.PayloadValidations;
+import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * POST /_plugins/_content_manager/logtest/detection
+ *
+ * <p>Validates the incoming request, ensures the required {@code space}, {@code integration}, and
+ * {@code input} fields are present and valid, then delegates execution to {@link
+ * LogtestService#executeDetection(String, Space, JsonNode)}. The response contains only the
+ * Security Analytics Plugin (SAP) Sigma rule evaluation results.
+ */
+public class RestPostLogtestDetectionAction extends BaseRestHandler {
+    private static final String ENDPOINT_NAME = "content_manager_logtest_detection";
+    private static final String ENDPOINT_UNIQUE_NAME =
+            "plugin:content_manager/engine_logtest_detection";
+
+    private final LogtestService logtestService;
+    private final PayloadValidations payloadValidations;
+
+    /**
+     * Constructs a new RestPostLogtestDetectionAction.
+     *
+     * @param logtestService the service that orchestrates SA evaluation
+     */
+    public RestPostLogtestDetectionAction(LogtestService logtestService) {
+        this.logtestService = logtestService;
+        this.payloadValidations = new PayloadValidations();
+    }
+
+    /** Return a short identifier for this handler. */
+    @Override
+    public String getName() {
+        return ENDPOINT_NAME;
+    }
+
+    /**
+     * Return the route configuration for this handler.
+     *
+     * @return route configuration for the detection endpoint
+     */
+    @Override
+    public List<Route> routes() {
+        return List.of(
+                new NamedRoute.Builder()
+                        .path(PluginSettings.LOGTEST_DETECTION_URI)
+                        .method(POST)
+                        .uniqueName(ENDPOINT_UNIQUE_NAME)
+                        .build());
+    }
+
+    /**
+     * Handles incoming requests by delegating to {@link #handleRequest(RestRequest)}.
+     *
+     * @param request the incoming REST request
+     * @param client the node client
+     * @return a consumer that sends the detection response
+     */
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        RestResponse response = this.handleRequest(request);
+        return channel -> channel.sendResponse(response.toBytesRestResponse());
+    }
+
+    /**
+     * Validates the request and delegates detection execution to {@link LogtestService}.
+     *
+     * <p>Validation steps:
+     *
+     * <ol>
+     *   <li>Request has content
+     *   <li>Content is valid JSON
+     *   <li>Required fields {@code space}, {@code integration}, and {@code input} are present
+     *   <li>Space value is {@code "test"} or {@code "standard"}
+     *   <li>Input is a JSON object
+     * </ol>
+     *
+     * @param request the incoming REST request
+     * @return a {@link RestResponse} with the SAP detection result, or an error response
+     */
+    public RestResponse handleRequest(RestRequest request) {
+        // 1. Check request's payload exists
+        RestResponse validationError = this.payloadValidations.validateRequestHasContent(request);
+        if (validationError != null) return validationError;
+
+        // 2. Parse JSON
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode;
+        try {
+            jsonNode = mapper.readTree(request.content().streamInput());
+        } catch (IOException ex) {
+            return new RestResponse(
+                    Constants.E_400_INVALID_REQUEST_BODY, RestStatus.BAD_REQUEST.getStatus());
+        }
+
+        // 3. Validate required fields: space, integration, input
+        validationError =
+                this.payloadValidations.validateRequiredFields(
+                        jsonNode, List.of(Constants.KEY_SPACE, Constants.KEY_INTEGRATION, Constants.KEY_INPUT));
+        if (validationError != null) return validationError;
+
+        String space = jsonNode.get(Constants.KEY_SPACE).asText();
+
+        // 4. Validate space is "test" or "standard"
+        Space spaceEnum;
+        try {
+            spaceEnum = Space.fromValue(space);
+        } catch (IllegalArgumentException e) {
+            return new RestResponse(
+                    String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
+                    RestStatus.BAD_REQUEST.getStatus());
+        }
+        if (spaceEnum != Space.TEST && spaceEnum != Space.STANDARD) {
+            return new RestResponse(
+                    String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
+                    RestStatus.BAD_REQUEST.getStatus());
+        }
+
+        // 5. Extract integration and input
+        String integrationId = jsonNode.get(Constants.KEY_INTEGRATION).asText();
+        JsonNode inputEvent = jsonNode.get(Constants.KEY_INPUT);
+
+        // 6. Validate input is a JSON object
+        if (!inputEvent.isObject()) {
+            return new RestResponse(
+                    String.format(Locale.ROOT, Constants.E_400_INVALID_FIELD_FORMAT, Constants.KEY_INPUT),
+                    RestStatus.BAD_REQUEST.getStatus());
+        }
+
+        // 7. Delegate execution to Service
+        return this.logtestService.executeDetection(integrationId, spaceEnum, inputEvent);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestNormalizationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestNormalizationAction.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.NamedRoute;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import com.wazuh.contentmanager.rest.utils.PayloadValidations;
+import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+/**
+ * POST /_plugins/_content_manager/logtest/normalization
+ *
+ * <p>Validates the incoming request, ensures the required {@code space} field is present and valid,
+ * then delegates execution to {@link LogtestService#executeNormalization(ObjectNode)}. The response
+ * contains only the Wazuh Engine's normalization result.
+ */
+public class RestPostLogtestNormalizationAction extends BaseRestHandler {
+    private static final String ENDPOINT_NAME = "content_manager_logtest_normalization";
+    private static final String ENDPOINT_UNIQUE_NAME =
+            "plugin:content_manager/engine_logtest_normalization";
+
+    private final LogtestService logtestService;
+    private final PayloadValidations payloadValidations;
+
+    /**
+     * Constructs a new RestPostLogtestNormalizationAction.
+     *
+     * @param logtestService the service that orchestrates engine evaluation
+     */
+    public RestPostLogtestNormalizationAction(LogtestService logtestService) {
+        this.logtestService = logtestService;
+        this.payloadValidations = new PayloadValidations();
+    }
+
+    /** Return a short identifier for this handler. */
+    @Override
+    public String getName() {
+        return ENDPOINT_NAME;
+    }
+
+    /**
+     * Return the route configuration for this handler.
+     *
+     * @return route configuration for the normalization endpoint
+     */
+    @Override
+    public List<Route> routes() {
+        return List.of(
+                new NamedRoute.Builder()
+                        .path(PluginSettings.LOGTEST_NORMALIZATION_URI)
+                        .method(POST)
+                        .uniqueName(ENDPOINT_UNIQUE_NAME)
+                        .build());
+    }
+
+    /**
+     * Handles incoming requests by delegating to {@link #handleRequest(RestRequest)}.
+     *
+     * @param request the incoming REST request
+     * @param client the node client
+     * @return a consumer that sends the normalization response
+     */
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        RestResponse response = this.handleRequest(request);
+        return channel -> channel.sendResponse(response.toBytesRestResponse());
+    }
+
+    /**
+     * Validates the request and delegates normalization execution to {@link LogtestService}.
+     *
+     * <p>Validation steps:
+     *
+     * <ol>
+     *   <li>Request has content
+     *   <li>Content is valid JSON
+     *   <li>Required field {@code space} is present
+     *   <li>Space value is {@code "test"} or {@code "standard"}
+     * </ol>
+     *
+     * @param request the incoming REST request
+     * @return a {@link RestResponse} with the engine normalization result, or an error response
+     */
+    public RestResponse handleRequest(RestRequest request) {
+        // 1. Check request's payload exists
+        RestResponse validationError = this.payloadValidations.validateRequestHasContent(request);
+        if (validationError != null) return validationError;
+
+        // 2. Parse JSON
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode;
+        try {
+            jsonNode = mapper.readTree(request.content().streamInput());
+        } catch (IOException ex) {
+            return new RestResponse(
+                    Constants.E_400_INVALID_REQUEST_BODY, RestStatus.BAD_REQUEST.getStatus());
+        }
+
+        // 3. Validate required field: space
+        validationError =
+                this.payloadValidations.validateRequiredFields(jsonNode, List.of(Constants.KEY_SPACE));
+        if (validationError != null) return validationError;
+
+        String space = jsonNode.get(Constants.KEY_SPACE).asText();
+
+        // 4. Validate space is "test" or "standard"
+        Space spaceEnum;
+        try {
+            spaceEnum = Space.fromValue(space);
+        } catch (IllegalArgumentException e) {
+            return new RestResponse(
+                    String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
+                    RestStatus.BAD_REQUEST.getStatus());
+        }
+        if (spaceEnum != Space.TEST && spaceEnum != Space.STANDARD) {
+            return new RestResponse(
+                    String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
+                    RestStatus.BAD_REQUEST.getStatus());
+        }
+
+        // 5. Strip integration field if present, build engine payload
+        ObjectNode enginePayload = jsonNode.deepCopy();
+        enginePayload.remove(Constants.KEY_INTEGRATION);
+
+        // 6. Delegate execution to Service
+        return this.logtestService.executeNormalization(enginePayload);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -32,6 +32,8 @@ public class PluginSettings {
     public static final String SUBSCRIPTION_URI = PLUGINS_BASE_URI + "/subscription";
     public static final String UPDATE_URI = PLUGINS_BASE_URI + "/update";
     public static final String LOGTEST_URI = PLUGINS_BASE_URI + "/logtest";
+    public static final String LOGTEST_NORMALIZATION_URI = LOGTEST_URI + "/normalization";
+    public static final String LOGTEST_DETECTION_URI = LOGTEST_URI + "/detection";
     public static final String KVDBS_URI = PLUGINS_BASE_URI + "/kvdbs";
     public static final String DECODERS_URI = PLUGINS_BASE_URI + "/decoders";
     public static final String RULES_URI = PLUGINS_BASE_URI + "/rules";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -129,6 +129,7 @@ public class Constants {
     public static final String KEY_UPDATING = "updating";
     public static final String KEY_PAYLOAD = "payload";
     public static final String KEY_STATUS = "status";
+    public static final String KEY_INPUT = "input";
 
     // Newly added keys for ResourceMetadata
     public static final String KEY_REFERENCES = "references";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostLogtestDetectionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostLogtestDetectionActionTests.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link RestPostLogtestDetectionAction}. Validates request validation logic:
+ * required fields, space constraints, and delegation to {@link LogtestService}.
+ */
+public class RestPostLogtestDetectionActionTests extends OpenSearchTestCase {
+
+    private RestPostLogtestDetectionAction action;
+    private AutoCloseable closeable;
+
+    @Mock private LogtestService logtestService;
+
+    private static final String INTEGRATION_ID = "a0b448c8-3d3c-47d4-b7b9-cbc3c175f509";
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.closeable = MockitoAnnotations.openMocks(this);
+        this.action = new RestPostLogtestDetectionAction(this.logtestService);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        if (this.closeable != null) {
+            this.closeable.close();
+        }
+        super.tearDown();
+    }
+
+    private RestRequest mockRequest(String json) {
+        RestRequest request = mock(RestRequest.class);
+        when(request.hasContent()).thenReturn(true);
+        when(request.content()).thenReturn(new BytesArray(json.getBytes(StandardCharsets.UTF_8)));
+        return request;
+    }
+
+    // spotless:off
+    private String validRequest() {
+        return String.format(Locale.ROOT,
+            """
+            {
+              "space": "test",
+              "integration": "%s",
+              "input": {"event": {"category": "process", "type": "start"}, "host": {"name": "server01"}}
+            }
+            """,
+            INTEGRATION_ID);
+    }
+    // spotless:on
+
+    /** Empty payload returns 400. */
+    public void testEmptyPayload400() {
+        RestRequest request = mock(RestRequest.class);
+        when(request.hasContent()).thenReturn(false);
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        verify(this.logtestService, never()).executeDetection(anyString(), any(), any());
+    }
+
+    /** Invalid JSON returns 400. */
+    public void testInvalidJson400() {
+        RestRequest request = mockRequest("{not valid json");
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        verify(this.logtestService, never()).executeDetection(anyString(), any(), any());
+    }
+
+    /** Missing space field returns 400. */
+    public void testMissingSpace400() {
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"integration": "some-id", "input": {"event": {}}}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("space"));
+        verify(this.logtestService, never()).executeDetection(anyString(), any(), any());
+    }
+
+    /** Missing integration field returns 400. */
+    public void testMissingIntegration400() {
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"space": "test", "input": {"event": {}}}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("integration"));
+        verify(this.logtestService, never()).executeDetection(anyString(), any(), any());
+    }
+
+    /** Missing input field returns 400. */
+    public void testMissingInput400() {
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"space": "test", "integration": "some-id"}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("input"));
+        verify(this.logtestService, never()).executeDetection(anyString(), any(), any());
+    }
+
+    /** Non-test space returns 400 with appropriate message. */
+    public void testNonTestSpace400() {
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"space": "draft", "integration": "some-id", "input": {"event": {}}}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("draft"));
+        verify(this.logtestService, never()).executeDetection(anyString(), any(), any());
+    }
+
+    /** Input that is not a JSON object returns 400. */
+    public void testInputNotObject400() {
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"space": "test", "integration": "some-id", "input": "not an object"}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("input"));
+        verify(this.logtestService, never()).executeDetection(anyString(), any(), any());
+    }
+
+    /** Valid request delegates to LogtestService with correct arguments. */
+    public void testValidRequestDelegatesToService() {
+        RestResponse serviceResponse =
+                new RestResponse(
+                        "{\"status\":\"success\",\"rules_evaluated\":0,\"rules_matched\":0,\"matches\":[]}",
+                        RestStatus.OK.getStatus());
+        when(this.logtestService.executeDetection(anyString(), any(), any(JsonNode.class)))
+                .thenReturn(serviceResponse);
+
+        RestRequest request = mockRequest(validRequest());
+        RestResponse response = this.action.handleRequest(request);
+
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+        verify(this.logtestService).executeDetection(eq(INTEGRATION_ID), any(), any(JsonNode.class));
+    }
+
+    /** Service response is returned as-is. */
+    public void testServiceResponsePassedThrough() {
+        RestResponse serviceResponse =
+                new RestResponse(
+                        "{\"status\":\"success\",\"rules_evaluated\":5,\"rules_matched\":2,\"matches\":[]}",
+                        RestStatus.OK.getStatus());
+        when(this.logtestService.executeDetection(anyString(), any(), any(JsonNode.class)))
+                .thenReturn(serviceResponse);
+
+        RestRequest request = mockRequest(validRequest());
+        RestResponse response = this.action.handleRequest(request);
+
+        Assert.assertEquals(serviceResponse, response);
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostLogtestNormalizationActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostLogtestNormalizationActionTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.nio.charset.StandardCharsets;
+
+import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link RestPostLogtestNormalizationAction}. Validates request validation logic:
+ * required fields, space constraints, and delegation to {@link LogtestService}.
+ */
+public class RestPostLogtestNormalizationActionTests extends OpenSearchTestCase {
+
+    private RestPostLogtestNormalizationAction action;
+    private AutoCloseable closeable;
+
+    @Mock private LogtestService logtestService;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.closeable = MockitoAnnotations.openMocks(this);
+        this.action = new RestPostLogtestNormalizationAction(this.logtestService);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        if (this.closeable != null) {
+            this.closeable.close();
+        }
+        super.tearDown();
+    }
+
+    private RestRequest mockRequest(String json) {
+        RestRequest request = mock(RestRequest.class);
+        when(request.hasContent()).thenReturn(true);
+        when(request.content()).thenReturn(new BytesArray(json.getBytes(StandardCharsets.UTF_8)));
+        return request;
+    }
+
+    // spotless:off
+    private String validRequest() {
+        return """
+            {
+              "space": "test",
+              "queue": 1,
+              "location": "/var/log/cassandra/system.log",
+              "input": "INFO  [main] 2026-03-31 10:00:00 StorageService.java:123 - Node is ready to serve",
+              "trace_level": "NONE"
+            }
+            """;
+    }
+    // spotless:on
+
+    /** Empty payload returns 400. */
+    public void testEmptyPayload400() {
+        RestRequest request = mock(RestRequest.class);
+        when(request.hasContent()).thenReturn(false);
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        verify(this.logtestService, never()).executeNormalization(any());
+    }
+
+    /** Invalid JSON returns 400. */
+    public void testInvalidJson400() {
+        RestRequest request = mockRequest("{not valid json");
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        verify(this.logtestService, never()).executeNormalization(any());
+    }
+
+    /** Missing space field returns 400. */
+    public void testMissingSpace400() {
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"queue": 1, "location": "/var/log/test.log", "input": "test"}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("space"));
+        verify(this.logtestService, never()).executeNormalization(any());
+    }
+
+    /** Non-test space returns 400 with appropriate message. */
+    public void testNonTestSpace400() {
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"space": "draft", "queue": 1, "input": "test"}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("draft"));
+        verify(this.logtestService, never()).executeNormalization(any());
+    }
+
+    /** Valid request delegates to LogtestService with correct arguments. */
+    public void testValidRequestDelegatesToService() {
+        RestResponse serviceResponse = new RestResponse("{\"output\":{}}", RestStatus.OK.getStatus());
+        when(this.logtestService.executeNormalization(any(ObjectNode.class)))
+                .thenReturn(serviceResponse);
+
+        RestRequest request = mockRequest(validRequest());
+        RestResponse response = this.action.handleRequest(request);
+
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+        var captor = org.mockito.ArgumentCaptor.forClass(ObjectNode.class);
+        verify(this.logtestService).executeNormalization(captor.capture());
+
+        // Verify integration field is stripped from engine payload
+        ObjectNode payload = captor.getValue();
+        Assert.assertFalse(payload.has("integration"));
+        Assert.assertTrue(payload.has("space"));
+        Assert.assertTrue(payload.has("queue"));
+    }
+
+    /** Integration field is stripped if present. */
+    public void testIntegrationFieldStripped() {
+        RestResponse serviceResponse = new RestResponse("{\"output\":{}}", RestStatus.OK.getStatus());
+        when(this.logtestService.executeNormalization(any(ObjectNode.class)))
+                .thenReturn(serviceResponse);
+
+        // spotless:off
+        RestRequest request = mockRequest(
+            """
+            {"space": "test", "integration": "some-id", "queue": 1, "input": "test"}
+            """
+        );
+        // spotless:on
+        RestResponse response = this.action.handleRequest(request);
+
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+        var captor = org.mockito.ArgumentCaptor.forClass(ObjectNode.class);
+        verify(this.logtestService).executeNormalization(captor.capture());
+        Assert.assertFalse(captor.getValue().has("integration"));
+    }
+
+    /** Service response is returned as-is. */
+    public void testServiceResponsePassedThrough() {
+        RestResponse serviceResponse =
+                new RestResponse("{\"output\":{},\"asset_traces\":[]}", RestStatus.OK.getStatus());
+        when(this.logtestService.executeNormalization(any(ObjectNode.class)))
+                .thenReturn(serviceResponse);
+
+        RestRequest request = mockRequest(validRequest());
+        RestResponse response = this.action.handleRequest(request);
+
+        Assert.assertEquals(serviceResponse, response);
+    }
+}


### PR DESCRIPTION
### Description
This Pr adds two new endpoints, for different phases of the rule testing:
- `/logtest/normalization`:  Just for the engine related steps
- `/logtest/detection`: Just the SAP related steps

### Issues Resolved
Closes https://github.com/wazuh/wazuh-indexer-security-analytics/issues/56
