### PR TITLE
Implement custom user-agent communication for CTI client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement version check CM API endpoint [(#1028)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1028)
 - Add documentation for Wazuh Alerting plugin [(#980)](https://github.com/wazuh/wazuh-indexer-plugins/pull/980)
 - Add ruletesting extended endpoints [(#1040)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1040)
+- Set custom user-agent header for CTI API communications [(#1074)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1074)
 
 
 ### Dependencies

--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -66,8 +66,23 @@ The update check flow is split into two classes:
   - Headers sent:
     - `wazuh-uid`: cluster UUID
     - `wazuh-tag`: `v<version>`
-    - `user-agent`: `Wazuh Indexer <version>`
   - Fire-and-forget behavior: callback logs success/failure without blocking scheduler threads.
+
+### CTI HTTP Client User-Agent
+
+All HTTP clients that communicate with CTI services include a custom `User-Agent` header set as a **default header on the HTTP client builder**:
+
+```
+User-Agent: Wazuh Indexer <version>
+```
+
+The version is read from `VERSION.json` at plugin startup and stored in `PluginSettings`. The user-agent string is built by `PluginSettings.getUserAgent()` using the `Constants.USER_AGENT_PREFIX` constant. If the version is unavailable, the fallback value `unknown` is used.
+
+Affected clients:
+- **Console `ApiClient`** (`cti/console/client/ApiClient.java`) — async HTTP client for CTI Console authentication and plans.
+- **Catalog `ApiClient`** (`cti/catalog/client/ApiClient.java`) — async HTTP client for CTI Catalog consumer and changes.
+- **`SnapshotClient`** (`cti/catalog/client/SnapshotClient.java`) — sync HTTP client for downloading CTI snapshots.
+- **`TelemetryClient`** (`cti/console/client/TelemetryClient.java`) — inherits from Console `ApiClient`.
 
 Runtime toggle behavior:
 

--- a/docs/ref/modules/content-manager/architecture.md
+++ b/docs/ref/modules/content-manager/architecture.md
@@ -19,6 +19,8 @@ Exposes HTTP endpoints under `/_plugins/_content_manager/` for:
 
 Manages authentication with the Wazuh CTI API. Stores subscription tokens used for all CTI requests. Without a valid token, sync operations are rejected.
 
+All HTTP clients that communicate with CTI services send a custom `User-Agent` header in the format `Wazuh Indexer <version>` (e.g., `Wazuh Indexer 5.0.0`). This applies to the Console API client, Catalog API client, Snapshot client, and Telemetry client.
+
 ### Job Scheduler (CatalogSyncJob)
 
 Implements the OpenSearch `JobSchedulerExtension` interface. Registers a periodic job (`wazuh-catalog-sync-job`) that triggers content synchronization at a configurable interval (default: 60 minutes). The job metadata is stored in `.wazuh-content-manager-jobs`.
@@ -29,7 +31,7 @@ Implements a daily heartbeat job (`wazuh-telemetry-ping-job`) that calls the CTI
 
 - Enabled by default through `plugins.content_manager.telemetry.enabled`.
 - Can be toggled at runtime because it is a dynamic setting.
-- Sends deployment metadata required for update checks (cluster UUID and deployed Wazuh version).
+- Sends deployment metadata required for update checks (cluster UUID, deployed Wazuh version, and user-agent).
 - Job metadata is stored in `.wazuh-content-manager-jobs`.
 
 ### Consumer Service

--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -83,6 +83,16 @@ If you do not use the OpenSearch Security Analytics plugin:
 plugins.content_manager.catalog.create_detectors: false
 ```
 
+### CTI communication headers
+
+All HTTP clients that communicate with Wazuh CTI services send a custom `User-Agent` header:
+
+```
+User-Agent: Wazuh Indexer <version>
+```
+
+For example: `Wazuh Indexer 5.0.0`. This applies to the Console API client, Catalog API client, Snapshot client, and Telemetry client. The version is read from `VERSION.json` at plugin startup.
+
 ### Update check service behavior
 
 The update check service is enabled by default and runs once per day.

--- a/plugins/content-manager/imposter/README.md
+++ b/plugins/content-manager/imposter/README.md
@@ -23,6 +23,7 @@ imposter/
     ├── tokenResponse.groovy            # Token request logic
     ├── tokenExchangeResponse.groovy    # Token exchange logic
     ├── instanceMeResponse.groovy       # Instance me logic
+    ├── releasesUpdatesResponse.groovy  # Release updates logic
     └── catalogResponse.groovy          # Catalog endpoint logic
 ```
 
@@ -326,6 +327,23 @@ To stop the server, use the helper script:
 ```bash
 ./imposter.sh stop    # Stop containers without removing them
 ./imposter.sh down    # Stop and remove containers
+```
+
+## Observability
+
+All Groovy response scripts log the incoming `User-Agent` header for every request. This is useful for verifying that the Content Manager plugin sends the expected custom user-agent (`Wazuh Indexer <version>`) instead of the default Apache HttpClient one.
+
+To inspect the logs:
+
+```bash
+cd images/
+docker compose logs -f
+```
+
+Log lines follow the format:
+```
+[tokenRequest] User-Agent: Wazuh Indexer 5.0.0
+[catalogResponse] User-Agent: Wazuh Indexer 5.0.0
 ```
 
 ## Customization

--- a/plugins/content-manager/imposter/imposter-config.yml
+++ b/plugins/content-manager/imposter/imposter-config.yml
@@ -37,3 +37,9 @@ resources:
     method: GET
     response:
       scriptFile: scripts/catalogResponse.groovy
+
+  # Ping endpoint - returns available version updates
+  - path: /api/v1/ping
+    method: GET
+    response:
+      scriptFile: scripts/releasesUpdatesResponse.groovy

--- a/plugins/content-manager/imposter/openapi.yml
+++ b/plugins/content-manager/imposter/openapi.yml
@@ -35,6 +35,45 @@ tags:
     description: Wazuh release version endpoints
 
 paths:
+  /api/v1/ping:
+    get:
+      summary: Ping
+      description: |
+        Health check endpoint for telemetry ping.
+
+        This endpoint is used by the TelemetryClient to send periodic pings containing the instance UUID and version.
+        It can be used to verify connectivity and monitor active instances.
+      operationId: ping
+      tags:
+        - CTI Console
+      parameters:
+        - name: wazuh-uid
+          in: header
+          required: true
+          description: The unique identifier of the Wazuh instance (UUID).
+          schema:
+            type: string
+            example: a17c21ed-1234-5678-9abc-def012345678
+        - name: wazuh-tag
+          in: header
+          required: true
+          description: The version tag of the Wazuh instance (e.g., "v5.0.0").
+          schema:
+            type: string
+            example: v5.0.0
+      responses:
+        '200':
+          $ref: '#/components/responses/ReleaseUpdatesSuccess'
+        '400':
+          description: Invalid tag format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                errors:
+                  tag: ["is invalid"]
+
   /api/v1/instances/token:
     post:
       summary: Token Request

--- a/plugins/content-manager/imposter/scripts/catalogResponse.groovy
+++ b/plugins/content-manager/imposter/scripts/catalogResponse.groovy
@@ -1,6 +1,10 @@
 // Catalog Response Logic
 // Returns different responses based on verify parameter and query params
 
+// Log the incoming user-agent for validation
+def userAgent = context.request.headers['User-Agent']?.toString()
+logger.info("[catalogResponse] User-Agent: ${userAgent}")
+
 def verify = context.request.queryParams.verify?.toString()
 def fromOffsetStr = context.request.queryParams.from_offset?.toString()
 def toOffsetStr = context.request.queryParams.to_offset?.toString()

--- a/plugins/content-manager/imposter/scripts/instanceMeResponse.groovy
+++ b/plugins/content-manager/imposter/scripts/instanceMeResponse.groovy
@@ -1,6 +1,10 @@
 // Instance Me Response Logic
 // Returns different responses based on Authorization header token
 
+// Log the incoming user-agent for validation
+def userAgent = context.request.headers['User-Agent']?.toString()
+logger.info("[instanceMe] User-Agent: ${userAgent}")
+
 def authHeader = context.request.headers['Authorization']?.toString()
 
 // Check if Authorization header is present

--- a/plugins/content-manager/imposter/scripts/releasesUpdatesResponse.groovy
+++ b/plugins/content-manager/imposter/scripts/releasesUpdatesResponse.groovy
@@ -2,6 +2,10 @@
 // Returns mock release updates based on the version tag in the path.
 // Simulates the CTI API GET /api/v1/releases/:tag/updates endpoint.
 
+// Log the incoming user-agent for validation
+def userAgent = context.request.headers['User-Agent']?.toString()
+logger.info("[releasesUpdates] User-Agent: ${userAgent}")
+
 def tag = context.request.pathParams['tag']
 
 // Validate tag format (must start with 'v')

--- a/plugins/content-manager/imposter/scripts/tokenExchangeResponse.groovy
+++ b/plugins/content-manager/imposter/scripts/tokenExchangeResponse.groovy
@@ -1,6 +1,10 @@
 // Token Exchange Response Logic
 // Returns different responses based on Authorization header
 
+// Log the incoming user-agent for validation
+def userAgent = context.request.headers['User-Agent']?.toString()
+logger.info("[tokenExchange] User-Agent: ${userAgent}")
+
 def authHeader = context.request.headers.Authorization?.toString()
 def resource = context.request.formParams.resource?.toString()
 

--- a/plugins/content-manager/imposter/scripts/tokenResponse.groovy
+++ b/plugins/content-manager/imposter/scripts/tokenResponse.groovy
@@ -3,6 +3,10 @@
 
 import java.util.concurrent.ConcurrentHashMap
 
+// Log the incoming user-agent for validation
+def userAgent = context.request.headers['User-Agent']?.toString()
+logger.info("[tokenRequest] User-Agent: ${userAgent}")
+
 // Use a static map to track request counts across invocations
 @groovy.transform.Field
 static ConcurrentHashMap<String, Integer> requestCounts = new ConcurrentHashMap<>()

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -135,6 +135,7 @@ public class ContentManagerPlugin extends Plugin
             IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<RepositoriesService> repositoriesServiceSupplier) {
         PluginSettings.getInstance(environment.settings());
+        PluginSettings.getInstance().setWazuhVersion(getVersion(environment));
         this.environment = environment;
         this.clusterService = clusterService;
         this.client = client;

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -138,7 +138,7 @@ public class ContentManagerPlugin extends Plugin
             IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<RepositoriesService> repositoriesServiceSupplier) {
         PluginSettings.getInstance(environment.settings());
-        PluginSettings.getInstance().setWazuhVersion(getVersion(environment));
+        PluginSettings.getInstance().setVersion(ContentManagerPlugin.getVersion(environment));
         this.environment = environment;
         this.clusterService = clusterService;
         this.client = client;

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -21,6 +21,9 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
@@ -31,6 +34,7 @@ import javax.net.ssl.SSLContext;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -76,9 +80,14 @@ public class ApiClient {
             throw new RuntimeException("Failed to initialize HttpClient", e);
         }
 
+        List<Header> defaultHeaders =
+                List.of(
+                        new BasicHeader(HttpHeaders.USER_AGENT, PluginSettings.getInstance().getUserAgent()));
+
         this.client =
                 HttpAsyncClients.custom()
                         .setIOReactorConfig(ioReactorConfig)
+                        .setDefaultHeaders(defaultHeaders)
                         .setConnectionManager(
                                 PoolingAsyncClientConnectionManagerBuilder.create()
                                         .setTlsStrategy(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SnapshotClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SnapshotClient.java
@@ -20,6 +20,9 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.env.Environment;
@@ -33,6 +36,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import com.wazuh.contentmanager.settings.PluginSettings;
 
 /** Client responsible for downloading CTI snapshots from a remote source. */
 public class SnapshotClient {
@@ -58,7 +64,11 @@ public class SnapshotClient {
      * @throws URISyntaxException If the provided URI is invalid.
      */
     public Path downloadFile(String snapshotURI) throws IOException, URISyntaxException {
-        try (CloseableHttpClient client = HttpClients.createDefault()) {
+        List<Header> defaultHeaders =
+                List.of(
+                        new BasicHeader(HttpHeaders.USER_AGENT, PluginSettings.getInstance().getUserAgent()));
+        try (CloseableHttpClient client =
+                HttpClients.custom().setDefaultHeaders(defaultHeaders).build()) {
             // Setup
             final URI uri = new URI(snapshotURI);
             final HttpGet request = new HttpGet(uri);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
@@ -22,7 +22,9 @@ import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
@@ -42,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 
 import com.wazuh.contentmanager.cti.catalog.utils.HttpResponseCallback;
 import com.wazuh.contentmanager.cti.console.model.Token;
+import com.wazuh.contentmanager.settings.PluginSettings;
 
 /** CTI Console API client. */
 public class ApiClient {
@@ -74,9 +77,14 @@ public class ApiClient {
             throw new RuntimeException("Failed to initialize HttpClient", e);
         }
 
+        List<Header> defaultHeaders =
+                List.of(
+                        new BasicHeader(HttpHeaders.USER_AGENT, PluginSettings.getInstance().getUserAgent()));
+
         this.client =
                 HttpAsyncClients.custom()
                         .setIOReactorConfig(ioReactorConfig)
+                        .setDefaultHeaders(defaultHeaders)
                         .setConnectionManager(
                                 PoolingAsyncClientConnectionManagerBuilder.create()
                                         .setTlsStrategy(
@@ -183,7 +191,7 @@ public class ApiClient {
                 SimpleRequestBuilder.get(PRODUCTS_URI)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
-                        .addHeader("wazuh-tag", "v5.0.0") // TODO make dynamic
+                        .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getWazuhVersion())
                         .build();
 
         final Future<SimpleHttpResponse> future =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
@@ -191,7 +191,7 @@ public class ApiClient {
                 SimpleRequestBuilder.get(PRODUCTS_URI)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
-                        .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getWazuhVersion())
+                        .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
                         .build();
 
         final Future<SimpleHttpResponse> future =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
@@ -51,7 +51,6 @@ public class TelemetryClient extends ApiClient {
                     SimpleRequestBuilder.get(PING_URI)
                             .addHeader("wazuh-uid", uuid)
                             .addHeader("wazuh-tag", "v" + version)
-                            .addHeader("user-agent", "Wazuh Indexer " + version)
                             .addHeader("Accept", "application/json")
                             .build();
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
@@ -23,15 +23,14 @@ import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.wazuh.contentmanager.settings.PluginSettings;
+
 /**
  * Client for handling telemetry-related requests to the Wazuh CTI API. This class extends the base
  * ApiClient to reuse the asynchronous HTTP infrastructure.
  */
 public class TelemetryClient extends ApiClient {
     private static final Logger log = LogManager.getLogger(TelemetryClient.class);
-
-    /** Target endpoint for the telemetry heartbeat. */
-    private static final String PING_URI = "https://api.pre.cloud.wazuh.com/api/v1/ping";
 
     /**
      * Performs an asynchronous GET request to the CTI ping endpoint. This follows a "fire-and-forget"
@@ -41,6 +40,7 @@ public class TelemetryClient extends ApiClient {
      * @param version The current version of the Wazuh Indexer.
      */
     public void ping(String uuid, String version) {
+        String pingUrl = PluginSettings.getInstance().getCtiBaseUrl() + "/ping";
         if (uuid == null || version == null || uuid.isBlank() || version.isBlank()) {
             log.error("UUID or version is null or blank. Aborting telemetry ping.");
             return;
@@ -48,13 +48,13 @@ public class TelemetryClient extends ApiClient {
 
         try {
             SimpleHttpRequest request =
-                    SimpleRequestBuilder.get(PING_URI)
+                    SimpleRequestBuilder.get(pingUrl)
                             .addHeader("wazuh-uid", uuid)
                             .addHeader("wazuh-tag", "v" + version)
                             .addHeader("Accept", "application/json")
                             .build();
 
-            log.debug("Sending telemetry ping to: {}", PING_URI);
+            log.debug("Sending telemetry ping to: {}", pingUrl);
 
             // Execute the request using the inherited asynchronous client from ApiClient.
             // A null callback is used as the response body is not required for this heartbeat.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -22,7 +22,7 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 
 import com.wazuh.contentmanager.utils.Constants;
-import reactor.util.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 /** This class encapsulates configuration settings and constants for the Content Manager plugin. */
 public class PluginSettings {
@@ -244,7 +244,7 @@ public class PluginSettings {
     private final boolean engineMockEnabled;
     private final boolean createDetectors;
     private volatile boolean isTelemetryEnabled;
-    private String wazuhVersion;
+    private String version;
 
     /**
      * Private default constructor
@@ -304,21 +304,21 @@ public class PluginSettings {
     }
 
     /**
-     * Sets the Wazuh version. Should be called once during plugin initialization.
+     * Sets the version of Wazuh. Should be called once during plugin initialization.
      *
      * @param version the Wazuh version string (e.g., "5.0.0").
      */
-    public void setWazuhVersion(String version) {
-        this.wazuhVersion = version;
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     /**
-     * Retrieves the Wazuh version.
+     * Retrieves the version of Wazuh.
      *
      * @return the Wazuh version string, or null if not set.
      */
-    public String getWazuhVersion() {
-        return this.wazuhVersion;
+    public String getVersion() {
+        return this.version;
     }
 
     /**
@@ -327,7 +327,7 @@ public class PluginSettings {
      * @return the user-agent string in the format "Wazuh Indexer {version}".
      */
     public String getUserAgent() {
-        String version = this.wazuhVersion != null ? this.wazuhVersion : "unknown";
+        String version = this.version != null ? this.version : "unknown";
         return Constants.USER_AGENT_PREFIX + version;
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 
+import com.wazuh.contentmanager.utils.Constants;
 import reactor.util.annotation.NonNull;
 
 /** This class encapsulates configuration settings and constants for the Content Manager plugin. */
@@ -243,6 +244,7 @@ public class PluginSettings {
     private final boolean engineMockEnabled;
     private final boolean createDetectors;
     private volatile boolean isTelemetryEnabled;
+    private String wazuhVersion;
 
     /**
      * Private default constructor
@@ -299,6 +301,34 @@ public class PluginSettings {
 
     public void setTelemetryEnabled(boolean isTelemetryEnabled) {
         this.isTelemetryEnabled = isTelemetryEnabled;
+    }
+
+    /**
+     * Sets the Wazuh version. Should be called once during plugin initialization.
+     *
+     * @param version the Wazuh version string (e.g., "5.0.0").
+     */
+    public void setWazuhVersion(String version) {
+        this.wazuhVersion = version;
+    }
+
+    /**
+     * Retrieves the Wazuh version.
+     *
+     * @return the Wazuh version string, or null if not set.
+     */
+    public String getWazuhVersion() {
+        return this.wazuhVersion;
+    }
+
+    /**
+     * Builds the custom user-agent string for CTI API communications.
+     *
+     * @return the user-agent string in the format "Wazuh Indexer {version}".
+     */
+    public String getUserAgent() {
+        String version = this.wazuhVersion != null ? this.wazuhVersion : "unknown";
+        return Constants.USER_AGENT_PREFIX + version;
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -197,6 +197,9 @@ public class Constants {
     public static final String IOC_SNAPSHOT_FILENAME = "ioc.zip";
     public static final String CVE_SNAPSHOT_FILENAME = "cve.zip";
 
+    // HTTP headers
+    public static final String USER_AGENT_PREFIX = "Wazuh Indexer ";
+
     // IOC type hashes
     public static final String IOC_TYPE_HASHES_ID = "__ioc_type_hashes__";
     public static final String KEY_TYPE_HASHES = "type_hashes";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/console/CtiConsoleTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/console/CtiConsoleTests.java
@@ -18,6 +18,7 @@ package com.wazuh.contentmanager.cti.console;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.core5.http.ContentType;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Assert;
@@ -34,6 +35,7 @@ import com.wazuh.contentmanager.cti.console.service.AuthService;
 import com.wazuh.contentmanager.cti.console.service.AuthServiceImpl;
 import com.wazuh.contentmanager.cti.console.service.PlansService;
 import com.wazuh.contentmanager.cti.console.service.PlansServiceImpl;
+import com.wazuh.contentmanager.settings.PluginSettings;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.*;
@@ -56,6 +58,12 @@ public class CtiConsoleTests extends OpenSearchTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+
+        try {
+            PluginSettings.getInstance(Settings.EMPTY);
+        } catch (IllegalStateException e) {
+            // Already initialized
+        }
 
         // Mock CTI Console API Client
         this.mockClient = mock(ApiClient.class);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/console/service/AuthServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/console/service/AuthServiceTests.java
@@ -18,6 +18,7 @@ package com.wazuh.contentmanager.cti.console.service;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.core5.http.ContentType;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Assert;
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeoutException;
 import com.wazuh.contentmanager.cti.console.client.ApiClient;
 import com.wazuh.contentmanager.cti.console.model.Subscription;
 import com.wazuh.contentmanager.cti.console.model.Token;
+import com.wazuh.contentmanager.settings.PluginSettings;
 import org.mockito.Mock;
 
 import static org.mockito.Mockito.*;
@@ -51,6 +53,12 @@ public class AuthServiceTests extends OpenSearchTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+
+        try {
+            PluginSettings.getInstance(Settings.EMPTY);
+        } catch (IllegalStateException e) {
+            // Already initialized
+        }
 
         // Mock CTI Console API Client
         this.mockClient = mock(ApiClient.class);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
@@ -25,6 +25,8 @@ import org.junit.Before;
 
 import java.lang.reflect.Field;
 
+import com.wazuh.contentmanager.utils.Constants;
+
 public class PluginSettingsTests extends OpenSearchTestCase {
 
     /**
@@ -91,5 +93,33 @@ public class PluginSettingsTests extends OpenSearchTestCase {
         // Verify custom values
         Assert.assertFalse(pluginSettings.isUpdateOnStart());
         Assert.assertFalse(pluginSettings.isUpdateOnSchedule());
+    }
+
+    /** Tests that getUserAgent returns the fallback value when no version has been set. */
+    public void testGetUserAgentDefaultsToUnknown() {
+        PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
+
+        Assert.assertNull(pluginSettings.getWazuhVersion());
+        Assert.assertEquals(Constants.USER_AGENT_PREFIX + "unknown", pluginSettings.getUserAgent());
+    }
+
+    /** Tests that getUserAgent returns the correct value after setWazuhVersion is called. */
+    public void testGetUserAgentWithVersion() {
+        PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
+        pluginSettings.setWazuhVersion("5.0.0");
+
+        Assert.assertEquals("5.0.0", pluginSettings.getWazuhVersion());
+        Assert.assertEquals(Constants.USER_AGENT_PREFIX + "5.0.0", pluginSettings.getUserAgent());
+    }
+
+    /** Tests that setWazuhVersion can be updated and getUserAgent reflects the latest value. */
+    public void testSetWazuhVersionUpdatesUserAgent() {
+        PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
+        pluginSettings.setWazuhVersion("4.9.0");
+
+        Assert.assertEquals(Constants.USER_AGENT_PREFIX + "4.9.0", pluginSettings.getUserAgent());
+
+        pluginSettings.setWazuhVersion("5.0.0");
+        Assert.assertEquals(Constants.USER_AGENT_PREFIX + "5.0.0", pluginSettings.getUserAgent());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
@@ -99,27 +99,27 @@ public class PluginSettingsTests extends OpenSearchTestCase {
     public void testGetUserAgentDefaultsToUnknown() {
         PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
 
-        Assert.assertNull(pluginSettings.getWazuhVersion());
+        Assert.assertNull(pluginSettings.getVersion());
         Assert.assertEquals(Constants.USER_AGENT_PREFIX + "unknown", pluginSettings.getUserAgent());
     }
 
     /** Tests that getUserAgent returns the correct value after setWazuhVersion is called. */
     public void testGetUserAgentWithVersion() {
         PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
-        pluginSettings.setWazuhVersion("5.0.0");
+        pluginSettings.setVersion("5.0.0");
 
-        Assert.assertEquals("5.0.0", pluginSettings.getWazuhVersion());
+        Assert.assertEquals("5.0.0", pluginSettings.getVersion());
         Assert.assertEquals(Constants.USER_AGENT_PREFIX + "5.0.0", pluginSettings.getUserAgent());
     }
 
     /** Tests that setWazuhVersion can be updated and getUserAgent reflects the latest value. */
     public void testSetWazuhVersionUpdatesUserAgent() {
         PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
-        pluginSettings.setWazuhVersion("4.9.0");
+        pluginSettings.setVersion("4.9.0");
 
         Assert.assertEquals(Constants.USER_AGENT_PREFIX + "4.9.0", pluginSettings.getUserAgent());
 
-        pluginSettings.setWazuhVersion("5.0.0");
+        pluginSettings.setVersion("5.0.0");
         Assert.assertEquals(Constants.USER_AGENT_PREFIX + "5.0.0", pluginSettings.getUserAgent());
     }
 }


### PR DESCRIPTION
## Description
This PR Implement user-agent for CTI communication, also updates the imposter environment and the corresponding docs

### Validation
1. Startup imposter
    ```bash
    # cd plugins/content-manager/imposter
    # bash ./imposter.sh up
    Setting up SSL environment for Imposter...
    Using existing certificates
    Stopping existing containers...
    Starting Docker Compose environment...
    [+] Running 3/3
     ✔ Network images_default       Created                                              0.0s 
     ✔ Container images-imposter-1  Started                                              0.2s 
     ✔ Container images-nginx-1     Started                      
    ```
2. Install the package with the fix
3. Modify the `opensearch.yml` to use the imposter URL instead of the real CTI
    ```yaml
    plugins.content_manager.cti.api: "https://192.168.56.1:8443/api/v1"
    ```
    > This is my current local IP, it may vary on different systems
4. Start the wazuh-indexer service and wait for the PING telemetry job to be launched
    > It can also be validated using the `GET plugins/_content_manager/version/check` endpoint
5. Check Imposter logs for the `user-agent` header
    ```log
    12:45:34 INFO  s./opt/imposter/config/scripts/releasesUpdatesResponse - [releasesUpdates] User-Agent: Wazuh Indexer 5.0.0
    ```

### Issues Resolved
Closes #1069 
