### PR TITLE
Upgrade Splunk version and fix KV store error

### DIFF
--- a/integrations/docker/.env
+++ b/integrations/docker/.env
@@ -38,7 +38,7 @@ OS_VERSION=3
 LOGSTASH_OSS_VERSION=8.9.0
 
 # Splunk version:
-SPLUNK_VERSION=10.0.3
+SPLUNK_VERSION=10.2.1
 
 # Version of Elastic products
 STACK_VERSION=9.3.3

--- a/integrations/docker/.env
+++ b/integrations/docker/.env
@@ -38,7 +38,7 @@ OS_VERSION=3
 LOGSTASH_OSS_VERSION=8.9.0
 
 # Splunk version:
-SPLUNK_VERSION=10.2.1
+SPLUNK_VERSION=10.2.3
 
 # Version of Elastic products
 STACK_VERSION=9.3.3

--- a/integrations/docker/compose.indexer-splunk.yml
+++ b/integrations/docker/compose.indexer-splunk.yml
@@ -137,6 +137,7 @@ services:
 
   splunk:
     image: splunk/splunk:${SPLUNK_VERSION}
+    user: root
     volumes:
       - ./certs/splunk.key:/opt/splunk/etc/auth/custom/splunk.key
       - ./certs/splunk.pem:/opt/splunk/etc/auth/custom/splunk.pem
@@ -159,7 +160,7 @@ services:
       SPLUNK_PASSWORD: Password.1234
       SPLUNK_STANDALONE_URL: https://splunk:8080
       SPLUNK_GENERAL_TERMS: --accept-sgt-current-at-splunk-com
-      SPLUNK_START_ARGS: --accept-license
+      SPLUNK_START_ARGS: --accept-license --run-as-root
 
   logstash:
     image: logstash-oss:${LOGSTASH_OSS_VERSION}

--- a/integrations/splunk/config/default.yml
+++ b/integrations/splunk/config/default.yml
@@ -15,7 +15,11 @@ splunk:
           general:
             serverName: splunk
             pass4SymmKey: dadqaBZA2fzxHOvfdlSQpKjIooupehTnmjysUx7j+bP1/NucBL+rch/Kw==
-          sslConfig:
+    - key: inputs
+      value:
+        directory: /opt/splunk/etc/system/local
+        content:
+          http:
             serverCert: /opt/splunk/etc/auth/custom/splunkhec.pem
   hec:
     enable: True


### PR DESCRIPTION
### Description
This PR fixes the Splunk's KV store error, and upgrades its version to 10.2.1

#### Validations

> [!NOTE]
> Make sure the `wazuh-alerts` index is configured on: Data inputs -> HTTP Event Collector -> splunk_hec_token index

- Version used 
    <img width="1718" height="735" alt="image" src="https://github.com/user-attachments/assets/73099dad-76f8-4288-9fe6-7c08af06108e" />
- No error messages
    <img width="1718" height="735" alt="image" src="https://github.com/user-attachments/assets/d2b7cc82-7a40-43d1-86e2-771376bbdbc7" />
     

### Issues Resolved
Closes #913 
