### PR TITLE
Update integrations template

### DIFF
--- a/plugins/content-manager/src/main/resources/mappings/cti-integrations-mappings.json
+++ b/plugins/content-manager/src/main/resources/mappings/cti-integrations-mappings.json
@@ -6,7 +6,7 @@
         "id": {
           "type": "keyword"
         },
-        "parent_decoder": {
+        "default_parent": {
           "type": "keyword"
         },
         "category": {


### PR DESCRIPTION
### Description
This PR updates the integrations template to include the `default_parent` instead of  `parent_decoder` 

No new fields are needed

### Issues Resolved
Closes #1103