### PR TITLE
Add on SetupPlugin the wazuh-threatintel-filters index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix CodeQL maven caching [(#1007)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1007)
 - Fix broken Javadoc link reference in ContentManagerPlugin [(#1020)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1020)
 - Fix Telemetry Ping Job not running immediately after registration [(#1052)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1052)
+- Fix missing wazuh-threatintel-filters index [(#1143)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1143)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#484)](https://github.com/wazuh/wazuh-indexer-plugins/pull/484)

--- a/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
@@ -152,6 +152,8 @@ public class SetupPlugin extends Plugin implements ClusterPlugin, ActionPlugin {
         this.indices.add(new StateIndex("wazuh-states-inventory-users", "templates/states/inventory-users"));
         this.indices.add(new StateIndex("wazuh-states-vulnerabilities", "templates/states/vulnerabilities"));
 
+        this.indices.add(new StateIndex("wazuh-threatintel-filters", "templates/content/filters"));
+
         // Wazuh settings index - Instantiated as it is required by the RestPutSettingsAction.
         this.settingsIndex = new SettingsIndex(".wazuh-settings", "templates/settings");
         this.indices.add(this.settingsIndex);


### PR DESCRIPTION
### Description
This PR resolves the missing `wazuh-threatintel-filters` index by adding its creation to `SetupPlugin.java`

### Issues Resolved
Closes #1140 
