### PR TITLE
Implement CTI subscription GET and DELETE endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change check object in filters template to object[(#1062)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1062)
 - Update ruleset feed for 5.0.0 beta2 [(#1073)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1073)
 - Normalize space values in CM and SAP integration [(#1091)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1091)
+- CTI subscription API update [(#1145)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1145)
 
 ### Deprecated
 -

--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -93,11 +93,13 @@ Runtime toggle behavior:
 
 ### REST Handlers
 
-The plugin registers 24 REST handlers, grouped by domain:
+The plugin registers 26 REST handlers, grouped by domain:
 
 | Domain           | Handler                        | Method | URI                                            |
 | ---------------- | ------------------------------ | ------ | ---------------------------------------------- |
 | **Subscription** | `RestPostSubscriptionAction`   | POST   | `/_plugins/_content_manager/subscription`      |
+|                  | `RestGetSubscriptionAction`    | GET    | `/_plugins/_content_manager/subscription`      |
+|                  | `RestDeleteSubscriptionAction` | DELETE | `/_plugins/_content_manager/subscription`      |
 | **Update**       | `RestPostUpdateAction`         | POST   | `/_plugins/_content_manager/update`            |
 | **Logtest**      | `RestPostLogtestAction`        | POST   | `/_plugins/_content_manager/logtest`           |
 | **Policy**       | `RestPutPolicyAction`          | PUT    | `/_plugins/_content_manager/policy/{space}`    |

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -68,7 +68,7 @@ YAML parsing preserves numeric type fidelity. Floating-point values like `5.0` a
 
 ### Store CTI Credentials
 
-Stores the provided CTI access token in the `.wazuh-cti-credentials` hidden index and loads it into memory.
+Stores the provided CTI access token in the `.wazuh-cti-credentials` hidden index and loads it into memory. If the index does not exist it is recreated automatically before writing.
 
 **Request**
 - Method: `POST`
@@ -113,6 +113,8 @@ curl -sk -u admin:admin -X POST \
 ### Get CTI Subscription Status
 
 Returns the current subscription status and active plan. For registered instances the plan comes from the authenticated CTI endpoint; for unregistered instances, the public free plan is returned.
+
+> If the stored token is rejected by the CTI API (e.g. expired or revoked), the credentials document is deleted automatically, the in-memory token is cleared, and the response falls back to the public free plan as if the instance were unregistered.
 
 **Request**
 - Method: `GET`
@@ -166,7 +168,7 @@ curl -sk -u admin:admin -X GET \
 
 ### Delete CTI Credentials
 
-Clears the stored CTI access token document from the credentials index and clears the in-memory token. The credentials index is preserved. After this operation the instance is unregistered.
+Clears the stored CTI access token document from the credentials index and clears the in-memory token. The credentials index is preserved. After this operation the instance is unregistered. If the credentials index does not exist the operation succeeds without error.
 
 **Request**
 - Method: `DELETE`

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -110,6 +110,93 @@ curl -sk -u admin:admin -X POST \
 
 ---
 
+### Get CTI Subscription Status
+
+Returns the current subscription status and active plan. For registered instances the plan comes from the authenticated CTI endpoint; for unregistered instances, the public free plan is returned.
+
+**Request**
+- Method: `GET`
+- Path: `/_plugins/_content_manager/subscription`
+
+**Example Request**
+
+```bash
+curl -sk -u admin:admin -X GET \
+  "https://localhost:9200/_plugins/_content_manager/subscription"
+```
+
+**Example Response (registered)**
+
+```json
+{
+  "message": {
+    "plan": {
+      "name": "Premium Plan",
+      "is_public": false
+    },
+    "is_registered": true
+  },
+  "status": 200
+}
+```
+
+**Example Response (unregistered)**
+
+```json
+{
+  "message": {
+    "plan": {
+      "name": "Free",
+      "is_public": true
+    },
+    "is_registered": false
+  },
+  "status": 200
+}
+```
+
+**Status Codes**
+
+| Code | Description                                     |
+| ---- | ----------------------------------------------- |
+| 200  | Subscription status returned successfully       |
+| 500  | Internal error                                  |
+
+---
+
+### Delete CTI Credentials
+
+Removes the stored CTI access token from the credentials index and clears the in-memory token. After this operation the instance is unregistered.
+
+**Request**
+- Method: `DELETE`
+- Path: `/_plugins/_content_manager/subscription`
+
+**Example Request**
+
+```bash
+curl -sk -u admin:admin -X DELETE \
+  "https://localhost:9200/_plugins/_content_manager/subscription"
+```
+
+**Example Response**
+
+```json
+{
+  "message": "Credentials removed",
+  "status": 200
+}
+```
+
+**Status Codes**
+
+| Code | Description                                     |
+| ---- | ----------------------------------------------- |
+| 200  | Credentials removed successfully                |
+| 500  | Internal error                                  |
+
+---
+
 ## Content Updates
 
 ### Trigger Manual Sync

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -166,7 +166,7 @@ curl -sk -u admin:admin -X GET \
 
 ### Delete CTI Credentials
 
-Removes the stored CTI access token from the credentials index and clears the in-memory token. After this operation the instance is unregistered.
+Clears the stored CTI access token document from the credentials index and clears the in-memory token. The credentials index is preserved. After this operation the instance is unregistered.
 
 **Request**
 - Method: `DELETE`

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -81,6 +81,35 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+    get:
+      summary: Get CTI Subscription Status
+      description: |
+        Returns the subscription status and active plan. For registered instances,
+        the plan is fetched from the authenticated CTI endpoint. Otherwise, the
+        public free plan is returned.
+      operationId: getSubscription
+      tags:
+        - Subscription Management
+      responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionStatus"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    delete:
+      summary: Delete CTI Credentials
+      description: |
+        Removes the stored CTI access token from the credentials index and clears
+        the in-memory plugin variable. After this operation the instance is unregistered.
+      operationId: deleteSubscription
+      tags:
+        - Subscription Management
+      responses:
+        "200":
+          $ref: "#/components/responses/CredentialsRemoved"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /update:
     description: On demand content update
     post:
@@ -2241,6 +2270,60 @@ components:
               value:
                 message: "Credentials received"
                 status: 201
+
+    SubscriptionStatus:
+      description: OK - Subscription status and active plan details.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: object
+                properties:
+                  plan:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      is_public:
+                        type: boolean
+                  is_registered:
+                    type: boolean
+              status:
+                type: integer
+          examples:
+            registered:
+              summary: Registered instance
+              value:
+                message:
+                  plan:
+                    name: "Premium Plan"
+                    is_public: false
+                  is_registered: true
+                status: 200
+            unregistered:
+              summary: Unregistered instance
+              value:
+                message:
+                  plan:
+                    name: "Free"
+                    is_public: true
+                  is_registered: false
+                status: 200
+
+    CredentialsRemoved:
+      description: OK - Credentials removed successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RestResponse"
+          examples:
+            success:
+              summary: Credentials removed
+              value:
+                message: "Credentials removed"
+                status: 200
 
     UpdateAccepted:
       description: Accepted - The update request has been accepted for processing.

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -99,8 +99,9 @@ paths:
     delete:
       summary: Delete CTI Credentials
       description: |
-        Removes the stored CTI access token from the credentials index and clears
-        the in-memory plugin variable. After this operation the instance is unregistered.
+        Clears the stored CTI access token document from the credentials index and clears
+        the in-memory plugin variable. The index itself is preserved. After this operation
+        the instance is unregistered.
       operationId: deleteSubscription
       tags:
         - Subscription Management

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -154,7 +154,8 @@ public class ContentManagerPlugin extends Plugin
         this.consumersIndex = new ConsumersIndex(client);
         this.credentialsIndex = new CredentialsIndex(client);
         this.plansService = new PlansServiceImpl();
-        this.subscriptionService = new SubscriptionServiceImpl(this.plansService, this.credentialsIndex);
+        this.subscriptionService =
+                new SubscriptionServiceImpl(this.plansService, this.credentialsIndex);
 
         // Content Manager 5.0
         this.ctiConsole = new CtiConsole();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -315,22 +315,6 @@ public class ContentManagerPlugin extends Plugin
                                                 e);
                                     }
 
-                                    try {
-                                        CreateIndexResponse credentialsResponse = this.credentialsIndex.createIndex();
-                                        if (credentialsResponse != null && credentialsResponse.isAcknowledged()) {
-                                            log.info(
-                                                    "Index created: {} acknowledged={}",
-                                                    credentialsResponse.index(),
-                                                    credentialsResponse.isAcknowledged());
-                                        }
-                                    } catch (Exception e) {
-                                        log.error(
-                                                "Failed to create {} index, due to: {}",
-                                                CredentialsIndex.INDEX_NAME,
-                                                e.getMessage(),
-                                                e);
-                                    }
-
                                     this.tryLoadAccessToken();
                                 } finally {
                                     onComplete.run();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -71,6 +71,8 @@ import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsServiceImpl;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.cti.console.CtiConsole;
+import com.wazuh.contentmanager.cti.console.service.PlansService;
+import com.wazuh.contentmanager.cti.console.service.PlansServiceImpl;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.engine.service.EngineServiceImpl;
 import com.wazuh.contentmanager.jobscheduler.ContentJobParameter;
@@ -107,6 +109,7 @@ public class ContentManagerPlugin extends Plugin
     private Environment environment;
     private ClusterService clusterService;
     private LogtestService logtestService;
+    private PlansService plansService;
 
     /**
      * Initializes the plugin components, including the CTI console, consumer index helpers, and the
@@ -147,6 +150,7 @@ public class ContentManagerPlugin extends Plugin
         this.threadPool = threadPool;
         this.consumersIndex = new ConsumersIndex(client);
         this.credentialsIndex = new CredentialsIndex(client);
+        this.plansService = new PlansServiceImpl();
 
         // Content Manager 5.0
         this.ctiConsole = new CtiConsole();
@@ -244,6 +248,8 @@ public class ContentManagerPlugin extends Plugin
         return List.of(
                 // CTI subscription endpoints
                 new RestPostSubscriptionAction(this.credentialsIndex),
+                new RestGetSubscriptionAction(this.plansService),
+                new RestDeleteSubscriptionAction(this.credentialsIndex),
                 new RestPostUpdateAction(this.catalogSyncJob),
                 // Version check endpoint
                 new RestGetVersionCheckAction(this.environment, this.clusterService),

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -315,6 +315,22 @@ public class ContentManagerPlugin extends Plugin
                                                 e);
                                     }
 
+                                    try {
+                                        CreateIndexResponse credentialsResponse = this.credentialsIndex.createIndex();
+                                        if (credentialsResponse != null && credentialsResponse.isAcknowledged()) {
+                                            log.info(
+                                                    "Index created: {} acknowledged={}",
+                                                    credentialsResponse.index(),
+                                                    credentialsResponse.isAcknowledged());
+                                        }
+                                    } catch (Exception e) {
+                                        log.error(
+                                                "Failed to create {} index, due to: {}",
+                                                CredentialsIndex.INDEX_NAME,
+                                                e.getMessage(),
+                                                e);
+                                    }
+
                                     this.tryLoadAccessToken();
                                 } finally {
                                     onComplete.run();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -70,6 +70,8 @@ import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsServiceImpl;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionServiceImpl;
 import com.wazuh.contentmanager.cti.console.CtiConsole;
 import com.wazuh.contentmanager.cti.console.service.PlansService;
 import com.wazuh.contentmanager.cti.console.service.PlansServiceImpl;
@@ -110,6 +112,7 @@ public class ContentManagerPlugin extends Plugin
     private ClusterService clusterService;
     private LogtestService logtestService;
     private PlansService plansService;
+    private SubscriptionService subscriptionService;
 
     /**
      * Initializes the plugin components, including the CTI console, consumer index helpers, and the
@@ -151,6 +154,7 @@ public class ContentManagerPlugin extends Plugin
         this.consumersIndex = new ConsumersIndex(client);
         this.credentialsIndex = new CredentialsIndex(client);
         this.plansService = new PlansServiceImpl();
+        this.subscriptionService = new SubscriptionServiceImpl(this.plansService, this.credentialsIndex);
 
         // Content Manager 5.0
         this.ctiConsole = new CtiConsole();
@@ -247,9 +251,9 @@ public class ContentManagerPlugin extends Plugin
             Supplier<DiscoveryNodes> nodesInCluster) {
         return List.of(
                 // CTI subscription endpoints
-                new RestPostSubscriptionAction(this.credentialsIndex),
-                new RestGetSubscriptionAction(this.plansService),
-                new RestDeleteSubscriptionAction(this.credentialsIndex),
+                new RestPostSubscriptionAction(this.subscriptionService),
+                new RestGetSubscriptionAction(this.subscriptionService),
+                new RestDeleteSubscriptionAction(this.subscriptionService),
                 new RestPostUpdateAction(this.catalogSyncJob),
                 // Version check endpoint
                 new RestGetVersionCheckAction(this.environment, this.clusterService),

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
@@ -77,6 +77,9 @@ public class CredentialsIndex {
      */
     public IndexResponse storeCredentials(String accessToken)
             throws ExecutionException, InterruptedException, TimeoutException, IOException {
+        if (!this.exists()) {
+            this.createIndex();
+        }
         if (!ClusterInfo.indexStatusCheck(
                 this.client, INDEX_NAME, this.pluginSettings.getClientTimeout())) {
             throw new RuntimeException("Index not ready: " + INDEX_NAME);
@@ -126,6 +129,9 @@ public class CredentialsIndex {
      */
     public DeleteResponse deleteDocument()
             throws ExecutionException, InterruptedException, TimeoutException {
+        if (!this.exists()) {
+            return null;
+        }
         DeleteRequest request = new DeleteRequest(INDEX_NAME, DOCUMENT_ID);
         return this.client
                 .delete(request)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
@@ -22,10 +22,12 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.transport.client.Client;
@@ -112,6 +114,24 @@ public class CredentialsIndex {
         }
         Map<String, Object> source = response.getSourceAsMap();
         return source != null ? (String) source.get(ACCESS_TOKEN_FIELD) : null;
+    }
+
+    /**
+     * Deletes the credentials index entirely.
+     *
+     * @return the AcknowledgedResponse from the operation.
+     * @throws ExecutionException if the client failed to execute the request.
+     * @throws InterruptedException if the current thread was interrupted.
+     * @throws TimeoutException if the operation exceeded the configured timeout.
+     */
+    public AcknowledgedResponse deleteIndex()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        DeleteIndexRequest request = new DeleteIndexRequest(INDEX_NAME);
+        return this.client
+                .admin()
+                .indices()
+                .delete(request)
+                .get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
@@ -78,6 +78,7 @@ public class CredentialsIndex {
     public IndexResponse storeCredentials(String accessToken)
             throws ExecutionException, InterruptedException, TimeoutException, IOException {
         if (!this.exists()) {
+            log.info("Index [{}] not found. Recreating before storing credentials.", INDEX_NAME);
             this.createIndex();
         }
         if (!ClusterInfo.indexStatusCheck(
@@ -130,6 +131,7 @@ public class CredentialsIndex {
     public DeleteResponse deleteDocument()
             throws ExecutionException, InterruptedException, TimeoutException {
         if (!this.exists()) {
+            log.debug("Index [{}] does not exist, nothing to delete.", INDEX_NAME);
             return null;
         }
         DeleteRequest request = new DeleteRequest(INDEX_NAME, DOCUMENT_ID);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
@@ -22,12 +22,12 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
-import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.transport.client.Client;
@@ -117,19 +117,17 @@ public class CredentialsIndex {
     }
 
     /**
-     * Deletes the credentials index entirely.
+     * Deletes the credentials document from the index, preserving the index itself.
      *
-     * @return the AcknowledgedResponse from the operation.
+     * @return the DeleteResponse from the operation.
      * @throws ExecutionException if the client failed to execute the request.
      * @throws InterruptedException if the current thread was interrupted.
      * @throws TimeoutException if the operation exceeded the configured timeout.
      */
-    public AcknowledgedResponse deleteIndex()
+    public DeleteResponse deleteDocument()
             throws ExecutionException, InterruptedException, TimeoutException {
-        DeleteIndexRequest request = new DeleteIndexRequest(INDEX_NAME);
+        DeleteRequest request = new DeleteRequest(INDEX_NAME, DOCUMENT_ID);
         return this.client
-                .admin()
-                .indices()
                 .delete(request)
                 .get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import com.wazuh.contentmanager.cti.console.model.Plan;
+
+/** Service interface for managing the CTI subscription: get status, register, and unregister. */
+public interface SubscriptionService {
+
+    /**
+     * Returns the active CTI plan for this environment.
+     *
+     * <p>If a valid access token is present, the authenticated plan is returned. If the token is
+     * invalid or expired, the credentials document is deleted, the in-memory token is cleared, and
+     * the public plan is returned as a fallback.
+     *
+     * @return the active {@link Plan}, or the public plan if the token is invalid or absent.
+     */
+    Plan getPlan();
+
+    /**
+     * Stores the access token in the credentials index and updates the in-memory token.
+     *
+     * @param accessToken the CTI access token to persist.
+     * @throws Exception if storing the credentials fails.
+     */
+    void register(String accessToken) throws Exception;
+
+    /**
+     * Removes the credentials document from the index and clears the in-memory token.
+     *
+     * @throws Exception if deleting the credentials document fails.
+     */
+    void unregister() throws Exception;
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.cti.console.model.Plan;
+import com.wazuh.contentmanager.cti.console.model.Token;
+import com.wazuh.contentmanager.cti.console.service.PlansService;
+import com.wazuh.contentmanager.settings.PluginSettings;
+
+/** Centralizes CTI subscription logic: get status, register, and unregister. */
+public class SubscriptionServiceImpl implements SubscriptionService {
+    private static final Logger log = LogManager.getLogger(SubscriptionServiceImpl.class);
+
+    private final PlansService plansService;
+    private final CredentialsIndex credentialsIndex;
+
+    /**
+     * Constructs a new SubscriptionServiceImpl.
+     *
+     * @param plansService the service used to fetch CTI plans from the console API.
+     * @param credentialsIndex the index used to persist and remove the access token.
+     */
+    public SubscriptionServiceImpl(PlansService plansService, CredentialsIndex credentialsIndex) {
+        this.plansService = plansService;
+        this.credentialsIndex = credentialsIndex;
+    }
+
+    @Override
+    public Plan getPlan() {
+        String accessToken = PluginSettings.getInstance().getAccessToken();
+        if (accessToken != null) {
+            Plan plan = this.plansService.getMyPlan(new Token(accessToken, "Bearer"));
+            if (plan != null) {
+                return plan;
+            }
+            try {
+                this.credentialsIndex.deleteDocument();
+            } catch (Exception e) {
+                log.warn("Failed to delete invalid credentials document: {}", e.getMessage());
+            }
+            PluginSettings.getInstance().setAccessToken(null);
+        }
+        return this.plansService.getPlan();
+    }
+
+    @Override
+    public void register(String accessToken) throws Exception {
+        this.credentialsIndex.storeCredentials(accessToken);
+        PluginSettings.getInstance().setAccessToken(accessToken);
+    }
+
+    @Override
+    public void unregister() throws Exception {
+        this.credentialsIndex.deleteDocument();
+        PluginSettings.getInstance().setAccessToken(null);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImpl.java
@@ -51,6 +51,8 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             if (plan != null) {
                 return plan;
             }
+            log.info(
+                    "Access token is invalid or expired. Clearing credentials and falling back to public plan.");
             try {
                 this.credentialsIndex.deleteDocument();
             } catch (Exception e) {
@@ -65,11 +67,14 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     public void register(String accessToken) throws Exception {
         this.credentialsIndex.storeCredentials(accessToken);
         PluginSettings.getInstance().setAccessToken(accessToken);
+        log.info(
+                "Access token stored successfully. Registration will be confirmed on next plan retrieval.");
     }
 
     @Override
     public void unregister() throws Exception {
         this.credentialsIndex.deleteDocument();
         PluginSettings.getInstance().setAccessToken(null);
+        log.info("Access token removed successfully. Environment is now unregistered.");
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
@@ -49,7 +49,7 @@ import com.wazuh.contentmanager.settings.PluginSettings;
 /** CTI Console API client. */
 public class ApiClient {
 
-    private static final String BASE_URI = "https://localhost:8443";
+    private static final String BASE_URI = "https://api.pre.cloud.wazuh.com";
     private static final String API_PREFIX = "/api/v1";
     private static final String TOKEN_URI = BASE_URI + API_PREFIX + "/instances/token";
     private static final String PRODUCTS_URI = BASE_URI + API_PREFIX + "/instances/me";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansService.java
@@ -41,4 +41,13 @@ public interface PlansService extends ClosableHttpClient {
      * @return the applicable {@link Plan}, or {@code null} on error.
      */
     Plan getPlan();
+
+    /**
+     * Retrieves the plan for the registered environment using the provided token.
+     *
+     * @param token the authentication {@link Token}.
+     * @return the environment's active {@link Plan}, or {@code null} if the token is invalid or the
+     *     request fails.
+     */
+    Plan getMyPlan(Token token);
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeoutException;
 import com.wazuh.contentmanager.cti.console.model.CatalogPlansResponse;
 import com.wazuh.contentmanager.cti.console.model.Plan;
 import com.wazuh.contentmanager.cti.console.model.Token;
+import com.wazuh.contentmanager.settings.PluginSettings;
 
 /** Implementation of the PlansService interface. */
 public class PlansServiceImpl extends AbstractService implements PlansService {
@@ -118,6 +119,10 @@ public class PlansServiceImpl extends AbstractService implements PlansService {
 
     @Override
     public Plan getPlan() {
+        String accessToken = PluginSettings.getInstance().getAccessToken();
+        if (accessToken != null) {
+            return getMyPlan(new Token(accessToken, "Bearer"));
+        }
         return getPublicPlan();
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansServiceImpl.java
@@ -59,9 +59,6 @@ public class PlansServiceImpl extends AbstractService implements PlansService {
             // Perform request to the environment-specific endpoint
             SimpleHttpResponse response = this.client.getEnvironmentMe(token);
 
-            log.info("CTI Response Status: {}", response.getCode());
-            log.info("CTI Response Body: {}", response.getBodyText());
-
             if (response.getCode() == 401) {
                 log.error("Authentication failed: The environment token is invalid or missing.");
             } else if (response.getCode() == 200) {
@@ -72,7 +69,14 @@ public class PlansServiceImpl extends AbstractService implements PlansService {
                 List<Plan> plans =
                         this.mapper.readerFor(new TypeReference<List<Plan>>() {}).readValue(root);
 
-                return (plans != null && !plans.isEmpty()) ? plans.get(0) : null;
+                if (plans != null && !plans.isEmpty()) {
+                    log.info(
+                            "Active plan for registered environment retrieved successfully from CTI"
+                                    + " Console. Active plan is: {}.",
+                            plans.get(0).getName());
+                    return plans.get(0);
+                }
+                return null;
             } else {
                 log.warn(
                         "Operation to fetch environment plan failed: { \"status_code\": {}, \"message\": {}",
@@ -135,7 +139,14 @@ public class PlansServiceImpl extends AbstractService implements PlansService {
                         this.mapper.readValue(response.getBodyText(), CatalogPlansResponse.class);
 
                 if (parsedResponse.getPlans() != null) {
-                    return parsedResponse.getPlans().stream().filter(Plan::isPublic).findFirst().orElse(null);
+                    Plan publicPlan =
+                            parsedResponse.getPlans().stream().filter(Plan::isPublic).findFirst().orElse(null);
+                    if (publicPlan != null) {
+                        log.info(
+                                "Public plan retrieved successfully from CTI Console. Active plan" + " is: {}.",
+                                publicPlan.getName());
+                    }
+                    return publicPlan;
                 }
             } else {
                 log.warn(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/service/PlansServiceImpl.java
@@ -60,7 +60,7 @@ public class PlansServiceImpl extends AbstractService implements PlansService {
             SimpleHttpResponse response = this.client.getEnvironmentMe(token);
 
             if (response.getCode() == 401) {
-                log.error("Authentication failed: The environment token is invalid or missing.");
+                log.warn("Authentication failed: The environment token is invalid or missing.");
             } else if (response.getCode() == 200) {
                 // The API returns a list of plans, but for this endpoint
                 // it contains only ONE active plan for the environment.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
@@ -26,7 +26,7 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.io.IOException;
 import java.util.List;
 
-import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
@@ -35,9 +35,9 @@ import static org.opensearch.rest.RestRequest.Method.DELETE;
 /**
  * DELETE /_plugins/_content_manager/subscription
  *
- * <p>Removes the stored CTI credentials: clears the credentials document inside {@code
- * .wazuh-cti-credentials} and clears the in-memory token in {@link PluginSettings}. The index
- * itself is preserved.
+ * <p>Removes stored CTI credentials by delegating to {@link SubscriptionService#unregister()},
+ * which clears both the credentials document in {@code .wazuh-cti-credentials} and the in-memory
+ * token in {@link PluginSettings}.
  *
  * <p>Possible HTTP responses:
  *
@@ -49,22 +49,28 @@ import static org.opensearch.rest.RestRequest.Method.DELETE;
 public class RestDeleteSubscriptionAction extends BaseRestHandler {
     private static final String ENDPOINT_NAME = "content_manager_subscription_delete";
     private static final String ENDPOINT_UNIQUE_NAME = "plugin:content_manager/subscription_delete";
-    private final CredentialsIndex credentialsIndex;
+    private final SubscriptionService subscriptionService;
 
     /**
      * Create a new REST action.
      *
-     * @param credentialsIndex the index used to persist and delete the access token
+     * @param subscriptionService the service used to remove stored credentials
      */
-    public RestDeleteSubscriptionAction(CredentialsIndex credentialsIndex) {
-        this.credentialsIndex = credentialsIndex;
+    public RestDeleteSubscriptionAction(SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
     }
 
+    /** Return a short identifier for this handler. */
     @Override
     public String getName() {
         return ENDPOINT_NAME;
     }
 
+    /**
+     * Return the route configuration for this handler.
+     *
+     * @return route configuration for the DELETE endpoint
+     */
     @Override
     public List<Route> routes() {
         return List.of(
@@ -75,21 +81,27 @@ public class RestDeleteSubscriptionAction extends BaseRestHandler {
                         .build());
     }
 
+    /**
+     * Handles incoming requests by delegating to {@link #handleRequest()}.
+     *
+     * @param request the incoming REST request
+     * @param client the node client
+     * @return a consumer that sends the credential removal response
+     */
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         return channel -> channel.sendResponse(this.handleRequest());
     }
 
     /**
-     * Deletes the credentials document and clears the in-memory access token.
+     * Delegates to {@link SubscriptionService#unregister()} and returns the appropriate response.
      *
      * @return a {@link BytesRestResponse} representing the operation result
      * @throws IOException if an I/O error occurs while building the response
      */
     public BytesRestResponse handleRequest() throws IOException {
         try {
-            this.credentialsIndex.deleteDocument();
-            PluginSettings.getInstance().setAccessToken(null);
+            this.subscriptionService.unregister();
             RestResponse response = new RestResponse("Credentials removed", RestStatus.OK.getStatus());
             return new BytesRestResponse(RestStatus.OK, response.toXContent());
         } catch (Exception e) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024-2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.NamedRoute;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import com.wazuh.contentmanager.settings.PluginSettings;
+
+import static org.opensearch.rest.RestRequest.Method.DELETE;
+
+/**
+ * DELETE /_plugins/_content_manager/subscription
+ *
+ * <p>Removes the stored CTI credentials: deletes the document from {@code .wazuh-cti-credentials}
+ * and clears the in-memory token in {@link PluginSettings}.
+ *
+ * <p>Possible HTTP responses:
+ *
+ * <ul>
+ *   <li>200 OK: Credentials removed successfully.
+ *   <li>500 Internal Server Error: Unexpected error during processing.
+ * </ul>
+ */
+public class RestDeleteSubscriptionAction extends BaseRestHandler {
+    private static final String ENDPOINT_NAME = "content_manager_subscription_delete";
+    private static final String ENDPOINT_UNIQUE_NAME = "plugin:content_manager/subscription_delete";
+    private final CredentialsIndex credentialsIndex;
+
+    /**
+     * Create a new REST action.
+     *
+     * @param credentialsIndex the index used to persist and delete the access token
+     */
+    public RestDeleteSubscriptionAction(CredentialsIndex credentialsIndex) {
+        this.credentialsIndex = credentialsIndex;
+    }
+
+    @Override
+    public String getName() {
+        return ENDPOINT_NAME;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+                new NamedRoute.Builder()
+                        .path(PluginSettings.SUBSCRIPTION_URI)
+                        .method(DELETE)
+                        .uniqueName(ENDPOINT_UNIQUE_NAME)
+                        .build());
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> channel.sendResponse(this.handleRequest());
+    }
+
+    /**
+     * Deletes the credentials index and clears the in-memory access token.
+     *
+     * @return a {@link BytesRestResponse} representing the operation result
+     * @throws IOException if an I/O error occurs while building the response
+     */
+    public BytesRestResponse handleRequest() throws IOException {
+        try {
+            this.credentialsIndex.deleteIndex();
+            PluginSettings.getInstance().setAccessToken(null);
+            RestResponse response = new RestResponse("Credentials removed", RestStatus.OK.getStatus());
+            return new BytesRestResponse(RestStatus.OK, response.toXContent());
+        } catch (Exception e) {
+            RestResponse error =
+                    new RestResponse(
+                            e.getMessage() != null
+                                    ? e.getMessage()
+                                    : "An unexpected error occurred while processing your request.",
+                            RestStatus.INTERNAL_SERVER_ERROR.getStatus());
+            return new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, error.toXContent());
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
@@ -35,8 +35,9 @@ import static org.opensearch.rest.RestRequest.Method.DELETE;
 /**
  * DELETE /_plugins/_content_manager/subscription
  *
- * <p>Removes the stored CTI credentials: deletes the document from {@code .wazuh-cti-credentials}
- * and clears the in-memory token in {@link PluginSettings}.
+ * <p>Removes the stored CTI credentials: clears the credentials document inside {@code
+ * .wazuh-cti-credentials} and clears the in-memory token in {@link PluginSettings}. The index
+ * itself is preserved.
  *
  * <p>Possible HTTP responses:
  *
@@ -80,14 +81,14 @@ public class RestDeleteSubscriptionAction extends BaseRestHandler {
     }
 
     /**
-     * Deletes the credentials index and clears the in-memory access token.
+     * Deletes the credentials document and clears the in-memory access token.
      *
      * @return a {@link BytesRestResponse} representing the operation result
      * @throws IOException if an I/O error occurs while building the response
      */
     public BytesRestResponse handleRequest() throws IOException {
         try {
-            this.credentialsIndex.deleteIndex();
+            this.credentialsIndex.deleteDocument();
             PluginSettings.getInstance().setAccessToken(null);
             RestResponse response = new RestResponse("Credentials removed", RestStatus.OK.getStatus());
             return new BytesRestResponse(RestStatus.OK, response.toXContent());

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
@@ -35,8 +35,8 @@ import static org.opensearch.rest.RestRequest.Method.DELETE;
 /**
  * DELETE /_plugins/_content_manager/subscription
  *
- * <p>Removes the stored CTI credentials: deletes the document from {@code .wazuh-cti-credentials}
- * and clears the in-memory token in {@link PluginSettings}.
+ * <p>Removes the stored CTI credentials: deletes the index {@code .wazuh-cti-credentials} and
+ * clears the in-memory token in {@link PluginSettings}.
  *
  * <p>Possible HTTP responses:
  *

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionAction.java
@@ -35,8 +35,8 @@ import static org.opensearch.rest.RestRequest.Method.DELETE;
 /**
  * DELETE /_plugins/_content_manager/subscription
  *
- * <p>Removes the stored CTI credentials: deletes the index {@code .wazuh-cti-credentials} and
- * clears the in-memory token in {@link PluginSettings}.
+ * <p>Removes the stored CTI credentials: deletes the document from {@code .wazuh-cti-credentials}
+ * and clears the in-memory token in {@link PluginSettings}.
  *
  * <p>Possible HTTP responses:
  *

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionAction.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2024-2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.NamedRoute;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.wazuh.contentmanager.cti.console.model.Plan;
+import com.wazuh.contentmanager.cti.console.service.PlansService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import com.wazuh.contentmanager.settings.PluginSettings;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+/**
+ * GET /_plugins/_content_manager/subscription
+ *
+ * <p>Returns the subscription status and active plan. Delegates to {@link PlansService#getPlan()},
+ * which routes to the authenticated or public CTI endpoint based on whether an access token is
+ * present in {@link PluginSettings}.
+ *
+ * <p>Possible HTTP responses:
+ *
+ * <ul>
+ *   <li>200 OK: Returns plan name, is_public flag, and is_registered state.
+ *   <li>500 Internal Server Error: Unexpected error during processing.
+ * </ul>
+ */
+public class RestGetSubscriptionAction extends BaseRestHandler {
+    private static final String ENDPOINT_NAME = "content_manager_subscription_get";
+    private static final String ENDPOINT_UNIQUE_NAME = "plugin:content_manager/subscription_get";
+    private final PlansService plansService;
+
+    /**
+     * Construct the REST handler.
+     *
+     * @param plansService the service used to retrieve the active plan
+     */
+    public RestGetSubscriptionAction(PlansService plansService) {
+        this.plansService = plansService;
+    }
+
+    @Override
+    public String getName() {
+        return ENDPOINT_NAME;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+                new NamedRoute.Builder()
+                        .path(PluginSettings.SUBSCRIPTION_URI)
+                        .method(GET)
+                        .uniqueName(ENDPOINT_UNIQUE_NAME)
+                        .build());
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> channel.sendResponse(this.handleRequest());
+    }
+
+    /**
+     * Builds the subscription status response.
+     *
+     * @return a {@link BytesRestResponse} with the nested plan and registration state
+     * @throws IOException if an I/O error occurs while building the response
+     */
+    public BytesRestResponse handleRequest() throws IOException {
+        try {
+            boolean isRegistered = PluginSettings.getInstance().getAccessToken() != null;
+            Plan plan = this.plansService.getPlan();
+
+            XContentBuilder builder =
+                    XContentFactory.jsonBuilder()
+                            .startObject()
+                            .startObject("message")
+                            .startObject("plan")
+                            .field("name", plan != null ? plan.getName() : null)
+                            .field("is_public", plan != null && plan.isPublic())
+                            .endObject()
+                            .field("is_registered", isRegistered)
+                            .endObject()
+                            .field("status", RestStatus.OK.getStatus())
+                            .endObject();
+
+            return new BytesRestResponse(RestStatus.OK, builder);
+        } catch (Exception e) {
+            RestResponse error =
+                    new RestResponse(
+                            e.getMessage() != null
+                                    ? e.getMessage()
+                                    : "An unexpected error occurred while processing your request.",
+                            RestStatus.INTERNAL_SERVER_ERROR.getStatus());
+            return new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, error.toXContent());
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionAction.java
@@ -28,8 +28,8 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.io.IOException;
 import java.util.List;
 
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
 import com.wazuh.contentmanager.cti.console.model.Plan;
-import com.wazuh.contentmanager.cti.console.service.PlansService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
@@ -38,9 +38,11 @@ import static org.opensearch.rest.RestRequest.Method.GET;
 /**
  * GET /_plugins/_content_manager/subscription
  *
- * <p>Returns the subscription status and active plan. Delegates to {@link PlansService#getPlan()},
- * which routes to the authenticated or public CTI endpoint based on whether an access token is
- * present in {@link PluginSettings}.
+ * <p>Returns the subscription status and active plan. Delegates to {@link
+ * SubscriptionService#getPlan()}, which routes to the authenticated or public CTI endpoint based on
+ * whether an access token is present in {@link PluginSettings}. The registration state is read
+ * after {@code getPlan()} returns so that any token invalidation performed inside the service is
+ * reflected in the response.
  *
  * <p>Possible HTTP responses:
  *
@@ -52,22 +54,28 @@ import static org.opensearch.rest.RestRequest.Method.GET;
 public class RestGetSubscriptionAction extends BaseRestHandler {
     private static final String ENDPOINT_NAME = "content_manager_subscription_get";
     private static final String ENDPOINT_UNIQUE_NAME = "plugin:content_manager/subscription_get";
-    private final PlansService plansService;
+    private final SubscriptionService subscriptionService;
 
     /**
      * Construct the REST handler.
      *
-     * @param plansService the service used to retrieve the active plan
+     * @param subscriptionService the service used to retrieve the active plan
      */
-    public RestGetSubscriptionAction(PlansService plansService) {
-        this.plansService = plansService;
+    public RestGetSubscriptionAction(SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
     }
 
+    /** Return a short identifier for this handler. */
     @Override
     public String getName() {
         return ENDPOINT_NAME;
     }
 
+    /**
+     * Return the route configuration for this handler.
+     *
+     * @return route configuration for the GET endpoint
+     */
     @Override
     public List<Route> routes() {
         return List.of(
@@ -78,6 +86,13 @@ public class RestGetSubscriptionAction extends BaseRestHandler {
                         .build());
     }
 
+    /**
+     * Handles incoming requests by delegating to {@link #handleRequest()}.
+     *
+     * @param request the incoming REST request
+     * @param client the node client
+     * @return a consumer that sends the subscription status response
+     */
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         return channel -> channel.sendResponse(this.handleRequest());
@@ -91,8 +106,8 @@ public class RestGetSubscriptionAction extends BaseRestHandler {
      */
     public BytesRestResponse handleRequest() throws IOException {
         try {
+            Plan plan = this.subscriptionService.getPlan();
             boolean isRegistered = PluginSettings.getInstance().getAccessToken() != null;
-            Plan plan = this.plansService.getPlan();
 
             XContentBuilder builder =
                     XContentFactory.jsonBuilder()

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
@@ -27,7 +27,7 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.io.IOException;
 import java.util.List;
 
-import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
@@ -36,34 +36,34 @@ import static org.opensearch.rest.RestRequest.Method.POST;
 /**
  * POST /_plugins/_content_manager/subscription
  *
- * <p>Stores the provided CTI access token in the credentials index and in the plugin-wide
- * PluginSettings variable.
+ * <p>Stores the provided CTI access token by delegating to {@link
+ * SubscriptionService#register(String)}.
  *
- * <p>Possible HTTP responses: - 201 Created: Credentials stored successfully. - 400 Bad Request:
- * Missing or empty access_token field. - 500 Internal Server Error: Unexpected error during
- * processing.
+ * <p>Possible HTTP responses:
+ *
+ * <ul>
+ *   <li>201 Created: Credentials stored successfully.
+ *   <li>400 Bad Request: Missing or empty access_token field.
+ *   <li>500 Internal Server Error: Unexpected error during processing.
+ * </ul>
  */
 public class RestPostSubscriptionAction extends BaseRestHandler {
     private static final String ENDPOINT_NAME = "content_manager_subscription_post";
     private static final String ENDPOINT_UNIQUE_NAME = "plugin:content_manager/subscription_post";
     private static final String ACCESS_TOKEN_FIELD = "access_token";
 
-    private final CredentialsIndex credentialsIndex;
+    private final SubscriptionService subscriptionService;
 
     /**
      * Constructs the REST handler.
      *
-     * @param credentialsIndex the index used to persist the access token
+     * @param subscriptionService the service used to register credentials
      */
-    public RestPostSubscriptionAction(CredentialsIndex credentialsIndex) {
-        this.credentialsIndex = credentialsIndex;
+    public RestPostSubscriptionAction(SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
     }
 
-    /**
-     * Return a short name identifying this handler.
-     *
-     * @return a short name identifying this handler
-     */
+    /** Return a short identifier for this handler. */
     @Override
     public String getName() {
         return ENDPOINT_NAME;
@@ -72,7 +72,7 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
     /**
      * Return the route configuration for this handler.
      *
-     * @return route configuration for POST subscription
+     * @return route configuration for the POST endpoint
      */
     @Override
     public List<Route> routes() {
@@ -85,11 +85,11 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
     }
 
     /**
-     * Prepares the request for execution.
+     * Handles incoming requests by delegating to {@link #handleRequest(RestRequest)}.
      *
      * @param request the incoming REST request
      * @param client the node client
-     * @return a RestChannelConsumer to handle the request
+     * @return a consumer that sends the subscription registration response
      */
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
@@ -97,8 +97,8 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
     }
 
     /**
-     * Parses the request payload, validates the access_token field, persists it, and updates the
-     * plugin-wide variable.
+     * Parses the request payload, validates the access_token field, and delegates to {@link
+     * SubscriptionService#register(String)}.
      *
      * @param request the incoming REST request
      * @return a BytesRestResponse representing the operation result
@@ -127,8 +127,7 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
         }
 
         try {
-            this.credentialsIndex.storeCredentials(accessToken);
-            PluginSettings.getInstance().setAccessToken(accessToken);
+            this.subscriptionService.register(accessToken);
 
             RestResponse response =
                     new RestResponse("Credentials received", RestStatus.CREATED.getStatus());

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
@@ -127,6 +127,9 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
         }
 
         try {
+            if (!this.credentialsIndex.exists()) {
+                this.credentialsIndex.createIndex();
+            }
             this.credentialsIndex.storeCredentials(accessToken);
             PluginSettings.getInstance().setAccessToken(accessToken);
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
@@ -127,9 +127,6 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
         }
 
         try {
-            if (!this.credentialsIndex.exists()) {
-                this.credentialsIndex.createIndex();
-            }
             this.credentialsIndex.storeCredentials(accessToken);
             PluginSettings.getInstance().setAccessToken(accessToken);
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
@@ -17,11 +17,14 @@
 package com.wazuh.contentmanager.cti.catalog.index;
 
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.IndicesAdminClient;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -127,5 +130,28 @@ public class CredentialsIndexTests extends OpenSearchTestCase {
                 };
 
         Assert.assertEquals("my-token", idx.getAccessToken());
+    }
+
+    /**
+     * deleteIndex() calls client.admin().indices().delete() and returns the acknowledged response.
+     */
+    @SuppressWarnings("unchecked")
+    public void testDeleteIndex() throws Exception {
+        Client client = mock(Client.class);
+        AdminClient admin = mock(AdminClient.class);
+        IndicesAdminClient indicesAdmin = mock(IndicesAdminClient.class);
+        ActionFuture<AcknowledgedResponse> future = mock(ActionFuture.class);
+        AcknowledgedResponse ackResponse = mock(AcknowledgedResponse.class);
+
+        when(client.admin()).thenReturn(admin);
+        when(admin.indices()).thenReturn(indicesAdmin);
+        when(indicesAdmin.delete(any())).thenReturn(future);
+        when(future.get(anyLong(), any())).thenReturn(ackResponse);
+
+        CredentialsIndex idx = new CredentialsIndex(client);
+        AcknowledgedResponse result = idx.deleteIndex();
+
+        Assert.assertNotNull(result);
+        verify(indicesAdmin, times(1)).delete(any());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
@@ -16,15 +16,13 @@
  */
 package com.wazuh.contentmanager.cti.catalog.index;
 
+import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
-import org.opensearch.transport.client.IndicesAdminClient;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -132,26 +130,20 @@ public class CredentialsIndexTests extends OpenSearchTestCase {
         Assert.assertEquals("my-token", idx.getAccessToken());
     }
 
-    /**
-     * deleteIndex() calls client.admin().indices().delete() and returns the acknowledged response.
-     */
+    /** deleteDocument() calls client.delete() and returns the delete response. */
     @SuppressWarnings("unchecked")
-    public void testDeleteIndex() throws Exception {
+    public void testDeleteDocument() throws Exception {
         Client client = mock(Client.class);
-        AdminClient admin = mock(AdminClient.class);
-        IndicesAdminClient indicesAdmin = mock(IndicesAdminClient.class);
-        ActionFuture<AcknowledgedResponse> future = mock(ActionFuture.class);
-        AcknowledgedResponse ackResponse = mock(AcknowledgedResponse.class);
+        ActionFuture<DeleteResponse> future = mock(ActionFuture.class);
+        DeleteResponse deleteResponse = mock(DeleteResponse.class);
 
-        when(client.admin()).thenReturn(admin);
-        when(admin.indices()).thenReturn(indicesAdmin);
-        when(indicesAdmin.delete(any())).thenReturn(future);
-        when(future.get(anyLong(), any())).thenReturn(ackResponse);
+        when(client.delete(any())).thenReturn(future);
+        when(future.get(anyLong(), any())).thenReturn(deleteResponse);
 
         CredentialsIndex idx = new CredentialsIndex(client);
-        AcknowledgedResponse result = idx.deleteIndex();
+        DeleteResponse result = idx.deleteDocument();
 
         Assert.assertNotNull(result);
-        verify(indicesAdmin, times(1)).delete(any());
+        verify(client, times(1)).delete(any());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
@@ -130,7 +130,7 @@ public class CredentialsIndexTests extends OpenSearchTestCase {
         Assert.assertEquals("my-token", idx.getAccessToken());
     }
 
-    /** deleteDocument() calls client.delete() and returns the delete response. */
+    /** deleteDocument() calls client.delete() and returns the delete response when index exists. */
     @SuppressWarnings("unchecked")
     public void testDeleteDocument() throws Exception {
         Client client = mock(Client.class);
@@ -140,10 +140,42 @@ public class CredentialsIndexTests extends OpenSearchTestCase {
         when(client.delete(any())).thenReturn(future);
         when(future.get(anyLong(), any())).thenReturn(deleteResponse);
 
-        CredentialsIndex idx = new CredentialsIndex(client);
+        CredentialsIndex idx = spy(new CredentialsIndex(client));
+        doReturn(true).when(idx).exists();
         DeleteResponse result = idx.deleteDocument();
 
         Assert.assertNotNull(result);
         verify(client, times(1)).delete(any());
+    }
+
+    /** deleteDocument() returns null without calling the client when the index does not exist. */
+    public void testDeleteDocument_NoOp_WhenIndexMissing() throws Exception {
+        Client client = mock(Client.class);
+
+        CredentialsIndex idx = spy(new CredentialsIndex(client));
+        doReturn(false).when(idx).exists();
+
+        DeleteResponse result = idx.deleteDocument();
+
+        Assert.assertNull(result);
+        verify(client, never()).delete(any());
+    }
+
+    /** storeCredentials() calls createIndex() before writing when the index does not exist. */
+    @SuppressWarnings("unchecked")
+    public void testStoreCredentials_RecreatesIndex_WhenMissing() throws Exception {
+        Client client = mock(Client.class);
+
+        CredentialsIndex idx = spy(new CredentialsIndex(client));
+        doReturn(false).when(idx).exists();
+        doReturn(null).when(idx).createIndex();
+
+        try {
+            idx.storeCredentials("my-token");
+        } catch (RuntimeException ignored) {
+            // ClusterInfo.indexStatusCheck is unavailable in unit tests (expected)
+        }
+
+        verify(idx, times(1)).createIndex();
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImplTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2024-2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.lang.reflect.Field;
+
+import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.cti.console.model.Plan;
+import com.wazuh.contentmanager.cti.console.model.Token;
+import com.wazuh.contentmanager.cti.console.service.PlansService;
+import com.wazuh.contentmanager.settings.PluginSettings;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class SubscriptionServiceImplTests extends OpenSearchTestCase {
+
+    private PlansService plansService;
+    private CredentialsIndex credentialsIndex;
+    private SubscriptionServiceImpl service;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        clearPluginSettingsInstance();
+        PluginSettings.getInstance(org.opensearch.common.settings.Settings.EMPTY);
+        this.plansService = mock(PlansService.class);
+        this.credentialsIndex = mock(CredentialsIndex.class);
+        this.service = new SubscriptionServiceImpl(this.plansService, this.credentialsIndex);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clearPluginSettingsInstance();
+        super.tearDown();
+    }
+
+    @SuppressForbidden(reason = "Unit test reset")
+    private static void clearPluginSettingsInstance() throws Exception {
+        Field f = PluginSettings.class.getDeclaredField("INSTANCE");
+        f.setAccessible(true);
+        f.set(null, null);
+    }
+
+    /** Token present and valid → returns plan from getMyPlan(); does not fall back. */
+    public void testGetPlan_ValidToken() {
+        PluginSettings.getInstance().setAccessToken("valid-token");
+        Plan plan = mock(Plan.class);
+        when(this.plansService.getMyPlan(any(Token.class))).thenReturn(plan);
+
+        Plan result = this.service.getPlan();
+
+        Assert.assertSame(plan, result);
+        ArgumentCaptor<Token> tokenCaptor = ArgumentCaptor.forClass(Token.class);
+        verify(this.plansService).getMyPlan(tokenCaptor.capture());
+        Assert.assertEquals("valid-token", tokenCaptor.getValue().getAccessToken());
+        Assert.assertEquals("Bearer", tokenCaptor.getValue().getTokenType());
+        verify(this.plansService, never()).getPlan();
+    }
+
+    /**
+     * Token present but getMyPlan() returns null (invalid token) → deletes credentials
+     * document, clears in-memory token, and falls back to the public plan.
+     */
+    public void testGetPlan_InvalidToken_FallsBackToPublicPlan() throws Exception {
+        PluginSettings.getInstance().setAccessToken("bad-token");
+        when(this.plansService.getMyPlan(any(Token.class))).thenReturn(null);
+        Plan publicPlan = mock(Plan.class);
+        when(this.plansService.getPlan()).thenReturn(publicPlan);
+
+        Plan result = this.service.getPlan();
+
+        Assert.assertSame(publicPlan, result);
+        verify(this.credentialsIndex).deleteDocument();
+        Assert.assertNull(PluginSettings.getInstance().getAccessToken());
+    }
+
+    /** No token in PluginSettings → calls getPlan() directly without attempting getMyPlan(). */
+    public void testGetPlan_NoToken() {
+        Plan publicPlan = mock(Plan.class);
+        when(this.plansService.getPlan()).thenReturn(publicPlan);
+
+        Plan result = this.service.getPlan();
+
+        Assert.assertSame(publicPlan, result);
+        verify(this.plansService, never()).getMyPlan(any());
+        verify(this.plansService).getPlan();
+    }
+
+    /** register() persists credentials and updates the in-memory token. */
+    public void testRegister() throws Exception {
+        this.service.register("new-token");
+
+        verify(this.credentialsIndex).storeCredentials("new-token");
+        Assert.assertEquals("new-token", PluginSettings.getInstance().getAccessToken());
+    }
+
+    /**
+     * Token invalid and deleteDocument() throws → exception is swallowed, token still cleared, falls
+     * back to public plan.
+     */
+    public void testGetPlan_InvalidToken_DeleteThrows_StillFallsBackToPublicPlan() throws Exception {
+        PluginSettings.getInstance().setAccessToken("bad-token");
+        when(this.plansService.getMyPlan(any(Token.class))).thenReturn(null);
+        doThrow(new RuntimeException("index gone")).when(this.credentialsIndex).deleteDocument();
+        Plan publicPlan = mock(Plan.class);
+        when(this.plansService.getPlan()).thenReturn(publicPlan);
+
+        Plan result = this.service.getPlan();
+
+        Assert.assertSame(publicPlan, result);
+        Assert.assertNull(PluginSettings.getInstance().getAccessToken());
+    }
+
+    /** unregister() deletes the credentials document and clears the in-memory token. */
+    public void testUnregister() throws Exception {
+        PluginSettings.getInstance().setAccessToken("existing-token");
+
+        this.service.unregister();
+
+        verify(this.credentialsIndex).deleteDocument();
+        Assert.assertNull(PluginSettings.getInstance().getAccessToken());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SubscriptionServiceImplTests.java
@@ -81,8 +81,8 @@ public class SubscriptionServiceImplTests extends OpenSearchTestCase {
     }
 
     /**
-     * Token present but getMyPlan() returns null (invalid token) → deletes credentials
-     * document, clears in-memory token, and falls back to the public plan.
+     * Token present but getMyPlan() returns null (invalid token) → deletes credentials document,
+     * clears in-memory token, and falls back to the public plan.
      */
     public void testGetPlan_InvalidToken_FallsBackToPublicPlan() throws Exception {
         PluginSettings.getInstance().setAccessToken("bad-token");

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/console/service/PlansServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/console/service/PlansServiceTests.java
@@ -18,12 +18,14 @@ package com.wazuh.contentmanager.cti.console.service;
 
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.core5.http.ContentType;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -54,22 +56,20 @@ public class PlansServiceTests extends OpenSearchTestCase {
     private PlansService plansService;
     @Mock private ApiClient mockClient;
 
+    @SuppressForbidden(reason = "Unit test reset")
+    private static void clearPluginSettingsInstance() throws Exception {
+        Field f = PluginSettings.class.getDeclaredField("INSTANCE");
+        f.setAccessible(true);
+        f.set(null, null);
+    }
+
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
-
-        try {
-            PluginSettings.getInstance(Settings.EMPTY);
-        } catch (IllegalStateException e) {
-            // Already initialized
-        }
-
-        // Mock CTI Console API Client
+        clearPluginSettingsInstance();
+        PluginSettings.getInstance(Settings.EMPTY);
         this.mockClient = mock(ApiClient.class);
-
-        // Create service and replace its client with the mock
-        // Note: This creates a real ApiClient internally first, which needs to be closed
         this.plansService = new PlansServiceImpl();
         this.plansService.setClient(this.mockClient);
     }
@@ -77,11 +77,11 @@ public class PlansServiceTests extends OpenSearchTestCase {
     @Override
     @After
     public void tearDown() throws Exception {
-        super.tearDown();
-        // Close the service to properly shut down the HTTP client
         if (this.plansService != null) {
             this.plansService.close();
         }
+        clearPluginSettingsInstance();
+        super.tearDown();
     }
 
     /**
@@ -249,5 +249,59 @@ public class PlansServiceTests extends OpenSearchTestCase {
         Plan plan = ((PlansServiceImpl) this.plansService).getMyPlan(new Token("anyToken", "Bearer"));
 
         Assert.assertNull("Should return null on API error code", plan);
+    }
+
+    /** getPlan() when accessToken is set must delegate to getMyPlan(). */
+    public void testGetPlanWhenRegistered()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        PluginSettings.getInstance().setAccessToken("test-bearer-token");
+
+        // spotless:off
+        String response = """
+            {
+              "name": "env-01",
+              "organization": { "name": "Acme" },
+              "plans": [
+                { "name": "Premium Plan", "is_public": false, "features": [] }
+              ]
+            }""";
+        // spotless:on
+        when(this.mockClient.getEnvironmentMe(any(Token.class)))
+                .thenReturn(
+                        SimpleHttpResponse.create(
+                                200, response.getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_JSON));
+
+        Plan plan = this.plansService.getPlan();
+
+        Assert.assertNotNull(plan);
+        Assert.assertEquals("Premium Plan", plan.getName());
+        verify(this.mockClient, times(1)).getEnvironmentMe(any(Token.class));
+        verify(this.mockClient, times(0)).getCatalogPlans();
+    }
+
+    /** getPlan() when accessToken is null must delegate to getPublicPlan(). */
+    public void testGetPlanWhenUnregistered()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        // accessToken is null by default after setUp()
+
+        // spotless:off
+        String response = """
+            {
+              "plans": [
+                { "name": "Free", "is_public": true, "features": [] }
+              ]
+            }""";
+        // spotless:on
+        when(this.mockClient.getCatalogPlans())
+                .thenReturn(
+                        SimpleHttpResponse.create(
+                                200, response.getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_JSON));
+
+        Plan plan = this.plansService.getPlan();
+
+        Assert.assertNotNull(plan);
+        Assert.assertTrue(plan.isPublic());
+        verify(this.mockClient, times(1)).getCatalogPlans();
+        verify(this.mockClient, times(0)).getEnvironmentMe(any(Token.class));
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionActionTests.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 
 import java.lang.reflect.Field;
 
-import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
 import static org.mockito.Mockito.*;
@@ -34,10 +34,10 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests for {@link RestDeleteSubscriptionAction}.
  *
- * <p>Validates credential removal, in-memory token cleanup, and error handling.
+ * <p>Validates credential removal and error handling via a mocked {@link SubscriptionService}.
  */
 public class RestDeleteSubscriptionActionTests extends OpenSearchTestCase {
-    private CredentialsIndex credentialsIndex;
+    private SubscriptionService subscriptionService;
     private RestDeleteSubscriptionAction action;
 
     @Before
@@ -46,8 +46,8 @@ public class RestDeleteSubscriptionActionTests extends OpenSearchTestCase {
         super.setUp();
         clearPluginSettingsInstance();
         PluginSettings.getInstance(org.opensearch.common.settings.Settings.EMPTY);
-        this.credentialsIndex = mock(CredentialsIndex.class);
-        this.action = new RestDeleteSubscriptionAction(this.credentialsIndex);
+        this.subscriptionService = mock(SubscriptionService.class);
+        this.action = new RestDeleteSubscriptionAction(this.subscriptionService);
     }
 
     @After
@@ -63,23 +63,20 @@ public class RestDeleteSubscriptionActionTests extends OpenSearchTestCase {
         f.set(null, null);
     }
 
-    /** Successful deletion returns 200 "Credentials removed" and clears the in-memory token. */
-    public void testDeleteCredentials200() throws Exception {
-        PluginSettings.getInstance().setAccessToken("some-token");
-
+    /** Successful deletion returns 200 "Credentials removed" and delegates to unregister(). */
+    public void testDeleteSubscription200() throws Exception {
         BytesRestResponse response = this.action.handleRequest();
 
         Assert.assertEquals(RestStatus.OK, response.status());
         String body = response.content().utf8ToString();
         Assert.assertTrue(body.contains("Credentials removed"));
         Assert.assertTrue(body.contains("200"));
-        Assert.assertNull(PluginSettings.getInstance().getAccessToken());
-        verify(this.credentialsIndex, times(1)).deleteDocument();
+        verify(this.subscriptionService, times(1)).unregister();
     }
 
-    /** When deleteDocument() throws, returns 500 with the error message. */
-    public void testDeleteCredentials500() throws Exception {
-        doThrow(new RuntimeException("Delete failed")).when(this.credentialsIndex).deleteDocument();
+    /** When unregister() throws, returns 500 with the error message. */
+    public void testDeleteSubscription500() throws Exception {
+        doThrow(new RuntimeException("Delete failed")).when(this.subscriptionService).unregister();
 
         BytesRestResponse response = this.action.handleRequest();
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionActionTests.java
@@ -74,16 +74,16 @@ public class RestDeleteSubscriptionActionTests extends OpenSearchTestCase {
         Assert.assertTrue(body.contains("Credentials removed"));
         Assert.assertTrue(body.contains("200"));
         Assert.assertNull(PluginSettings.getInstance().getAccessToken());
-        verify(this.credentialsIndex, times(1)).deleteIndex();
+        verify(this.credentialsIndex, times(1)).deleteDocument();
     }
 
-    /** When deleteIndex() throws, returns 500 with the error message. */
+    /** When deleteDocument() throws, returns 500 with the error message. */
     public void testDeleteCredentials500() throws Exception {
-        doThrow(new RuntimeException("Index not ready")).when(this.credentialsIndex).deleteIndex();
+        doThrow(new RuntimeException("Delete failed")).when(this.credentialsIndex).deleteDocument();
 
         BytesRestResponse response = this.action.handleRequest();
 
         Assert.assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
-        Assert.assertTrue(response.content().utf8ToString().contains("Index not ready"));
+        Assert.assertTrue(response.content().utf8ToString().contains("Delete failed"));
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestDeleteSubscriptionActionTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024-2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.lang.reflect.Field;
+
+import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.settings.PluginSettings;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link RestDeleteSubscriptionAction}.
+ *
+ * <p>Validates credential removal, in-memory token cleanup, and error handling.
+ */
+public class RestDeleteSubscriptionActionTests extends OpenSearchTestCase {
+    private CredentialsIndex credentialsIndex;
+    private RestDeleteSubscriptionAction action;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        clearPluginSettingsInstance();
+        PluginSettings.getInstance(org.opensearch.common.settings.Settings.EMPTY);
+        this.credentialsIndex = mock(CredentialsIndex.class);
+        this.action = new RestDeleteSubscriptionAction(this.credentialsIndex);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clearPluginSettingsInstance();
+        super.tearDown();
+    }
+
+    @SuppressForbidden(reason = "Unit test reset")
+    private static void clearPluginSettingsInstance() throws Exception {
+        Field f = PluginSettings.class.getDeclaredField("INSTANCE");
+        f.setAccessible(true);
+        f.set(null, null);
+    }
+
+    /** Successful deletion returns 200 "Credentials removed" and clears the in-memory token. */
+    public void testDeleteCredentials200() throws Exception {
+        PluginSettings.getInstance().setAccessToken("some-token");
+
+        BytesRestResponse response = this.action.handleRequest();
+
+        Assert.assertEquals(RestStatus.OK, response.status());
+        String body = response.content().utf8ToString();
+        Assert.assertTrue(body.contains("Credentials removed"));
+        Assert.assertTrue(body.contains("200"));
+        Assert.assertNull(PluginSettings.getInstance().getAccessToken());
+        verify(this.credentialsIndex, times(1)).deleteIndex();
+    }
+
+    /** When deleteIndex() throws, returns 500 with the error message. */
+    public void testDeleteCredentials500() throws Exception {
+        doThrow(new RuntimeException("Index not ready")).when(this.credentialsIndex).deleteIndex();
+
+        BytesRestResponse response = this.action.handleRequest();
+
+        Assert.assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
+        Assert.assertTrue(response.content().utf8ToString().contains("Index not ready"));
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionActionTests.java
@@ -28,19 +28,14 @@ import org.junit.Before;
 
 import java.lang.reflect.Field;
 
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
 import com.wazuh.contentmanager.cti.console.model.Plan;
-import com.wazuh.contentmanager.cti.console.service.PlansService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
 import static org.mockito.Mockito.*;
 
-/**
- * Unit tests for {@link RestGetSubscriptionAction}.
- *
- * <p>Validates the nested JSON response shape and correct registration state detection.
- */
 public class RestGetSubscriptionActionTests extends OpenSearchTestCase {
-    private PlansService plansService;
+    private SubscriptionService subscriptionService;
     private RestGetSubscriptionAction action;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -50,8 +45,8 @@ public class RestGetSubscriptionActionTests extends OpenSearchTestCase {
         super.setUp();
         clearPluginSettingsInstance();
         PluginSettings.getInstance(org.opensearch.common.settings.Settings.EMPTY);
-        this.plansService = mock(PlansService.class);
-        this.action = new RestGetSubscriptionAction(this.plansService);
+        this.subscriptionService = mock(SubscriptionService.class);
+        this.action = new RestGetSubscriptionAction(this.subscriptionService);
     }
 
     @After
@@ -67,14 +62,11 @@ public class RestGetSubscriptionActionTests extends OpenSearchTestCase {
         f.set(null, null);
     }
 
-    /**
-     * Registered instance: accessToken set, getPlan() returns a plan. Response must contain plan
-     * name, is_public and is_registered=true.
-     */
+    /** Token present (registered) → 200 with plan details and "is_registered":true. */
     public void testGetSubscription200_Registered() throws Exception {
         PluginSettings.getInstance().setAccessToken("bearer-token");
         Plan plan = MAPPER.readValue("{\"name\":\"Premium Plan\",\"is_public\":false}", Plan.class);
-        when(this.plansService.getPlan()).thenReturn(plan);
+        when(this.subscriptionService.getPlan()).thenReturn(plan);
 
         BytesRestResponse response = this.action.handleRequest();
 
@@ -86,13 +78,10 @@ public class RestGetSubscriptionActionTests extends OpenSearchTestCase {
         Assert.assertTrue(body.contains("\"status\":200"));
     }
 
-    /**
-     * Unregistered instance: accessToken null, getPlan() returns public plan. Response must contain
-     * is_registered=false.
-     */
+    /** No token (unregistered) → 200 with public plan and "is_registered":false. */
     public void testGetSubscription200_Unregistered() throws Exception {
         Plan plan = MAPPER.readValue("{\"name\":\"Free\",\"is_public\":true}", Plan.class);
-        when(this.plansService.getPlan()).thenReturn(plan);
+        when(this.subscriptionService.getPlan()).thenReturn(plan);
 
         BytesRestResponse response = this.action.handleRequest();
 
@@ -102,9 +91,9 @@ public class RestGetSubscriptionActionTests extends OpenSearchTestCase {
         Assert.assertTrue(body.contains("Free"));
     }
 
-    /** When getPlan() throws, returns 500 with the error message. */
+    /** getPlan() throws → 500 with the error message. */
     public void testGetSubscription500() throws Exception {
-        when(this.plansService.getPlan()).thenThrow(new RuntimeException("CTI unreachable"));
+        when(this.subscriptionService.getPlan()).thenThrow(new RuntimeException("CTI unreachable"));
 
         BytesRestResponse response = this.action.handleRequest();
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestGetSubscriptionActionTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024-2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.lang.reflect.Field;
+
+import com.wazuh.contentmanager.cti.console.model.Plan;
+import com.wazuh.contentmanager.cti.console.service.PlansService;
+import com.wazuh.contentmanager.settings.PluginSettings;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link RestGetSubscriptionAction}.
+ *
+ * <p>Validates the nested JSON response shape and correct registration state detection.
+ */
+public class RestGetSubscriptionActionTests extends OpenSearchTestCase {
+    private PlansService plansService;
+    private RestGetSubscriptionAction action;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        clearPluginSettingsInstance();
+        PluginSettings.getInstance(org.opensearch.common.settings.Settings.EMPTY);
+        this.plansService = mock(PlansService.class);
+        this.action = new RestGetSubscriptionAction(this.plansService);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clearPluginSettingsInstance();
+        super.tearDown();
+    }
+
+    @SuppressForbidden(reason = "Unit test reset")
+    private static void clearPluginSettingsInstance() throws Exception {
+        Field f = PluginSettings.class.getDeclaredField("INSTANCE");
+        f.setAccessible(true);
+        f.set(null, null);
+    }
+
+    /**
+     * Registered instance: accessToken set, getPlan() returns a plan. Response must contain plan
+     * name, is_public and is_registered=true.
+     */
+    public void testGetSubscription200_Registered() throws Exception {
+        PluginSettings.getInstance().setAccessToken("bearer-token");
+        Plan plan = MAPPER.readValue("{\"name\":\"Premium Plan\",\"is_public\":false}", Plan.class);
+        when(this.plansService.getPlan()).thenReturn(plan);
+
+        BytesRestResponse response = this.action.handleRequest();
+
+        Assert.assertEquals(RestStatus.OK, response.status());
+        String body = response.content().utf8ToString();
+        Assert.assertTrue(body.contains("Premium Plan"));
+        Assert.assertTrue(body.contains("\"is_public\":false"));
+        Assert.assertTrue(body.contains("\"is_registered\":true"));
+        Assert.assertTrue(body.contains("\"status\":200"));
+    }
+
+    /**
+     * Unregistered instance: accessToken null, getPlan() returns public plan. Response must contain
+     * is_registered=false.
+     */
+    public void testGetSubscription200_Unregistered() throws Exception {
+        Plan plan = MAPPER.readValue("{\"name\":\"Free\",\"is_public\":true}", Plan.class);
+        when(this.plansService.getPlan()).thenReturn(plan);
+
+        BytesRestResponse response = this.action.handleRequest();
+
+        Assert.assertEquals(RestStatus.OK, response.status());
+        String body = response.content().utf8ToString();
+        Assert.assertTrue(body.contains("\"is_registered\":false"));
+        Assert.assertTrue(body.contains("Free"));
+    }
+
+    /** When getPlan() throws, returns 500 with the error message. */
+    public void testGetSubscription500() throws Exception {
+        when(this.plansService.getPlan()).thenThrow(new RuntimeException("CTI unreachable"));
+
+        BytesRestResponse response = this.action.handleRequest();
+
+        Assert.assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
+        Assert.assertTrue(response.content().utf8ToString().contains("CTI unreachable"));
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionActionTests.java
@@ -32,13 +32,13 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 
-import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
 import static org.mockito.Mockito.*;
 
 public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
-    private CredentialsIndex credentialsIndex;
+    private SubscriptionService subscriptionService;
     private RestPostSubscriptionAction action;
 
     @Before
@@ -47,8 +47,8 @@ public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
         super.setUp();
         clearPluginSettingsInstance();
         PluginSettings.getInstance(org.opensearch.common.settings.Settings.EMPTY);
-        this.credentialsIndex = mock(CredentialsIndex.class);
-        this.action = new RestPostSubscriptionAction(this.credentialsIndex);
+        this.subscriptionService = mock(SubscriptionService.class);
+        this.action = new RestPostSubscriptionAction(this.subscriptionService);
     }
 
     @After
@@ -70,8 +70,8 @@ public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
                 .build();
     }
 
-    /** Valid access_token → 201 with "Credentials received" */
-    public void testPostCredentials201() throws Exception {
+    /** Valid access_token → 201 with "Credentials received" and delegates to register(). */
+    public void testPostSubscription201() throws Exception {
         RestRequest request = buildRequest("{\"access_token\": \"my-token-abc\"}");
 
         BytesRestResponse response = this.action.handleRequest(request);
@@ -80,13 +80,11 @@ public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
         String body = response.content().utf8ToString();
         Assert.assertTrue(body.contains("Credentials received"));
         Assert.assertTrue(body.contains(String.valueOf(RestStatus.CREATED.getStatus())));
-
-        verify(this.credentialsIndex, times(1)).storeCredentials("my-token-abc");
-        Assert.assertEquals("my-token-abc", PluginSettings.getInstance().getAccessToken());
+        verify(this.subscriptionService, times(1)).register("my-token-abc");
     }
 
     /** Missing access_token field → 400 with "Missing [access_token] field." */
-    public void testPostCredentials400_MissingField() throws IOException {
+    public void testPostSubscription400_MissingField() throws IOException {
         RestRequest request = buildRequest("{}");
 
         BytesRestResponse response = this.action.handleRequest(request);
@@ -97,7 +95,7 @@ public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
     }
 
     /** access_token present but empty → 400 */
-    public void testPostCredentials400_EmptyToken() throws IOException {
+    public void testPostSubscription400_EmptyToken() throws IOException {
         RestRequest request = buildRequest("{\"access_token\": \"\"}");
 
         BytesRestResponse response = this.action.handleRequest(request);
@@ -108,7 +106,7 @@ public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
     }
 
     /** access_token present but blank (whitespace) → 400 */
-    public void testPostCredentials400_BlankToken() throws IOException {
+    public void testPostSubscription400_BlankToken() throws IOException {
         RestRequest request = buildRequest("{\"access_token\": \"   \"}");
 
         BytesRestResponse response = this.action.handleRequest(request);
@@ -116,12 +114,10 @@ public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
         Assert.assertEquals(RestStatus.BAD_REQUEST, response.status());
     }
 
-    /** Index throws → 500 */
-    public void testPostCredentials500_IndexError() throws Exception {
+    /** register() throws → 500 */
+    public void testPostSubscription500_IndexError() throws Exception {
         RestRequest request = buildRequest("{\"access_token\": \"tok\"}");
-        doThrow(new RuntimeException("Index not ready"))
-                .when(this.credentialsIndex)
-                .storeCredentials("tok");
+        doThrow(new RuntimeException("Index not ready")).when(this.subscriptionService).register("tok");
 
         BytesRestResponse response = this.action.handleRequest(request);
 


### PR DESCRIPTION
### Description

Implements the `GET` and `DELETE` endpoints for the CTI subscription API.
`GET` returns the active plan and registration status; `DELETE` removes only
the credentials document from `.wazuh-cti-credentials`, preserving the index.
`POST` now recreates the index automatically if it was manually deleted before
storing the token. The subscription logic (plan retrieval, credential registration and removal)
is centralized behind a `SubscriptionService` interface and its corresponding
`SubscriptionServiceImpl`.

A bug was fixed where a stored but invalid or expired token caused `GET` to
return `is_registered: true` with no plan data. The token is now validated on
retrieval ,if the CTI API rejects it, the credentials are cleared automatically
and the response falls back to the public free plan with `is_registered: false`.

Logging was improved and the API reference was updated to document the new behaviors.

### Issues Resolved
Closes IDR4697
