### PR TITLE
Add support for pre-registered deployments via keystore-seeded CTI token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement GET /platform/environments/me API service [(#1134)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1134)
 - Implement token exchange service [(#1130)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1130)
 - Implement catalog plans service [(#1135)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1135)
-- Add support for pre-registered deployments via keystore-seeded CTI token
+- Add support for pre-registered deployments via keystore-seeded CTI token [(#1146)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1146)
 
 ### Dependencies
 - Upgrade to Gradle 8.14.3 [(#649)](https://github.com/wazuh/wazuh-indexer-plugins/pull/649)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement GET /platform/environments/me API service [(#1134)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1134)
 - Implement token exchange service [(#1130)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1130)
 - Implement catalog plans service [(#1135)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1135)
+- Add support for pre-registered deployments via keystore-seeded CTI token
 
 ### Dependencies
 - Upgrade to Gradle 8.14.3 [(#649)](https://github.com/wazuh/wazuh-indexer-plugins/pull/649)

--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -21,6 +21,7 @@ The Content Manager plugin is configured through settings in `opensearch.yml`. A
 | `plugins.content_manager.cve.content.consumer`       | String  | `public-vulnerabilities-5`               | CVE content consumer identifier                                                 |
 | `plugins.content_manager.catalog.create_detectors`   | Boolean | `true`                                   | Automatically create Security Analytics detectors from CTI content              |
 | `plugins.content_manager.telemetry.enabled`          | Boolean | `true`                                   | Enable or disable the daily Update check service ping. This setting is dynamic. |
+| `plugins.content_manager.preregistered`              | Boolean | `false`                                  | Mark the deployment as pre-registered. When `true`, the permanent CTI token is read from the keystore key `plugins.content_manager.cti.token` and seeded into the credentials index on first start. |
 
 ## Configuration Examples
 
@@ -73,6 +74,25 @@ plugins.content_manager.max_items_per_bulk: 10
 plugins.content_manager.max_concurrent_bulks: 2
 plugins.content_manager.client.timeout: 30
 ```
+
+### Pre-registered Deployments
+
+Cloud and other pre-provisioned deployments may ship with a permanent CTI token already issued. In this mode, the device-code subscription flow (`POST /_plugins/_content_manager/subscription`) is not required on first boot — the token is seeded from the OpenSearch keystore.
+
+1. Add the token to the keystore on every node:
+
+   ```bash
+   bin/opensearch-keystore add plugins.content_manager.cti.token
+   ```
+
+2. Enable the toggle in `opensearch.yml`:
+
+   ```yaml
+   # opensearch.yml
+   plugins.content_manager.preregistered: true
+   ```
+
+On the cluster manager node, the token is written to `.wazuh-cti-credentials` and loaded into memory before the initial catalog sync runs. The credentials index remains the runtime source of truth — once seeded, the keystore value is not re-read on subsequent restarts. The `POST /subscription` endpoint stays available and can be used to overwrite the token at any time.
 
 ### Disable Security Analytics Detector Creation
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -215,8 +215,9 @@ public class ContentManagerPlugin extends Plugin
                         this.scheduleTelemetryPingJob();
                     });
         } else {
-            // Non-CM nodes load credentials asynchronously on startup.
-            this.threadPool.generic().execute(this::tryLoadAccessToken);
+            // Non-CM nodes load credentials asynchronously on startup. They never persist the
+            // keystore seed — only the cluster manager writes to .wazuh-cti-credentials.
+            this.threadPool.generic().execute(() -> this.tryLoadAccessToken(false));
         }
     }
 
@@ -325,7 +326,7 @@ public class ContentManagerPlugin extends Plugin
                                                 e);
                                     }
 
-                                    this.tryLoadAccessToken();
+                                    this.tryLoadAccessToken(true);
                                 } finally {
                                     onComplete.run();
                                 }
@@ -337,29 +338,67 @@ public class ContentManagerPlugin extends Plugin
     }
 
     /**
-     * Attempts to load the CTI access token from the credentials index into memory.
+     * Attempts to load the CTI access token from the credentials index into memory. When the
+     * deployment is pre-registered and the credentials index has no token yet, falls back to the
+     * token read from the OpenSearch keystore at plugin startup, persists it to the credentials index
+     * (cluster manager only), and loads it into memory.
      *
      * <p>NOTE: The in-memory token is only updated on the node that handles the POST /subscription
      * request. Other nodes in the cluster will not see the new token until they are restarted. A
      * cluster-wide propagation mechanism (e.g. cluster state metadata or an internal transport
      * action) may be needed in the future to keep all nodes in sync without restart.
+     *
+     * @param canPersistSeed whether this caller is allowed to write the keystore seed to the
+     *     credentials index. Only the cluster manager node should pass {@code true}.
      */
-    private void tryLoadAccessToken() {
+    private void tryLoadAccessToken(boolean canPersistSeed) {
         try {
             if (this.credentialsIndex.exists()) {
                 String token = this.credentialsIndex.getAccessToken();
                 if (token != null) {
                     PluginSettings.getInstance().setAccessToken(token);
                     log.info("CTI access token loaded from credentials index.");
-                } else {
-                    log.debug("Credentials index exists but no access token is stored.");
+                    return;
                 }
+                log.debug("Credentials index exists but no access token is stored.");
             } else {
                 log.debug("Credentials index does not exist yet; access token not loaded.");
             }
+
+            this.trySeedAccessTokenFromKeystore(canPersistSeed);
         } catch (Exception e) {
             log.warn("Could not load CTI access token from credentials index: {}", e.getMessage());
         }
+    }
+
+    /**
+     * Seeds the credentials index and in-memory token from the OpenSearch keystore, when the
+     * deployment is configured as pre-registered. No-op when the toggle is off.
+     *
+     * @param canPersistSeed when {@code true}, writes the seed to the credentials index. Set this
+     *     only on the cluster manager node.
+     */
+    private void trySeedAccessTokenFromKeystore(boolean canPersistSeed) {
+        PluginSettings settings = PluginSettings.getInstance();
+        if (!settings.isPreregistered()) {
+            return;
+        }
+        String seed = settings.getKeystoreSeedToken();
+        if (seed == null) {
+            log.warn(
+                    "Pre-registered mode is enabled but no '{}' keystore entry was found.",
+                    PluginSettings.CTI_TOKEN.getKey());
+            return;
+        }
+        if (canPersistSeed) {
+            try {
+                this.credentialsIndex.storeCredentials(seed);
+                log.info("CTI access token seeded from keystore into credentials index.");
+            } catch (Exception e) {
+                log.warn("Failed to persist keystore-seeded CTI access token: {}", e.getMessage());
+            }
+        }
+        settings.setAccessToken(seed);
     }
 
     /** Check if the index exists; if not, create it with specific settings. */
@@ -632,7 +671,9 @@ public class ContentManagerPlugin extends Plugin
                 PluginSettings.CVE_CONSUMER,
                 PluginSettings.PIT_KEEPALIVE,
                 PluginSettings.ENGINE_MOCK_ENABLED,
-                PluginSettings.CREATE_DETECTORS);
+                PluginSettings.CREATE_DETECTORS,
+                PluginSettings.PREREGISTERED,
+                PluginSettings.CTI_TOKEN);
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -18,8 +18,10 @@ package com.wazuh.contentmanager.settings;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.SecureSetting;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.settings.SecureString;
 
 import com.wazuh.contentmanager.utils.Constants;
 import org.jspecify.annotations.NonNull;
@@ -227,6 +229,25 @@ public class PluginSettings {
                     Setting.Property.NodeScope,
                     Setting.Property.Dynamic);
 
+    /**
+     * Pre-registered deployment toggle. When {@code true} and {@link #CTI_TOKEN} is set in the
+     * keystore, the permanent CTI token is seeded into the credentials index on cluster manager
+     * startup if it is not already present.
+     */
+    public static final Setting<Boolean> PREREGISTERED =
+            Setting.boolSetting(
+                    "plugins.content_manager.preregistered",
+                    false,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Filtered);
+
+    /**
+     * Permanent CTI access token for pre-registered deployments. Sourced from the OpenSearch
+     * keystore. Used only as a seed; the credentials index remains the runtime source of truth.
+     */
+    public static final Setting<SecureString> CTI_TOKEN =
+            SecureSetting.secureString("plugins.content_manager.cti.token", null);
+
     private final String ctiBaseUrl;
     private final int maximumItemsPerBulk;
     private final int maximumConcurrentBulks;
@@ -243,6 +264,8 @@ public class PluginSettings {
     private final long pitKeepalive;
     private final boolean engineMockEnabled;
     private final boolean createDetectors;
+    private final boolean preregistered;
+    private final String keystoreSeedToken;
     private volatile boolean isTelemetryEnabled;
     private volatile String accessToken;
     private String version;
@@ -270,7 +293,27 @@ public class PluginSettings {
         this.engineMockEnabled = ENGINE_MOCK_ENABLED.get(settings);
         this.createDetectors = CREATE_DETECTORS.get(settings);
         this.isTelemetryEnabled = TELEMETRY_ENABLED.get(settings);
+        this.preregistered = PREREGISTERED.get(settings);
+        this.keystoreSeedToken = readKeystoreSeedToken(settings);
         log.debug("Settings.loaded: {}", this.toString());
+    }
+
+    /**
+     * Reads the CTI token from the OpenSearch keystore and returns it as a String. The {@link
+     * SecureString} is closed (and its backing char array zeroed) before returning. The keystore is
+     * closed by OpenSearch shortly after {@code createComponents()}, so this MUST run during {@link
+     * PluginSettings} construction.
+     *
+     * @param settings node settings used to access the keystore.
+     * @return the token, or {@code null} if the key is unset or empty.
+     */
+    private static String readKeystoreSeedToken(@NonNull final Settings settings) {
+        try (SecureString secure = CTI_TOKEN.get(settings)) {
+            if (secure == null || secure.length() == 0) {
+                return null;
+            }
+            return secure.toString();
+        }
     }
 
     /**
@@ -320,6 +363,25 @@ public class PluginSettings {
      */
     public String getAccessToken() {
         return this.accessToken;
+    }
+
+    /**
+     * Retrieves the value of the pre-registered deployment toggle.
+     *
+     * @return {@code true} when the deployment is pre-registered.
+     */
+    public boolean isPreregistered() {
+        return this.preregistered;
+    }
+
+    /**
+     * Retrieves the CTI token read from the OpenSearch keystore at construction time. Used as a
+     * one-time seed for the credentials index when {@link #isPreregistered()} is {@code true}.
+     *
+     * @return the keystore-sourced token, or {@code null} if unset.
+     */
+    public String getKeystoreSeedToken() {
+        return this.keystoreSeedToken;
     }
 
     /**

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
@@ -18,12 +18,14 @@ package com.wazuh.contentmanager;
 
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 
 import java.lang.reflect.Field;
@@ -31,6 +33,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.ExecutorService;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
+import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
 import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.jobscheduler.jobs.TelemetryPingJob;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -59,6 +62,7 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
     @Mock private CatalogSyncJob catalogSyncJob;
     @Mock private TelemetryPingJob telemetryPingJob;
     @Mock private ConsumersIndex consumersIndex;
+    @Mock private CredentialsIndex credentialsIndex;
 
     /** Sets up the test environment before each test method. */
     @Before
@@ -83,6 +87,7 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
         this.injectField(this.plugin, "catalogSyncJob", this.catalogSyncJob);
         this.injectField(this.plugin, "telemetryPingJob", this.telemetryPingJob);
         this.injectField(this.plugin, "consumersIndex", this.consumersIndex);
+        this.injectField(this.plugin, "credentialsIndex", this.credentialsIndex);
 
         ContentManagerPluginTests.clearInstance();
     }
@@ -240,6 +245,90 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
         verify(this.catalogSyncJob, never()).trigger();
     }
 
+    /**
+     * When the credentials index already has a token, the keystore seed must be ignored even if
+     * pre-registered mode is on.
+     */
+    public void testTryLoadAccessTokenIndexWinsOverKeystore() throws Exception {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("plugins.content_manager.cti.token", "keystore-token");
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.preregistered", true)
+                        .setSecureSettings(secureSettings)
+                        .build();
+        PluginSettings.getInstance(settings);
+
+        when(this.credentialsIndex.exists()).thenReturn(true);
+        when(this.credentialsIndex.getAccessToken()).thenReturn("index-token");
+
+        this.invokePrivateBoolMethod("tryLoadAccessToken", true);
+
+        Assert.assertEquals("index-token", PluginSettings.getInstance().getAccessToken());
+        verify(this.credentialsIndex, never()).storeCredentials(anyString());
+    }
+
+    /**
+     * When the credentials index is empty, pre-registered is true, the keystore seed is set, and the
+     * caller may persist, the seed must be written to the index and loaded into memory.
+     */
+    public void testTryLoadAccessTokenSeedsFromKeystoreOnClusterManager() throws Exception {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("plugins.content_manager.cti.token", "keystore-token");
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.preregistered", true)
+                        .setSecureSettings(secureSettings)
+                        .build();
+        PluginSettings.getInstance(settings);
+
+        when(this.credentialsIndex.exists()).thenReturn(true);
+        when(this.credentialsIndex.getAccessToken()).thenReturn(null);
+
+        this.invokePrivateBoolMethod("tryLoadAccessToken", true);
+
+        verify(this.credentialsIndex).storeCredentials("keystore-token");
+        Assert.assertEquals("keystore-token", PluginSettings.getInstance().getAccessToken());
+    }
+
+    /** A non-cluster-manager caller must never write the keystore seed to the index. */
+    public void testTryLoadAccessTokenSeedNotPersistedOnNonClusterManager() throws Exception {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("plugins.content_manager.cti.token", "keystore-token");
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.preregistered", true)
+                        .setSecureSettings(secureSettings)
+                        .build();
+        PluginSettings.getInstance(settings);
+
+        when(this.credentialsIndex.exists()).thenReturn(true);
+        when(this.credentialsIndex.getAccessToken()).thenReturn(null);
+
+        this.invokePrivateBoolMethod("tryLoadAccessToken", false);
+
+        verify(this.credentialsIndex, never()).storeCredentials(anyString());
+        Assert.assertEquals("keystore-token", PluginSettings.getInstance().getAccessToken());
+    }
+
+    /**
+     * When pre-registered is enabled but no keystore seed is present, no token must be loaded and
+     * nothing is written.
+     */
+    public void testTryLoadAccessTokenPreregisteredMissingKeystore() throws Exception {
+        Settings settings =
+                Settings.builder().put("plugins.content_manager.preregistered", true).build();
+        PluginSettings.getInstance(settings);
+
+        when(this.credentialsIndex.exists()).thenReturn(true);
+        when(this.credentialsIndex.getAccessToken()).thenReturn(null);
+
+        this.invokePrivateBoolMethod("tryLoadAccessToken", true);
+
+        verify(this.credentialsIndex, never()).storeCredentials(anyString());
+        Assert.assertNull(PluginSettings.getInstance().getAccessToken());
+    }
+
     /** Helper to inject private fields via reflection. */
     @SuppressForbidden(reason = "Unit test injection")
     private void injectField(Object target, String fieldName, Object value) throws Exception {
@@ -252,6 +341,14 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
     @SuppressForbidden(reason = "Unit test reflection")
     private void invokePrivateIntMethod(String methodName, int value) throws Exception {
         Method method = ContentManagerPlugin.class.getDeclaredMethod(methodName, int.class);
+        method.setAccessible(true);
+        method.invoke(this.plugin, value);
+    }
+
+    /** Helper to invoke a private {@code void method(boolean)} on the plugin via reflection. */
+    @SuppressForbidden(reason = "Unit test reflection")
+    private void invokePrivateBoolMethod(String methodName, boolean value) throws Exception {
+        Method method = ContentManagerPlugin.class.getDeclaredMethod(methodName, boolean.class);
         method.setAccessible(true);
         method.invoke(this.plugin, value);
     }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
@@ -17,6 +17,7 @@
 package com.wazuh.contentmanager.settings;
 
 import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
@@ -150,5 +151,40 @@ public class PluginSettingsTests extends OpenSearchTestCase {
         pluginSettings.setAccessToken("a-token");
         pluginSettings.setAccessToken(null);
         Assert.assertNull(pluginSettings.getAccessToken());
+    }
+
+    /** Tests that preregistered defaults to false and the keystore seed token defaults to null. */
+    public void testPreregisteredDefaults() {
+        PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
+        Assert.assertFalse(pluginSettings.isPreregistered());
+        Assert.assertNull(pluginSettings.getKeystoreSeedToken());
+    }
+
+    /** Tests that the preregistered toggle is read from settings when set. */
+    public void testPreregisteredEnabled() {
+        Settings settings =
+                Settings.builder().put("plugins.content_manager.preregistered", true).build();
+        PluginSettings pluginSettings = PluginSettings.getInstance(settings);
+        Assert.assertTrue(pluginSettings.isPreregistered());
+    }
+
+    /** Tests that the keystore-backed CTI token is read into the seed field at construction. */
+    public void testKeystoreSeedTokenIsLoaded() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("plugins.content_manager.cti.token", "keystore-token-xyz");
+        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
+
+        PluginSettings pluginSettings = PluginSettings.getInstance(settings);
+        Assert.assertEquals("keystore-token-xyz", pluginSettings.getKeystoreSeedToken());
+    }
+
+    /** Tests that an empty keystore value is treated as absent. */
+    public void testKeystoreSeedTokenEmptyIsNull() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString("plugins.content_manager.cti.token", "");
+        Settings settings = Settings.builder().setSecureSettings(secureSettings).build();
+
+        PluginSettings pluginSettings = PluginSettings.getInstance(settings);
+        Assert.assertNull(pluginSettings.getKeystoreSeedToken());
     }
 }


### PR DESCRIPTION
### Description

Adds support for **pre-registered deployments** (e.g. Cloud instances) where the permanent CTI token is provisioned out-of-band in the Wazuh Indexer keystore instead of being requested at runtime via the device-code subscription flow.

Two new settings are introduced:

- `plugins.content_manager.preregistered` [`Setting<Boolean>`], defaults to `false`. Marks the deployment as pre-registered.
- `plugins.content_manager.cti.token` [`SecureSetting<SecureString>`], keystore-only. Holds the permanent CTI token.

When `preregistered=true` and the `.wazuh-cti-credentials` index has no token yet, the cluster manager seeds the index with the keystore-sourced token and loads it into memory before the initial catalog sync runs. The credentials index remains the runtime source of truth, once seeded, the keystore value is not re-read on subsequent restarts. `POST /_plugins/_content_manager/subscription` keeps working and may overwrite the seeded token at any time.

**Changes:**

- `PluginSettings`: declares both settings; reads the `SecureString` once at construction (closed in try-with-resources) and exposes `isPreregistered()` + `getKeystoreSeedToken()`.
- `ContentManagerPlugin`: registers the new settings in `getSettings()`; updates `tryLoadAccessToken(boolean canPersistSeed)` with keystore-seed fallback. The CM-node path passes `true` (allowed to persist), the non-CM path passes `false`.
- Ordering guarantee: `tryLoadAccessToken()` runs inside `start()` before `onComplete.run()` invokes `catalogSyncJob.trigger()`, so the token is loaded before the first sync.
- Unit tests for default/custom settings, keystore loading via `MockSecureSettings`, and the four bootstrap precedence cases (index wins, seed-on-CM, seed-not-persisted-on-non-CM, missing keystore).
- Documentation: `CHANGELOG.md` entry + new "Pre-registered Deployments" section in `docs/ref/modules/content-manager/configuration.md` covering the `opensearch-keystore add` flow.

### Issues Resolved

Closes IDR3528