### PR TITLE
Change initialization to generic thread

### DIFF
--- a/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
@@ -176,31 +176,35 @@ public class SetupPlugin extends Plugin implements ClusterPlugin, ActionPlugin {
     public void onNodeStarted(DiscoveryNode localNode) {
         // Initialize the indices only if this node is the cluster manager node.
         if (localNode.isClusterManagerNode()) {
+            this.threadPool
+                    .generic()
+                    .execute(
+                            () -> {
+                                // Apply cluster.default_number_of_replicas from opensearch.yml settings if present
+                                try {
+                                    String defaultNumberOfReplicas =
+                                            this.clusterService.getSettings().get(CLUSTER_DEFAULT_NUMBER_OF_REPLICAS);
+                                    if (defaultNumberOfReplicas != null) {
+                                        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+                                        request.persistentSettings(
+                                                Settings.builder()
+                                                        .put(CLUSTER_DEFAULT_NUMBER_OF_REPLICAS, defaultNumberOfReplicas)
+                                                        .build());
+                                        this.client
+                                                .admin()
+                                                .cluster()
+                                                .updateSettings(request)
+                                                .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
+                                        log.info(
+                                                "Successfully updated cluster.default_number_of_replicas to {}",
+                                                defaultNumberOfReplicas);
+                                    }
+                                } catch (Exception e) {
+                                    log.error("Failed to update cluster.default_number_of_replicas", e);
+                                }
 
-            // Apply cluster.default_number_of_replicas from opensearch.yml settings if present
-            try {
-                String defaultNumberOfReplicas =
-                        this.clusterService.getSettings().get(CLUSTER_DEFAULT_NUMBER_OF_REPLICAS);
-                if (defaultNumberOfReplicas != null) {
-                    ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
-                    request.persistentSettings(
-                            Settings.builder()
-                                    .put(CLUSTER_DEFAULT_NUMBER_OF_REPLICAS, defaultNumberOfReplicas)
-                                    .build());
-                    this.client
-                            .admin()
-                            .cluster()
-                            .updateSettings(request)
-                            .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
-                    log.info(
-                            "Successfully updated cluster.default_number_of_replicas to {}",
-                            defaultNumberOfReplicas);
-                }
-            } catch (Exception e) {
-                log.error("Failed to update cluster.default_number_of_replicas", e);
-            }
-
-            this.indices.forEach(Index::initialize);
+                                this.indices.forEach(Index::initialize);
+                            });
         }
     }
 


### PR DESCRIPTION
### Description
This PR changes initialization process so now is performed by a generic thread, instead of the bootstrap, this avoids that an accumulation of delays crashes the plugin

### Issues Resolved
Closes https://github.com/wazuh/wazuh-indexer/issues/1418
