### PR TITLE
Initialize root decoder to null on user spaces

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Policy.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Policy.java
@@ -310,12 +310,12 @@ public class Policy {
     }
 
     /**
-     * Sets the root decoder identifier.
+     * Sets the root decoder identifier. Nullable.
      *
-     * @param rootDecoder The root decoder identifier to set. If null, defaults to empty string.
+     * @param rootDecoder The root decoder identifier to set.
      */
     public void setRootDecoder(String rootDecoder) {
-        this.rootDecoder = rootDecoder != null ? rootDecoder : "";
+        this.rootDecoder = rootDecoder;
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -169,7 +169,7 @@ public class SpaceService {
             policy.setTitle(title);
             policy.setDescription(title);
             policy.setAuthor("Custom");
-            policy.setRootDecoder("");
+            policy.setRootDecoder(null);
             policy.setDocumentation("");
             policy.setIntegrations(Collections.emptyList());
             policy.setFilters(Collections.emptyList());


### PR DESCRIPTION
### Description
Initialize root-decoder to null in user spaces to unmask the engine validation error during promotion. 

**Validation**

<img width="1705" height="719" alt="image" src="https://github.com/user-attachments/assets/5cec113a-8efd-411f-82af-5e2987dce80f" />



```json
POST /_plugins/_content_manager/integrations
{
  "resource": {
    "metadata": {
      "description": "This is a test integration.",
      "documentation": "test1234",
      "references": [
        "https://wazuh.com"
      ],
      "title": "findings-enrichment-test",
      "author": "Wazuh Inc."
    },
    "category": "other"
  }
}
GET _plugins/_content_manager/promote?space=draft
POST _plugins/_content_manager/promote
{
  "space": "draft",
  "changes": {
    "kvdbs": [],
    "rules": [],
    "decoders": [],
    "filters": [],
    "integrations": [
      {
        "id": "eee10098-866a-4579-b016-4935b7681914",
        "operation": "add"
      }
    ],
    "policy": [
      {
        "id": "4a2bbfac-1235-37ba-ac04-0cefe3ecace0",
        "operation": "update"
      }
    ]
  }
}
{
  "message": "Promotion completed successfully.",
  "status": 200
}
```

### Issues Resolved
Closes #1158 
