### PR TITLE
Update ruleset consumer to `beta-2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Initialization from snapshots rework [(#1139)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1139)
 - Skip engine validation for engine-unrelated resources promotion [(#1133)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1133)
 - CTI subscription API update [(#1145)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1145)
+- Update ruleset consumer to beta-2 [(#1161)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1161)
 
 ### Deprecated
 -

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -59,7 +59,8 @@ public class PluginSettings {
     private static final boolean DEFAULT_CREATE_DETECTORS = true;
 
     // Default values for catalog consumer URLs
-    private static final String DEFAULT_CATALOG_RULESET = "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta-2-ruleset-5/consumers/public-ruleset-5";
+    private static final String DEFAULT_CATALOG_RULESET =
+            "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta-2-ruleset-5/consumers/public-ruleset-5";
     private static final String DEFAULT_CATALOG_IOCS = "";
     private static final String DEFAULT_CATALOG_VULNERABILITIES = "";
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -59,7 +59,7 @@ public class PluginSettings {
     private static final boolean DEFAULT_CREATE_DETECTORS = true;
 
     // Default values for catalog consumer URLs
-    private static final String DEFAULT_CATALOG_RULESET = "";
+    private static final String DEFAULT_CATALOG_RULESET = "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta-2-ruleset-5/consumers/public-ruleset-5";
     private static final String DEFAULT_CATALOG_IOCS = "";
     private static final String DEFAULT_CATALOG_VULNERABILITIES = "";
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
@@ -74,7 +74,9 @@ public class PluginSettingsTests extends OpenSearchTestCase {
         // Verify default values
         Assert.assertTrue(pluginSettings.isUpdateOnStart());
         Assert.assertTrue(pluginSettings.isUpdateOnSchedule());
-        Assert.assertEquals("", pluginSettings.getCatalogRuleset());
+        Assert.assertEquals(
+                "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta-2-ruleset-5/consumers/public-ruleset-5",
+                pluginSettings.getCatalogRuleset());
         Assert.assertEquals("", pluginSettings.getCatalogIocs());
         Assert.assertEquals("", pluginSettings.getCatalogVulnerabilities());
     }


### PR DESCRIPTION
### Description
This PR updates the default ruleset consumer to the one for `beta-2`.

### Issues Resolved
Resolves #1160
