### PR TITLE
Encode credentials in base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Skip engine validation for engine-unrelated resources promotion [(#1133)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1133)
 - CTI subscription API update [(#1145)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1145)
 - Update ruleset consumer to beta-2 [(#1161)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1161)
+- Encode credentials in base64 [(#1163)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1163)
 
 ### Deprecated
 -

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
@@ -35,6 +35,7 @@ import org.opensearch.transport.client.Client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -66,9 +67,10 @@ public class CredentialsIndex {
     }
 
     /**
-     * Stores the access token in the credentials index. Overwrites any previously stored value.
+     * Stores the access token in the credentials index, base64-encoded at rest. Overwrites any
+     * previously stored value.
      *
-     * @param accessToken the CTI access token to persist.
+     * @param accessToken the CTI access token to persist (plaintext).
      * @return the IndexResponse from the operation.
      * @throws ExecutionException if the client failed to execute the request.
      * @throws InterruptedException if the current thread was interrupted.
@@ -85,6 +87,8 @@ public class CredentialsIndex {
                 this.client, INDEX_NAME, this.pluginSettings.getClientTimeout())) {
             throw new RuntimeException("Index not ready: " + INDEX_NAME);
         }
+        String encoded =
+                Base64.getEncoder().encodeToString(accessToken.getBytes(StandardCharsets.UTF_8));
         IndexRequest request =
                 new IndexRequest()
                         .index(INDEX_NAME)
@@ -92,15 +96,15 @@ public class CredentialsIndex {
                         .source(
                                 XContentFactory.jsonBuilder()
                                         .startObject()
-                                        .field(ACCESS_TOKEN_FIELD, accessToken)
+                                        .field(ACCESS_TOKEN_FIELD, encoded)
                                         .endObject());
         return this.client.index(request).get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
     }
 
     /**
-     * Retrieves the stored access token from the index.
+     * Retrieves the stored access token from the index, decoded from its base64 form.
      *
-     * @return the access token string, or null if not found.
+     * @return the plaintext access token, or null if not found.
      * @throws ExecutionException if the client failed to execute the request.
      * @throws InterruptedException if the current thread was interrupted.
      * @throws TimeoutException if the operation exceeded the configured timeout.
@@ -117,7 +121,13 @@ public class CredentialsIndex {
             return null;
         }
         Map<String, Object> source = response.getSourceAsMap();
-        return source != null ? (String) source.get(ACCESS_TOKEN_FIELD) : null;
+        if (source == null) {
+            return null;
+        }
+        String stored = (String) source.get(ACCESS_TOKEN_FIELD);
+        return stored != null
+                ? new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8)
+                : null;
     }
 
     /**

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndexTests.java
@@ -29,6 +29,8 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -94,22 +96,28 @@ public class CredentialsIndexTests extends OpenSearchTestCase {
                         GetResponse r = client.get(null).get(10L, java.util.concurrent.TimeUnit.SECONDS);
                         if (!r.isExists()) return null;
                         Map<String, Object> src = r.getSourceAsMap();
-                        return src != null ? (String) src.get(ACCESS_TOKEN_FIELD) : null;
+                        if (src == null) return null;
+                        String stored = (String) src.get(ACCESS_TOKEN_FIELD);
+                        return stored != null
+                                ? new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8)
+                                : null;
                     }
                 };
 
         Assert.assertNull(idx.getAccessToken());
     }
 
-    /** getAccessToken returns the stored token when the document exists. */
+    /** getAccessToken returns the stored token, decoded from its base64 form. */
     @SuppressWarnings("unchecked")
     public void testGetAccessToken_Found() throws Exception {
         Client client = mock(Client.class);
 
+        String encoded =
+                Base64.getEncoder().encodeToString("my-token".getBytes(StandardCharsets.UTF_8));
         GetResponse getResponse = mock(GetResponse.class);
         when(getResponse.isExists()).thenReturn(true);
         when(getResponse.getSourceAsMap())
-                .thenReturn(Map.of(CredentialsIndex.ACCESS_TOKEN_FIELD, "my-token"));
+                .thenReturn(Map.of(CredentialsIndex.ACCESS_TOKEN_FIELD, encoded));
 
         ActionFuture<GetResponse> future = mock(ActionFuture.class);
         when(future.get(anyLong(), any())).thenReturn(getResponse);
@@ -123,7 +131,11 @@ public class CredentialsIndexTests extends OpenSearchTestCase {
                         GetResponse r = client.get(null).get(10L, java.util.concurrent.TimeUnit.SECONDS);
                         if (!r.isExists()) return null;
                         Map<String, Object> src = r.getSourceAsMap();
-                        return src != null ? (String) src.get(ACCESS_TOKEN_FIELD) : null;
+                        if (src == null) return null;
+                        String stored = (String) src.get(ACCESS_TOKEN_FIELD);
+                        return stored != null
+                                ? new String(Base64.getDecoder().decode(stored), StandardCharsets.UTF_8)
+                                : null;
                     }
                 };
 


### PR DESCRIPTION
### Description
This PR modifies `CredentialsIndex.java` so that credentials are base64-encoded at rest in their index.

### Issues Resolved
Resolves https://github.com/wazuh/internal-devel-requests/issues/4795
