### PR TITLE
Remove `space.hash` from non-policy resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix broken Javadoc link reference in ContentManagerPlugin [(#1020)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1020)
 - Fix Telemetry Ping Job not running immediately after registration [(#1052)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1052)
 - Fix missing wazuh-threatintel-filters index [(#1143)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1143)
+- Remove space.hash from non-policy resources [(#1167)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1167)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#484)](https://github.com/wazuh/wazuh-indexer-plugins/pull/484)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
@@ -141,8 +141,16 @@ public class Resource {
             Resource.nestMetadataFields(rawDoc);
 
             resource.setDocument(rawDoc);
+
+            // 2. Calculate Hash
+            String hashStr = Resource.computeSha256(rawDoc.toString());
+            if (!hashStr.isEmpty()) {
+                Map<String, String> hashMap = new HashMap<>();
+                hashMap.put("sha256", hashStr);
+                resource.setHash(hashMap);
+            }
         }
-        // 2. Set Space if not present in resource payload
+        // 3. Set Space if not present in resource payload
         this.populateSpaceObject(resource, payload);
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
@@ -141,35 +141,21 @@ public class Resource {
             Resource.nestMetadataFields(rawDoc);
 
             resource.setDocument(rawDoc);
-
-            // 2. Calculate Hash
-            String hashStr = Resource.computeSha256(rawDoc.toString());
-            if (!hashStr.isEmpty()) {
-                Map<String, String> hashMap = new HashMap<>();
-                hashMap.put("sha256", hashStr);
-                resource.setHash(hashMap);
-            }
         }
-        // 3. Set Space if not present in resource payload
+        // 2. Set Space if not present in resource payload
         this.populateSpaceObject(resource, payload);
     }
 
     private void populateSpaceObject(Resource resource, JsonNode payload) {
         Map<String, Object> spaceMap = new HashMap<>();
         String spaceName = Space.STANDARD.toString();
-        Map<String, String> hashMap = new HashMap<>();
-        hashMap.put(Constants.KEY_SHA256, "");
         if (payload.has("space") && payload.get("space").isObject()) {
             JsonNode spaceObj = payload.get("space");
             if (spaceObj.has("name")) {
                 spaceName = spaceObj.get("name").asText();
             }
-            if (spaceObj.has("hash") && spaceObj.get("hash").isObject()) {
-                hashMap = MAPPER.convertValue(spaceObj.get("hash"), Map.class);
-            }
         }
         spaceMap.put("name", spaceName);
-        spaceMap.put("hash", hashMap);
         resource.setSpace(spaceMap);
     }
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
@@ -417,7 +417,6 @@ public class ContentIndexTests extends OpenSearchTestCase {
 
         JsonNode source = this.mapper.readTree(request.source().utf8ToString());
         Assert.assertTrue("Should contain 'document' key", source.has("document"));
-        Assert.assertTrue("Should contain 'hash' key", source.has("hash"));
         Assert.assertTrue("Should contain 'space' key", source.has("space"));
     }
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/FilterTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/FilterTests.java
@@ -75,11 +75,4 @@ public class FilterTests extends OpenSearchTestCase {
         Filter filter = Filter.fromPayload(payload);
         assertNotNull("document field should be populated", filter.getDocument());
     }
-
-    public void testFromPayload_populatesHashField() throws IOException {
-        JsonNode payload = MAPPER.readTree(FILTER_PAYLOAD);
-        Filter filter = Filter.fromPayload(payload);
-        assertNotNull("hash field should be populated", filter.getHash());
-        assertFalse("hash sha256 should not be empty", filter.getHash().get("sha256").isEmpty());
-    }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/KvdbTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/KvdbTests.java
@@ -76,11 +76,4 @@ public class KvdbTests extends OpenSearchTestCase {
         Kvdb kvdb = Kvdb.fromPayload(payload);
         assertNotNull("document field should be populated", kvdb.getDocument());
     }
-
-    public void testFromPayload_populatesHashField() throws IOException {
-        JsonNode payload = MAPPER.readTree(KVDB_PAYLOAD);
-        Kvdb kvdb = Kvdb.fromPayload(payload);
-        assertNotNull("hash field should be populated", kvdb.getHash());
-        assertFalse("hash sha256 should not be empty", kvdb.getHash().get("sha256").isEmpty());
-    }
 }


### PR DESCRIPTION
### Description
This PR removes the `space.hash` object from non-policy `wazuh-threatintel` resources.

### Issues Resolved
Resolves #1166 