### PR TITLE
Fix Policy Metadata Duplicated At Root Level On Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix Telemetry Ping Job not running immediately after registration [(#1052)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1052)
 - Fix missing wazuh-threatintel-filters index [(#1143)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1143)
 - Remove space.hash from non-policy resources [(#1167)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1167)
+- Fix policy Metadata Duplicated At Root Level On Updates [(1174)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1174)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#484)](https://github.com/wazuh/wazuh-indexer-plugins/pull/484)

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -684,6 +684,8 @@ curl -sk -u admin:admin -X POST \
 Updates the routing policy in the specified space. The policy defines which integrations are active, the root decoder, enrichment types, and how events are routed through the Engine.
 
 > **Note**: The `integrations` and `filters` arrays allow reordering but do not allow adding or removing entries — membership is managed via their respective CRUD endpoints.
+>
+> **Stored document format**: after update, policy metadata is stored only under `document.metadata` in the indexed document (not duplicated at `document` root level).
 
 **Space-specific behavior**
 
@@ -1061,7 +1063,7 @@ Fields within `metadata`:
 | Field           | Type   | Description                          |
 | --------------- | ------ | ------------------------------------ |
 | `title`         | String | Human-readable decoder title         |
-| `description`   | String | Decoder description                  |
+| `description`   | String | Decoder description                   |
 | `module`        | String | Module name                          |
 | `compatibility` | String | Compatibility description            |
 | `author`        | Object | Author info (`name`, `email`, `url`) |
@@ -1239,9 +1241,9 @@ A decoder cannot be deleted if it is currently set as the root decoder in the dr
 
 **Parameters**
 
-| Name | In   | Type   | Required | Description         |
-| ---- | ---- | ------ | -------- | ------------------- |
-| `id` | Path | String | Yes      | Decoder document ID |
+| Name | In   | Type          | Required | Description         |
+| ---- | ---- | ------------- | -------- | ------------------- |
+| `id` | Path | String (UUID) | Yes      | Decoder document ID |
 
 **Example Request**
 
@@ -1393,9 +1395,9 @@ Updates an existing filter in the draft or standard space. The filter is re-vali
 
 **Parameters**
 
-| Name | In   | Type   | Required | Description        |
-| ---- | ---- | ------ | -------- | ------------------ |
-| `id` | Path | String | Yes      | Filter document ID |
+| Name | In   | Type          | Required | Description        |
+| ---- | ---- | ------------- | -------- | ------------------ |
+| `id` | Path | String (UUID) | Yes      | Filter document ID |
 
 **Request Body**
 
@@ -1459,9 +1461,9 @@ Deletes a filter from the draft or standard space. The filter is also removed fr
 
 **Parameters**
 
-| Name | In   | Type   | Required | Description        |
-| ---- | ---- | ------ | -------- | ------------------ |
-| `id` | Path | String | Yes      | Filter document ID |
+| Name | In   | Type          | Required | Description        |
+| ---- | ---- | ------------- | -------- | ------------------ |
+| `id` | Path | String (UUID) | Yes      | Filter document ID |
 
 **Example Request**
 
@@ -1495,7 +1497,7 @@ curl -sk -u admin:admin -X DELETE \
 
 Creates a new integration in the draft space. An integration is a logical grouping of related rules, decoders, and KVDBs. The integration is validated against the Engine and registered in the Security Analytics Plugin.
 
-The integration is also synchronized to the SAP, where a separate document is created with its own auto-generated UUID. The SAP document stores the CTI document UUID in a `document.id` field and the space in the `source` field (e.g., "Draft") for cross-reference.
+The integration is also synchronized to the SAP, where a separate document is created with its own auto-generated UUID. The SAP document stores the CTI document UUID in a `document.id` field and the space in a `source` field (e.g., "Draft") for cross-reference.
 
 **Request**
 - Method: `POST`

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -684,8 +684,6 @@ curl -sk -u admin:admin -X POST \
 Updates the routing policy in the specified space. The policy defines which integrations are active, the root decoder, enrichment types, and how events are routed through the Engine.
 
 > **Note**: The `integrations` and `filters` arrays allow reordering but do not allow adding or removing entries — membership is managed via their respective CRUD endpoints.
->
-> **Stored document format**: after update, policy metadata is stored only under `document.metadata` in the indexed document (not duplicated at `document` root level).
 
 **Space-specific behavior**
 

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -1169,13 +1169,16 @@ paths:
 
         **Draft space**: All policy fields are accepted. The `integrations` and `filters`
         arrays allow reordering but do not allow adding or removing entries.
-        Fields `author`, `description`, `documentation`, and `references` are required
-        in addition to the boolean fields.
+        Fields `metadata.author`, `metadata.description`, `metadata.documentation`,
+        and `metadata.references` are required in addition to the boolean fields.
 
         **Standard space**: Only `enrichments`, `filters`, `enabled`,
         `index_unclassified_events`, and `index_discarded_events` can be modified.
         All other fields are preserved from the existing standard policy document.
         The `filters` array allows reordering but not addition or removal.
+
+        **Stored document format**: Policy metadata is stored only under
+        `document.metadata` in the indexed document.
       operationId: policy_update
       parameters:
         - name: space
@@ -1218,7 +1221,8 @@ paths:
           description: The name of the user space to reset.
           schema:
             type: string
-            enum: [ draft ]
+            enum:
+              - draft
       responses:
         "200":
           $ref: "#/components/responses/OkResponse"

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPutPolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPutPolicyAction.java
@@ -369,7 +369,9 @@ public class RestPutPolicyAction extends BaseRestHandler {
         mergedPolicy.setReferences(existingReferences);
 
         Object compatObj = existingMetadata.get(Constants.KEY_COMPATIBILITY);
-        if (compatObj == null) compatObj = currentPolicyDoc.get(Constants.KEY_COMPATIBILITY);
+        if (compatObj == null) {
+            compatObj = currentPolicyDoc.get(Constants.KEY_COMPATIBILITY);
+        }
         @SuppressWarnings("unchecked")
         List<String> existingCompatibility =
                 (List<String>) (compatObj != null ? compatObj : Collections.emptyList());
@@ -479,7 +481,9 @@ public class RestPutPolicyAction extends BaseRestHandler {
         policy.setModified(docModificationDate);
 
         Object compatObj = existingMeta.get(Constants.KEY_COMPATIBILITY);
-        if (compatObj == null) compatObj = currentPolicyDoc.get(Constants.KEY_COMPATIBILITY);
+        if (compatObj == null) {
+            compatObj = currentPolicyDoc.get(Constants.KEY_COMPATIBILITY);
+        }
         @SuppressWarnings("unchecked")
         List<String> existingCompatibility =
                 (List<String>) (compatObj != null ? compatObj : Collections.emptyList());

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPutPolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPutPolicyAction.java
@@ -380,8 +380,10 @@ public class RestPutPolicyAction extends BaseRestHandler {
         mergedPolicy.setIndexUnclassifiedEvents(incomingPolicy.getIndexUnclassifiedEvents());
         mergedPolicy.setIndexDiscardedEvents(incomingPolicy.getIndexDiscardedEvents());
 
-        // Convert to JsonNode and persist
-        JsonNode policyNode = mapper.valueToTree(mergedPolicy);
+        // Convert to JsonNode and persist.
+        // Ensure metadata fields are stored only under document.metadata.
+        ObjectNode policyNode = mapper.valueToTree(mergedPolicy);
+        Resource.nestMetadataFields(policyNode);
 
         ContentIndex index = new ContentIndex(this.client, Constants.INDEX_POLICIES, null);
         try {
@@ -469,8 +471,12 @@ public class RestPutPolicyAction extends BaseRestHandler {
         policy.setDate(docCreationDate);
         policy.setModified(docModificationDate);
 
-        // Convert Policy to JsonNode
-        JsonNode policyNode = mapper.valueToTree(policy);
+        // Convert Policy to JsonNode.
+        // nestMetadataFields removes root-level duplicate fields (title, author, date, etc.)
+        // that Jackson emits from the public delegate getters in Policy, keeping them only
+        // inside the nested "metadata" object — consistent with how initializeSpace() works.
+        ObjectNode policyNode = mapper.valueToTree(policy);
+        Resource.nestMetadataFields(policyNode);
 
         ContentIndex index = new ContentIndex(this.client, Constants.INDEX_POLICIES, null);
         try {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPutPolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPutPolicyAction.java
@@ -368,6 +368,13 @@ public class RestPutPolicyAction extends BaseRestHandler {
                 (List<String>) (refObj != null ? refObj : Collections.emptyList());
         mergedPolicy.setReferences(existingReferences);
 
+        Object compatObj = existingMetadata.get(Constants.KEY_COMPATIBILITY);
+        if (compatObj == null) compatObj = currentPolicyDoc.get(Constants.KEY_COMPATIBILITY);
+        @SuppressWarnings("unchecked")
+        List<String> existingCompatibility =
+                (List<String>) (compatObj != null ? compatObj : Collections.emptyList());
+        mergedPolicy.getMetadata().setCompatibility(existingCompatibility);
+
         mergedPolicy.setRootDecoder((String) currentPolicyDoc.getOrDefault("root_decoder", ""));
         mergedPolicy.setIntegrations(
                 (List<String>)
@@ -470,6 +477,13 @@ public class RestPutPolicyAction extends BaseRestHandler {
         policy.setId(docId);
         policy.setDate(docCreationDate);
         policy.setModified(docModificationDate);
+
+        Object compatObj = existingMeta.get(Constants.KEY_COMPATIBILITY);
+        if (compatObj == null) compatObj = currentPolicyDoc.get(Constants.KEY_COMPATIBILITY);
+        @SuppressWarnings("unchecked")
+        List<String> existingCompatibility =
+                (List<String>) (compatObj != null ? compatObj : Collections.emptyList());
+        policy.getMetadata().setCompatibility(existingCompatibility);
 
         // Convert Policy to JsonNode.
         // nestMetadataFields removes root-level duplicate fields (title, author, date, etc.)

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPutPolicyActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPutPolicyActionTests.java
@@ -16,6 +16,9 @@
  */
 package com.wazuh.contentmanager.rest.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
@@ -52,6 +55,7 @@ import com.wazuh.contentmanager.rest.utils.PayloadValidations;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -1758,8 +1762,7 @@ public class RestPutPolicyActionTests extends OpenSearchTestCase {
                         .withContent(new BytesArray(policyJson), XContentType.JSON)
                         .build();
 
-        org.mockito.ArgumentCaptor<IndexRequest> indexCaptor =
-                org.mockito.ArgumentCaptor.forClass(IndexRequest.class);
+        ArgumentCaptor<IndexRequest> indexCaptor = ArgumentCaptor.forClass(IndexRequest.class);
         PlainActionFuture<IndexResponse> indexFuture = PlainActionFuture.newFuture();
         indexFuture.onResponse(this.indexResponse);
         when(this.client.index(any(IndexRequest.class))).thenReturn(indexFuture);
@@ -1771,10 +1774,9 @@ public class RestPutPolicyActionTests extends OpenSearchTestCase {
         // Capture the IndexRequest submitted to the client and inspect the stored document
         verify(this.client).index(indexCaptor.capture());
         String indexedJson = indexCaptor.getValue().source().utf8ToString();
-        com.fasterxml.jackson.databind.ObjectMapper om =
-                new com.fasterxml.jackson.databind.ObjectMapper();
-        com.fasterxml.jackson.databind.JsonNode root = om.readTree(indexedJson);
-        com.fasterxml.jackson.databind.JsonNode docNode = root.path(Constants.KEY_DOCUMENT);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(indexedJson);
+        JsonNode docNode = root.path(Constants.KEY_DOCUMENT);
 
         // Metadata fields must NOT appear at document root level
         String[] duplicateFields = {
@@ -1787,7 +1789,7 @@ public class RestPutPolicyActionTests extends OpenSearchTestCase {
         }
 
         // They must still be present inside document.metadata
-        com.fasterxml.jackson.databind.JsonNode metadataNode = docNode.path("metadata");
+        JsonNode metadataNode = docNode.path("metadata");
         Assert.assertFalse("document.metadata must be present", metadataNode.isMissingNode());
         Assert.assertFalse(
                 "document.metadata.title must be present", metadataNode.path("title").isMissingNode());

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPutPolicyActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPutPolicyActionTests.java
@@ -1715,4 +1715,81 @@ public class RestPutPolicyActionTests extends OpenSearchTestCase {
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         verify(this.engineService, never()).promote(any());
     }
+
+    /**
+     * Regression test: updating the draft policy must NOT duplicate metadata fields (title, author,
+     * date, description, documentation, references, modified) at the document root. They must only
+     * appear nested inside {@code document.metadata}.
+     *
+     * <p>Root cause: {@code mapper.valueToTree(policy)} serialises the public delegate getters in
+     * {@link com.wazuh.contentmanager.cti.catalog.model.Policy} (e.g. {@code getTitle()}) as
+     * root-level fields in addition to the nested {@code metadata} object. {@code
+     * Resource.nestMetadataFields()} must be called immediately afterwards to remove those
+     * duplicates, exactly as {@code SpaceService.initializeSpace()} does.
+     */
+    public void testPutDraftPolicy_DocumentRootHasNoMetadataDuplication() throws Exception {
+        when(this.service.calculateAndUpdate(anyList())).thenReturn(Collections.emptySet());
+
+        String policyJson =
+                "{"
+                        + "\"resource\": {"
+                        + "\"title\": \"Test Policy\","
+                        + "\"root_decoder\": \"decoder/integrations/0\","
+                        + "\"integrations\": [\"integration-1\"],"
+                        + "\"filters\": [],"
+                        + "\"enrichments\": [],"
+                        + "\"enabled\": true,"
+                        + "\"index_unclassified_events\": false,"
+                        + "\"index_discarded_events\": false,"
+                        + "\"author\": \"Wazuh Inc.\","
+                        + "\"description\": \"Test policy\","
+                        + "\"documentation\": \"Test documentation\","
+                        + "\"references\": [\"Test references\"]"
+                        + "}"
+                        + "}";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("space", "draft");
+        RestRequest request =
+                new FakeRestRequest.Builder(this.xContentRegistry())
+                        .withMethod(RestRequest.Method.PUT)
+                        .withPath(PluginSettings.POLICY_URI)
+                        .withParams(params)
+                        .withContent(new BytesArray(policyJson), XContentType.JSON)
+                        .build();
+
+        org.mockito.ArgumentCaptor<IndexRequest> indexCaptor =
+                org.mockito.ArgumentCaptor.forClass(IndexRequest.class);
+        PlainActionFuture<IndexResponse> indexFuture = PlainActionFuture.newFuture();
+        indexFuture.onResponse(this.indexResponse);
+        when(this.client.index(any(IndexRequest.class))).thenReturn(indexFuture);
+        when(this.indexResponse.getId()).thenReturn("test-policy-id");
+
+        RestResponse response = this.action.handleRequest(request);
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+
+        // Capture the IndexRequest submitted to the client and inspect the stored document
+        verify(this.client).index(indexCaptor.capture());
+        String indexedJson = indexCaptor.getValue().source().utf8ToString();
+        com.fasterxml.jackson.databind.ObjectMapper om =
+                new com.fasterxml.jackson.databind.ObjectMapper();
+        com.fasterxml.jackson.databind.JsonNode root = om.readTree(indexedJson);
+        com.fasterxml.jackson.databind.JsonNode docNode = root.path(Constants.KEY_DOCUMENT);
+
+        // Metadata fields must NOT appear at document root level
+        String[] duplicateFields = {
+            "title", "author", "description", "documentation", "references", "date", "modified"
+        };
+        for (String field : duplicateFields) {
+            Assert.assertFalse(
+                    "Metadata field '" + field + "' must not be duplicated at document root",
+                    docNode.has(field));
+        }
+
+        // They must still be present inside document.metadata
+        com.fasterxml.jackson.databind.JsonNode metadataNode = docNode.path("metadata");
+        Assert.assertFalse("document.metadata must be present", metadataNode.isMissingNode());
+        Assert.assertFalse(
+                "document.metadata.title must be present", metadataNode.path("title").isMissingNode());
+    }
 }


### PR DESCRIPTION
### Description
Fixes policy metadata duplicated at root level on updates.

### Issues Resolved
#1173 
