### PR TITLE
Add missing host fields to wazuh.agent object

### DIFF
--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -95,6 +95,257 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "host": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "boot": {
+                      "properties": {
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "cpu": {
+                      "properties": {
+                        "cores": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "speed": {
+                          "type": "long"
+                        },
+                        "usage": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "disk": {
+                      "properties": {
+                        "read": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "write": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "geo": {
+                      "properties": {
+                        "city_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "location": {
+                          "type": "geo_point"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "postal_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "timezone": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "hostname": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ip": {
+                      "type": "ip"
+                    },
+                    "mac": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "memory": {
+                      "properties": {
+                        "free": {
+                          "type": "long"
+                        },
+                        "total": {
+                          "type": "long"
+                        },
+                        "used": {
+                          "properties": {
+                            "percentage": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "network": {
+                      "properties": {
+                        "egress": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            },
+                            "drops": {
+                              "type": "long"
+                            },
+                            "errors": {
+                              "type": "long"
+                            },
+                            "packets": {
+                              "type": "long"
+                            },
+                            "queue": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "ingress": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            },
+                            "drops": {
+                              "type": "long"
+                            },
+                            "errors": {
+                              "type": "long"
+                            },
+                            "packets": {
+                              "type": "long"
+                            },
+                            "queue": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "os": {
+                      "properties": {
+                        "family": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "full": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "kernel": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "platform": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "pid_ns_ino": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "risk": {
+                      "properties": {
+                        "calculated_level": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "calculated_score": {
+                          "type": "float"
+                        },
+                        "calculated_score_norm": {
+                          "type": "float"
+                        },
+                        "static_level": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "static_score": {
+                          "type": "float"
+                        },
+                        "static_score_norm": {
+                          "type": "float"
+                        }
+                      }
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "uptime": {
+                      "type": "long"
+                    }
+                  }
+                },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/wcs/stateless/active-responses/docs/fields.csv
+++ b/wcs/stateless/active-responses/docs/fields.csv
@@ -12,6 +12,63 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 9.1.0,true,wazuh,wazuh.agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
 9.1.0,true,wazuh,wazuh.agent.groups,keyword,custom,array,"[""group1"", ""group2""]",List of groups the agent belongs to.
+9.1.0,true,wazuh,wazuh.agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
+9.1.0,true,wazuh,wazuh.agent.host.boot.id,keyword,extended,,88a1f0ed-5ae5-41ee-af6b-41921c311872,Linux boot uuid taken from /proc/sys/kernel/random/boot_id
+9.1.0,true,wazuh,wazuh.agent.host.cpu,object,custom,,"""name"": ""Intel(R) Core(TM) i7-7700HQ CPU"", ""cores"": 4, ""speed"": 2800",CPU-related data.
+9.1.0,true,wazuh,wazuh.agent.host.cpu.cores,long,custom,,4,Number of CPU cores.
+9.1.0,true,wazuh,wazuh.agent.host.cpu.name,keyword,custom,,Intel(R) Core(TM) i7-7700HQ CPU,CPU Model name.
+9.1.0,true,wazuh,wazuh.agent.host.cpu.speed,long,custom,,2800,CPU clock speed.
+9.1.0,true,wazuh,wazuh.agent.host.cpu.usage,scaled_float,extended,,,"Percent CPU used, between 0 and 1."
+9.1.0,true,wazuh,wazuh.agent.host.disk.read.bytes,long,extended,,,The number of bytes read by all disks.
+9.1.0,true,wazuh,wazuh.agent.host.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
+9.1.0,true,wazuh,wazuh.agent.host.domain,keyword,extended,,CONTOSO,Name of the directory the group is a member of.
+9.1.0,true,wazuh,wazuh.agent.host.geo.city_name,keyword,core,,Montreal,City name.
+9.1.0,true,wazuh,wazuh.agent.host.geo.continent_code,keyword,core,,NA,Continent code.
+9.1.0,true,wazuh,wazuh.agent.host.geo.continent_name,keyword,core,,North America,Name of the continent.
+9.1.0,true,wazuh,wazuh.agent.host.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+9.1.0,true,wazuh,wazuh.agent.host.geo.country_name,keyword,core,,Canada,Country name.
+9.1.0,true,wazuh,wazuh.agent.host.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+9.1.0,true,wazuh,wazuh.agent.host.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+9.1.0,true,wazuh,wazuh.agent.host.geo.postal_code,keyword,core,,94040,Postal code.
+9.1.0,true,wazuh,wazuh.agent.host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+9.1.0,true,wazuh,wazuh.agent.host.geo.region_name,keyword,core,,Quebec,Region name.
+9.1.0,true,wazuh,wazuh.agent.host.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+9.1.0,true,wazuh,wazuh.agent.host.hostname,keyword,core,,,Hostname of the host.
+9.1.0,true,wazuh,wazuh.agent.host.id,keyword,core,,,Unique host id.
+9.1.0,true,wazuh,wazuh.agent.host.ip,ip,core,array,,Host ip addresses.
+9.1.0,true,wazuh,wazuh.agent.host.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",Host MAC addresses.
+9.1.0,true,wazuh,wazuh.agent.host.memory,object,custom,,"""total"": 100000, ""free"": 90000, ""used"": {""percentage"": 10}",Memory-related data.
+9.1.0,true,wazuh,wazuh.agent.host.memory.free,long,custom,,1024,Free memory in MB.
+9.1.0,true,wazuh,wazuh.agent.host.memory.total,long,custom,,1024,Total memory in MB.
+9.1.0,true,wazuh,wazuh.agent.host.memory.used,object,custom,,"""percentage"": 10",Used memory-related data.
+9.1.0,true,wazuh,wazuh.agent.host.memory.used.percentage,long,custom,,10,Used memory percentage.
+9.1.0,true,wazuh,wazuh.agent.host.name,keyword,core,,,Name of the host.
+9.1.0,true,wazuh,wazuh.agent.host.network.egress.bytes,long,extended,,,The number of bytes sent on all network interfaces.
+9.1.0,true,wazuh,wazuh.agent.host.network.egress.drops,long,custom,,10,Number of dropped transmitted packets.
+9.1.0,true,wazuh,wazuh.agent.host.network.egress.errors,long,custom,,10,Number of transmission errors.
+9.1.0,true,wazuh,wazuh.agent.host.network.egress.packets,long,extended,,,The number of packets sent on all network interfaces.
+9.1.0,true,wazuh,wazuh.agent.host.network.egress.queue,long,custom,,10,Transmit queue length.
+9.1.0,true,wazuh,wazuh.agent.host.network.ingress.bytes,long,extended,,,The number of bytes received on all network interfaces.
+9.1.0,true,wazuh,wazuh.agent.host.network.ingress.drops,long,custom,,10,Number of dropped received packets.
+9.1.0,true,wazuh,wazuh.agent.host.network.ingress.errors,long,custom,,10,Number of reception errors.
+9.1.0,true,wazuh,wazuh.agent.host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
+9.1.0,true,wazuh,wazuh.agent.host.network.ingress.queue,long,custom,,10,Receive queue length.
+9.1.0,true,wazuh,wazuh.agent.host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
+9.1.0,true,wazuh,wazuh.agent.host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+9.1.0,true,wazuh,wazuh.agent.host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
+9.1.0,true,wazuh,wazuh.agent.host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
+9.1.0,true,wazuh,wazuh.agent.host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+9.1.0,true,wazuh,wazuh.agent.host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
+9.1.0,true,wazuh,wazuh.agent.host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
+9.1.0,true,wazuh,wazuh.agent.host.pid_ns_ino,keyword,extended,,256383,Pid namespace inode
+9.1.0,true,wazuh,wazuh.agent.host.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+9.1.0,true,wazuh,wazuh.agent.host.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+9.1.0,true,wazuh,wazuh.agent.host.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+9.1.0,true,wazuh,wazuh.agent.host.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+9.1.0,true,wazuh,wazuh.agent.host.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+9.1.0,true,wazuh,wazuh.agent.host.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
+9.1.0,true,wazuh,wazuh.agent.host.type,keyword,core,,,Type of host.
+9.1.0,true,wazuh,wazuh.agent.host.uptime,long,extended,,1325,Seconds the host has been up.
 9.1.0,true,wazuh,wazuh.agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
 9.1.0,true,wazuh,wazuh.agent.name,keyword,core,,foo,Custom name of the agent.
 9.1.0,true,wazuh,wazuh.agent.type,keyword,core,,filebeat,Type of the agent.

--- a/wcs/stateless/active-responses/docs/wcs_flat.yml
+++ b/wcs/stateless/active-responses/docs/wcs_flat.yml
@@ -175,6 +175,724 @@ wazuh.agent.groups:
   original_fieldset: agent
   short: List of groups the agent belongs to.
   type: keyword
+wazuh.agent.host.architecture:
+  dashed_name: wazuh-agent-host-architecture
+  description: Operating system architecture.
+  example: x86_64
+  flat_name: wazuh.agent.host.architecture
+  ignore_above: 1024
+  level: core
+  name: architecture
+  normalize: []
+  original_fieldset: host
+  short: Operating system architecture.
+  type: keyword
+wazuh.agent.host.boot.id:
+  dashed_name: wazuh-agent-host-boot-id
+  description: Linux boot uuid taken from /proc/sys/kernel/random/boot_id. Note the
+    boot_id value from /proc may or may not be the same in containers as on the host.
+    Some container runtimes will bind mount a new boot_id value onto the proc file
+    in each container.
+  example: 88a1f0ed-5ae5-41ee-af6b-41921c311872
+  flat_name: wazuh.agent.host.boot.id
+  ignore_above: 1024
+  level: extended
+  name: boot.id
+  normalize: []
+  original_fieldset: host
+  short: Linux boot uuid taken from /proc/sys/kernel/random/boot_id
+  type: keyword
+wazuh.agent.host.cpu:
+  dashed_name: wazuh-agent-host-cpu
+  description: CPU-related data.
+  example: '"name": "Intel(R) Core(TM) i7-7700HQ CPU", "cores": 4, "speed": 2800'
+  flat_name: wazuh.agent.host.cpu
+  level: custom
+  name: cpu
+  normalize: []
+  original_fieldset: host
+  short: CPU-related data.
+  type: object
+wazuh.agent.host.cpu.cores:
+  dashed_name: wazuh-agent-host-cpu-cores
+  description: Number of CPU cores.
+  example: 4
+  flat_name: wazuh.agent.host.cpu.cores
+  level: custom
+  name: cpu.cores
+  normalize: []
+  original_fieldset: host
+  short: Number of CPU cores.
+  type: long
+wazuh.agent.host.cpu.name:
+  dashed_name: wazuh-agent-host-cpu-name
+  description: CPU Model name.
+  example: Intel(R) Core(TM) i7-7700HQ CPU
+  flat_name: wazuh.agent.host.cpu.name
+  ignore_above: 1024
+  level: custom
+  name: cpu.name
+  normalize: []
+  original_fieldset: host
+  short: CPU Model name.
+  type: keyword
+wazuh.agent.host.cpu.speed:
+  dashed_name: wazuh-agent-host-cpu-speed
+  description: CPU clock speed.
+  example: 2800
+  flat_name: wazuh.agent.host.cpu.speed
+  level: custom
+  name: cpu.speed
+  normalize: []
+  original_fieldset: host
+  short: CPU clock speed.
+  type: long
+wazuh.agent.host.cpu.usage:
+  dashed_name: wazuh-agent-host-cpu-usage
+  description: 'Percent CPU used which is normalized by the number of CPU cores and
+    it ranges from 0 to 1.
+
+    Scaling factor: 1000.
+
+    For example: For a two core host, this value should be the average of the two
+    cores, between 0 and 1.'
+  flat_name: wazuh.agent.host.cpu.usage
+  level: extended
+  name: cpu.usage
+  normalize: []
+  original_fieldset: host
+  scaling_factor: 1000
+  short: Percent CPU used, between 0 and 1.
+  type: scaled_float
+wazuh.agent.host.disk.read.bytes:
+  dashed_name: wazuh-agent-host-disk-read-bytes
+  description: The total number of bytes (gauge) read successfully (aggregated from
+    all disks) since the last metric collection.
+  flat_name: wazuh.agent.host.disk.read.bytes
+  level: extended
+  name: disk.read.bytes
+  normalize: []
+  original_fieldset: host
+  short: The number of bytes read by all disks.
+  type: long
+wazuh.agent.host.disk.write.bytes:
+  dashed_name: wazuh-agent-host-disk-write-bytes
+  description: The total number of bytes (gauge) written successfully (aggregated
+    from all disks) since the last metric collection.
+  flat_name: wazuh.agent.host.disk.write.bytes
+  level: extended
+  name: disk.write.bytes
+  normalize: []
+  original_fieldset: host
+  short: The number of bytes written on all disks.
+  type: long
+wazuh.agent.host.domain:
+  dashed_name: wazuh-agent-host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: wazuh.agent.host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: host
+  short: Name of the directory the group is a member of.
+  type: keyword
+wazuh.agent.host.geo.city_name:
+  dashed_name: wazuh-agent-host-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: wazuh.agent.host.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+wazuh.agent.host.geo.continent_code:
+  dashed_name: wazuh-agent-host-geo-continent-code
+  description: Two-letter code representing continent's name.
+  example: NA
+  flat_name: wazuh.agent.host.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Continent code.
+  type: keyword
+wazuh.agent.host.geo.continent_name:
+  dashed_name: wazuh-agent-host-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: wazuh.agent.host.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+wazuh.agent.host.geo.country_iso_code:
+  dashed_name: wazuh-agent-host-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: wazuh.agent.host.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+wazuh.agent.host.geo.country_name:
+  dashed_name: wazuh-agent-host-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: wazuh.agent.host.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+wazuh.agent.host.geo.location:
+  dashed_name: wazuh-agent-host-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: wazuh.agent.host.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+wazuh.agent.host.geo.name:
+  dashed_name: wazuh-agent-host-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: wazuh.agent.host.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+wazuh.agent.host.geo.postal_code:
+  dashed_name: wazuh-agent-host-geo-postal-code
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
+  example: 94040
+  flat_name: wazuh.agent.host.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code.
+  type: keyword
+wazuh.agent.host.geo.region_iso_code:
+  dashed_name: wazuh-agent-host-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: wazuh.agent.host.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+wazuh.agent.host.geo.region_name:
+  dashed_name: wazuh-agent-host-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: wazuh.agent.host.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
+wazuh.agent.host.geo.timezone:
+  dashed_name: wazuh-agent-host-geo-timezone
+  description: The time zone of the location, such as IANA time zone name.
+  example: America/Argentina/Buenos_Aires
+  flat_name: wazuh.agent.host.geo.timezone
+  ignore_above: 1024
+  level: core
+  name: timezone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
+  type: keyword
+wazuh.agent.host.hostname:
+  dashed_name: wazuh-agent-host-hostname
+  description: 'Hostname of the host.
+
+    It normally contains what the `hostname` command returns on the host machine.'
+  flat_name: wazuh.agent.host.hostname
+  ignore_above: 1024
+  level: core
+  name: hostname
+  normalize: []
+  original_fieldset: host
+  short: Hostname of the host.
+  type: keyword
+wazuh.agent.host.id:
+  dashed_name: wazuh-agent-host-id
+  description: 'Unique host id.
+
+    As hostname is not always unique, use values that are meaningful in your environment.
+
+    Example: The current usage of `beat.name`.'
+  flat_name: wazuh.agent.host.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: host
+  short: Unique host id.
+  type: keyword
+wazuh.agent.host.ip:
+  dashed_name: wazuh-agent-host-ip
+  description: Host ip addresses.
+  flat_name: wazuh.agent.host.ip
+  level: core
+  name: ip
+  normalize:
+  - array
+  original_fieldset: host
+  short: Host ip addresses.
+  type: ip
+wazuh.agent.host.mac:
+  dashed_name: wazuh-agent-host-mac
+  description: 'Host MAC addresses.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
+  flat_name: wazuh.agent.host.mac
+  ignore_above: 1024
+  level: core
+  name: mac
+  normalize:
+  - array
+  original_fieldset: host
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
+  short: Host MAC addresses.
+  type: keyword
+wazuh.agent.host.memory:
+  dashed_name: wazuh-agent-host-memory
+  description: Memory-related data.
+  example: '"total": 100000, "free": 90000, "used": {"percentage": 10}'
+  flat_name: wazuh.agent.host.memory
+  level: custom
+  name: memory
+  normalize: []
+  original_fieldset: host
+  short: Memory-related data.
+  type: object
+wazuh.agent.host.memory.free:
+  dashed_name: wazuh-agent-host-memory-free
+  description: Free memory in MB.
+  example: 1024
+  flat_name: wazuh.agent.host.memory.free
+  level: custom
+  name: memory.free
+  normalize: []
+  original_fieldset: host
+  short: Free memory in MB.
+  type: long
+wazuh.agent.host.memory.total:
+  dashed_name: wazuh-agent-host-memory-total
+  description: Total memory in MB.
+  example: 1024
+  flat_name: wazuh.agent.host.memory.total
+  level: custom
+  name: memory.total
+  normalize: []
+  original_fieldset: host
+  short: Total memory in MB.
+  type: long
+wazuh.agent.host.memory.used:
+  dashed_name: wazuh-agent-host-memory-used
+  description: Used memory-related data.
+  example: '"percentage": 10'
+  flat_name: wazuh.agent.host.memory.used
+  level: custom
+  name: memory.used
+  normalize: []
+  original_fieldset: host
+  short: Used memory-related data.
+  type: object
+wazuh.agent.host.memory.used.percentage:
+  dashed_name: wazuh-agent-host-memory-used-percentage
+  description: Used memory percentage.
+  example: 10
+  flat_name: wazuh.agent.host.memory.used.percentage
+  level: custom
+  name: memory.used.percentage
+  normalize: []
+  original_fieldset: host
+  short: Used memory percentage.
+  type: long
+wazuh.agent.host.name:
+  dashed_name: wazuh-agent-host-name
+  description: 'Name of the host.
+
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
+  flat_name: wazuh.agent.host.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  original_fieldset: host
+  short: Name of the host.
+  type: keyword
+wazuh.agent.host.network.egress.bytes:
+  dashed_name: wazuh-agent-host-network-egress-bytes
+  description: The number of bytes (gauge) sent out on all network interfaces by the
+    host since the last metric collection.
+  flat_name: wazuh.agent.host.network.egress.bytes
+  level: extended
+  name: network.egress.bytes
+  normalize: []
+  original_fieldset: host
+  short: The number of bytes sent on all network interfaces.
+  type: long
+wazuh.agent.host.network.egress.drops:
+  dashed_name: wazuh-agent-host-network-egress-drops
+  description: Number of dropped transmitted packets.
+  example: 10
+  flat_name: wazuh.agent.host.network.egress.drops
+  level: custom
+  name: network.egress.drops
+  normalize: []
+  original_fieldset: host
+  short: Number of dropped transmitted packets.
+  type: long
+wazuh.agent.host.network.egress.errors:
+  dashed_name: wazuh-agent-host-network-egress-errors
+  description: Number of transmission errors.
+  example: 10
+  flat_name: wazuh.agent.host.network.egress.errors
+  level: custom
+  name: network.egress.errors
+  normalize: []
+  original_fieldset: host
+  short: Number of transmission errors.
+  type: long
+wazuh.agent.host.network.egress.packets:
+  dashed_name: wazuh-agent-host-network-egress-packets
+  description: The number of packets (gauge) sent out on all network interfaces by
+    the host since the last metric collection.
+  flat_name: wazuh.agent.host.network.egress.packets
+  level: extended
+  name: network.egress.packets
+  normalize: []
+  original_fieldset: host
+  short: The number of packets sent on all network interfaces.
+  type: long
+wazuh.agent.host.network.egress.queue:
+  dashed_name: wazuh-agent-host-network-egress-queue
+  description: Transmit queue length.
+  example: 10
+  flat_name: wazuh.agent.host.network.egress.queue
+  level: custom
+  name: network.egress.queue
+  normalize: []
+  original_fieldset: host
+  short: Transmit queue length.
+  type: long
+wazuh.agent.host.network.ingress.bytes:
+  dashed_name: wazuh-agent-host-network-ingress-bytes
+  description: The number of bytes received (gauge) on all network interfaces by the
+    host since the last metric collection.
+  flat_name: wazuh.agent.host.network.ingress.bytes
+  level: extended
+  name: network.ingress.bytes
+  normalize: []
+  original_fieldset: host
+  short: The number of bytes received on all network interfaces.
+  type: long
+wazuh.agent.host.network.ingress.drops:
+  dashed_name: wazuh-agent-host-network-ingress-drops
+  description: Number of dropped received packets.
+  example: 10
+  flat_name: wazuh.agent.host.network.ingress.drops
+  level: custom
+  name: network.ingress.drops
+  normalize: []
+  original_fieldset: host
+  short: Number of dropped received packets.
+  type: long
+wazuh.agent.host.network.ingress.errors:
+  dashed_name: wazuh-agent-host-network-ingress-errors
+  description: Number of reception errors.
+  example: 10
+  flat_name: wazuh.agent.host.network.ingress.errors
+  level: custom
+  name: network.ingress.errors
+  normalize: []
+  original_fieldset: host
+  short: Number of reception errors.
+  type: long
+wazuh.agent.host.network.ingress.packets:
+  dashed_name: wazuh-agent-host-network-ingress-packets
+  description: The number of packets (gauge) received on all network interfaces by
+    the host since the last metric collection.
+  flat_name: wazuh.agent.host.network.ingress.packets
+  level: extended
+  name: network.ingress.packets
+  normalize: []
+  original_fieldset: host
+  short: The number of packets received on all network interfaces.
+  type: long
+wazuh.agent.host.network.ingress.queue:
+  dashed_name: wazuh-agent-host-network-ingress-queue
+  description: Receive queue length.
+  example: 10
+  flat_name: wazuh.agent.host.network.ingress.queue
+  level: custom
+  name: network.ingress.queue
+  normalize: []
+  original_fieldset: host
+  short: Receive queue length.
+  type: long
+wazuh.agent.host.os.family:
+  dashed_name: wazuh-agent-host-os-family
+  description: OS family (such as redhat, debian, freebsd, windows).
+  example: debian
+  flat_name: wazuh.agent.host.os.family
+  ignore_above: 1024
+  level: extended
+  name: family
+  normalize: []
+  original_fieldset: os
+  short: OS family (such as redhat, debian, freebsd, windows).
+  type: keyword
+wazuh.agent.host.os.full:
+  dashed_name: wazuh-agent-host-os-full
+  description: Operating system name, including the version or code name.
+  example: Mac OS Mojave
+  flat_name: wazuh.agent.host.os.full
+  ignore_above: 1024
+  level: extended
+  name: full
+  normalize: []
+  original_fieldset: os
+  short: Operating system name, including the version or code name.
+  type: keyword
+wazuh.agent.host.os.kernel:
+  dashed_name: wazuh-agent-host-os-kernel
+  description: Operating system kernel version as a raw string.
+  example: 4.4.0-112-generic
+  flat_name: wazuh.agent.host.os.kernel
+  ignore_above: 1024
+  level: extended
+  name: kernel
+  normalize: []
+  original_fieldset: os
+  short: Operating system kernel version as a raw string.
+  type: keyword
+wazuh.agent.host.os.name:
+  dashed_name: wazuh-agent-host-os-name
+  description: Operating system name, without the version.
+  example: Mac OS X
+  flat_name: wazuh.agent.host.os.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: os
+  short: Operating system name, without the version.
+  type: keyword
+wazuh.agent.host.os.platform:
+  dashed_name: wazuh-agent-host-os-platform
+  description: Operating system platform (such centos, ubuntu, windows).
+  example: darwin
+  flat_name: wazuh.agent.host.os.platform
+  ignore_above: 1024
+  level: extended
+  name: platform
+  normalize: []
+  original_fieldset: os
+  short: Operating system platform (such centos, ubuntu, windows).
+  type: keyword
+wazuh.agent.host.os.type:
+  dashed_name: wazuh-agent-host-os-type
+  description: 'Use the `os.type` field to categorize the operating system into one
+    of the broad commercial families.
+
+    If the OS you''re dealing with is not listed as an expected value, the field should
+    not be populated. Please let us know by opening an issue with ECS, to propose
+    its addition.'
+  example: macos
+  expected_values:
+  - linux
+  - macos
+  - unix
+  - windows
+  - ios
+  - android
+  flat_name: wazuh.agent.host.os.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  original_fieldset: os
+  short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or
+    android).'
+  type: keyword
+wazuh.agent.host.os.version:
+  dashed_name: wazuh-agent-host-os-version
+  description: Operating system version as a raw string.
+  example: 10.14.1
+  flat_name: wazuh.agent.host.os.version
+  ignore_above: 1024
+  level: extended
+  name: version
+  normalize: []
+  original_fieldset: os
+  short: Operating system version as a raw string.
+  type: keyword
+wazuh.agent.host.pid_ns_ino:
+  dashed_name: wazuh-agent-host-pid-ns-ino
+  description: This is the inode number of the namespace in the namespace file system
+    (nsfs). Unsigned int inum in include/linux/ns_common.h.
+  example: 256383
+  flat_name: wazuh.agent.host.pid_ns_ino
+  ignore_above: 1024
+  level: extended
+  name: pid_ns_ino
+  normalize: []
+  original_fieldset: host
+  short: Pid namespace inode
+  type: keyword
+wazuh.agent.host.risk.calculated_level:
+  dashed_name: wazuh-agent-host-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: wazuh.agent.host.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+wazuh.agent.host.risk.calculated_score:
+  dashed_name: wazuh-agent-host-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: wazuh.agent.host.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+wazuh.agent.host.risk.calculated_score_norm:
+  dashed_name: wazuh-agent-host-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: wazuh.agent.host.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+wazuh.agent.host.risk.static_level:
+  dashed_name: wazuh-agent-host-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: wazuh.agent.host.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+wazuh.agent.host.risk.static_score:
+  dashed_name: wazuh-agent-host-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: wazuh.agent.host.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+wazuh.agent.host.risk.static_score_norm:
+  dashed_name: wazuh-agent-host-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: wazuh.agent.host.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
+wazuh.agent.host.type:
+  dashed_name: wazuh-agent-host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: wazuh.agent.host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  original_fieldset: host
+  short: Type of host.
+  type: keyword
+wazuh.agent.host.uptime:
+  dashed_name: wazuh-agent-host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: wazuh.agent.host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  original_fieldset: host
+  short: Seconds the host has been up.
+  type: long
 wazuh.agent.id:
   dashed_name: wazuh-agent-id
   description: 'Unique identifier of this agent (if one exists).

--- a/wcs/stateless/active-responses/fields/custom/host.yml
+++ b/wcs/stateless/active-responses/fields/custom/host.yml
@@ -1,0 +1,97 @@
+---
+- name: host
+  reusable:
+    top_level: false
+    expected:
+      - { at: wazuh.agent, as: host }
+  fields:
+    - name: memory
+      description: >
+        Memory-related data.
+      type: object
+      level: custom
+      example: "\"total\": 100000, \"free\": 90000, \"used\": {\"percentage\": 10}"
+    - name: memory.total
+      description: >
+        Total memory in MB.
+      type: long
+      level: custom
+      example: 1024
+    - name: memory.free
+      description: >
+        Free memory in MB.
+      type: long
+      level: custom
+      example: 1024
+    - name: memory.used
+      description: >
+        Used memory-related data.
+      type: object
+      level: custom
+      example: "\"percentage\": 10"
+    - name: memory.used.percentage
+      description: >
+        Used memory percentage.
+      type: long
+      level: custom
+      example: 10
+    - name: cpu
+      description: >
+        CPU-related data.
+      type: object
+      level: custom
+      example: "\"name\": \"Intel(R) Core(TM) i7-7700HQ CPU\", \"cores\": 4, \"speed\": 2800"
+    - name: cpu.name
+      description: >
+        CPU Model name.
+      type: keyword
+      level: custom
+      example: "Intel(R) Core(TM) i7-7700HQ CPU"
+    - name: cpu.cores
+      description: >
+        Number of CPU cores.
+      type: long
+      level: custom
+      example: 4
+    - name: cpu.speed
+      description: >
+        CPU clock speed.
+      type: long
+      level: custom
+      example: 2800
+    - name: network.ingress.queue
+      type: long
+      level: custom
+      description: >
+        Receive queue length.
+      example: 10
+    - name: network.egress.queue
+      type: long
+      level: custom
+      description: >
+        Transmit queue length.
+      example: 10
+    - name: network.egress.drops
+      type: long
+      level: custom
+      description: >
+        Number of dropped transmitted packets.
+      example: 10
+    - name: network.egress.errors
+      type: long
+      level: custom
+      description: >
+        Number of transmission errors.
+      example: 10
+    - name: network.ingress.drops
+      type: long
+      level: custom
+      description: >
+        Number of dropped received packets.
+      example: 10
+    - name: network.ingress.errors
+      type: long
+      level: custom
+      description: >
+        Number of reception errors.
+      example: 10

--- a/wcs/stateless/active-responses/fields/custom/os.yml
+++ b/wcs/stateless/active-responses/fields/custom/os.yml
@@ -1,0 +1,6 @@
+---
+- name: os
+  reusable:
+    top_level: false
+    expected:
+      - wazuh.agent.host

--- a/wcs/stateless/active-responses/fields/custom/risk.yml
+++ b/wcs/stateless/active-responses/fields/custom/risk.yml
@@ -1,0 +1,6 @@
+---
+- name: risk
+  reusable:
+    top_level: false
+    expected:
+      - wazuh.agent.host


### PR DESCRIPTION
### Description
This PR adds the missing host fields to the AR response template, now `wazuh` object from events and from AR only differ in these fields:

- wazuh.active_response.agent_id
- wazuh.active_response.executable
- wazuh.active_response.extra_arguments
- wazuh.active_response.location
- wazuh.active_response.name
- wazuh.active_response.stateful_timeout
- wazuh.active_response.type

They are AR specific fields, that are not included in the events template

### Issues Resolved
Closes #1178 
