### PR TITLE
Allow custom space in logtest endpoint

### DIFF
--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -271,7 +271,7 @@ Sends a log event to the Wazuh Engine for analysis. If an `integration` ID is pr
 | Field            | Type    | Required | Description                                          |
 | ---------------- | ------- | -------- | ---------------------------------------------------- |
 | `integration`    | String  | No       | ID of the integration to test against. If omitted, only normalization is performed. |
-| `space`          | String  | Yes      | `"test"` or `"standard"`                             |
+| `space`          | String  | Yes      | `"test"`, `"standard"` or `"custom"`                             |
 | `queue`          | Integer | Yes      | Queue number for logtest execution                   |
 | `location`       | String  | Yes      | Log file path or logical source location             |
 | `event`          | String  | Yes      | Raw log event to test                                |

--- a/docs/ref/modules/content-manager/rule-testing.md
+++ b/docs/ref/modules/content-manager/rule-testing.md
@@ -16,7 +16,7 @@ Draft → Test → Custom
 
 Logtest sends a raw log event through the full detection pipeline — the Wazuh Engine normalizes the event, and the Security Analytics Plugin (SAP) evaluates your Sigma rules against the normalized output. The combined result shows exactly what was decoded and which rules matched.
 
-Logtest supports both the `test` and `standard` spaces. Use `test` for validating draft content, and `standard` for testing against production rules.
+Logtest supports both the `test`, `standard`, and `custom` spaces. Use `test` for validating draft content, `standard` for testing against production rules, and `custom` for validating content promoted to production
 
 ---
 

--- a/docs/ref/modules/content-manager/rule-testing.md
+++ b/docs/ref/modules/content-manager/rule-testing.md
@@ -16,7 +16,7 @@ Draft → Test → Custom
 
 Logtest sends a raw log event through the full detection pipeline — the Wazuh Engine normalizes the event, and the Security Analytics Plugin (SAP) evaluates your Sigma rules against the normalized output. The combined result shows exactly what was decoded and which rules matched.
 
-Logtest supports both the `test`, `standard`, and `custom` spaces. Use `test` for validating draft content, `standard` for testing against production rules, and `custom` for validating content promoted to production
+Logtest supports the `test`, `standard`, and `custom` spaces. Use `test` for validating draft content, `standard` for testing against production rules, and `custom` for validating content promoted to production
 
 ---
 

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -961,7 +961,7 @@ paths:
         the normalization step is performed and the `detection` section is returned with
         `status: "skipped"`.
 
-        The integration must exist in the specified space (`test` or `standard`). If the
+        The integration must exist in the specified space (`test`, `standard` or `custom`). If the
         integration has no rules, the SAP result returns zero matches. If the engine fails,
         SAP evaluation is skipped.
       operationId: executeLogtest
@@ -1047,7 +1047,7 @@ paths:
         `/logtest/normalization` endpoint, or when you already have a normalized event
         and want to test different integrations' rules against it.
 
-        The integration must exist in the specified space (`test` or `standard`).
+        The integration must exist in the specified space (`test`, `standard`, or `custom`).
       operationId: executeLogtestDetection
       requestBody:
         required: true
@@ -1365,7 +1365,8 @@ components:
           enum:
             - test
             - standard
-          description: Space where the integration exists. Must be `"test"` or `"standard"`.
+            - custom
+          description: Space where the integration exists. Must be `"test"`, `"standard"`or `"custom"`.
           example: "test"
 
         queue:
@@ -1411,7 +1412,8 @@ components:
           enum:
             - test
             - standard
-          description: Space context for the normalization. Must be `"test"` or `"standard"`.
+            - custom
+          description: Space context for the normalization. Must be `"test"`, `"standard"` or `"custom"`.
           example: "test"
 
         queue:
@@ -1459,7 +1461,8 @@ components:
           enum:
             - test
             - standard
-          description: Space where the integration exists. Must be `"test"` or `"standard"`.
+            - custom
+          description: Space where the integration exists. Must be `"test"`, `"standard"` or `"custom"`.
           example: "test"
 
         integration:

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -403,8 +403,7 @@ public class SpaceService {
 
         // Root payload structure
         ObjectNode rootPayload = this.objectMapper.createObjectNode();
-        boolean isTesterSpace =
-                Space.TEST.toString().equals(targetSpace) || Space.STANDARD.toString().equals(targetSpace);
+        boolean isTesterSpace = !Space.DRAFT.toString().equals(targetSpace);
         rootPayload.put(Constants.KEY_PROMOTE, isTesterSpace);
         rootPayload.put(Constants.KEY_SPACE, targetSpace);
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestAction.java
@@ -144,7 +144,7 @@ public class RestPostLogtestAction extends BaseRestHandler {
                     String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
                     RestStatus.BAD_REQUEST.getStatus());
         }
-        if (spaceEnum != Space.TEST && spaceEnum != Space.STANDARD) {
+        if (spaceEnum != Space.TEST && spaceEnum != Space.STANDARD && spaceEnum != Space.CUSTOM) {
             return new RestResponse(
                     String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
                     RestStatus.BAD_REQUEST.getStatus());

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestAction.java
@@ -144,7 +144,7 @@ public class RestPostLogtestAction extends BaseRestHandler {
                     String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
                     RestStatus.BAD_REQUEST.getStatus());
         }
-        if (spaceEnum != Space.TEST && spaceEnum != Space.STANDARD && spaceEnum != Space.CUSTOM) {
+        if (spaceEnum == Space.DRAFT) {
             return new RestResponse(
                     String.format(Locale.ROOT, Constants.E_400_INVALID_SPACE, space),
                     RestStatus.BAD_REQUEST.getStatus());

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostPromoteAction.java
@@ -177,7 +177,7 @@ public class RestPostPromoteAction extends BaseRestHandler {
             // holds engine resources from prior promotions (integration/rule-only changesets still
             // require engine validation when engine resources are already present in the target).
             Space targetSpace = spaceDiff.getSpace().promote();
-            if (targetSpace == Space.TEST
+            if ((targetSpace == Space.TEST || targetSpace == Space.CUSTOM)
                     && (hasEngineRelatedChanges(context)
                             || this.spaceService.hasEngineResources(targetSpace))) {
                 RestResponse engineResponse = this.engine.promote(context.enginePayload);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -63,7 +63,7 @@ public class Constants {
     public static final String E_400_CANNOT_REMOVE_ROOT_DECODER =
             "Cannot remove decoder [%s] as it is set as root decoder.";
     public static final String E_400_INVALID_SPACE =
-            "Logtest is only supported for the 'test' and 'standard' spaces. Received space: '%s'.";
+            "Logtest is only supported for the 'test', 'custom' and 'standard' spaces. Received space: '%s'.";
     public static final String E_400_INTEGRATION_NOT_FOUND =
             "Integration [%s] not found in the '%s' space.";
     public static final String E_404_RESOURCE_NOT_FOUND = "Resource not found.";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostLogtestActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostLogtestActionTests.java
@@ -173,4 +173,32 @@ public class RestPostLogtestActionTests extends OpenSearchTestCase {
 
         Assert.assertEquals(serviceResponse, response);
     }
+
+    /** Custom space is allowed and delegates to LogtestService. */
+    public void testCustomSpaceDelegatesToService() {
+        RestResponse serviceResponse =
+                new RestResponse("{\"normalization\":{}}", RestStatus.OK.getStatus());
+        when(this.logtestService.executeLogtest(anyString(), any(), any(ObjectNode.class)))
+                .thenReturn(serviceResponse);
+
+        // spotless:off
+        RestRequest request = mockRequest(String.format(Locale.ROOT,
+            """
+            {
+              "integration": "%s",
+              "space": "custom",
+              "queue": 1,
+              "location": "/var/log/cassandra/system.log",
+              "event": "INFO  [main] 2026-03-31 10:00:00 StorageService.java:123 - Node is ready to serve",
+              "trace_level": "NONE"
+            }
+            """,
+            INTEGRATION_ID));
+        // spotless:on
+
+        RestResponse response = this.action.handleRequest(request);
+
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+        verify(this.logtestService).executeLogtest(eq(INTEGRATION_ID), any(), any(ObjectNode.class));
+    }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostPromoteActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostPromoteActionTests.java
@@ -560,8 +560,17 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         Assert.assertTrue(actualResponse.getMessage().contains("expected source space"));
     }
 
-    /** If the promotion is from TEST to CUSTOM, the engine should not be called. */
-    public void testPostPromoteToCustomSkipsEngine() throws IOException {
+    /**
+     * If the promotion is from TEST to CUSTOM and the changeset carries engine resources, the engine
+     * must be invoked so the CUSTOM space is loaded for logtest consumption.
+     */
+    public void testPostPromoteToCustomInvokesEngine() throws IOException {
+        // Mock engine to return success (200 OK)
+        RestResponse engineResponse = new RestResponse();
+        engineResponse.setStatus(200);
+        engineResponse.setMessage("OK");
+        when(this.engine.promote(any(JsonNode.class))).thenReturn(engineResponse);
+
         // Mock spaces
         Map<String, String> mockSpaceTest = new HashMap<>();
         mockSpaceTest.put(Constants.KEY_NAME, Space.TEST.toString());
@@ -607,9 +616,9 @@ public class RestPostPromoteActionTests extends OpenSearchTestCase {
         // Invoke method to test
         RestResponse actualResponse = this.action.handleRequest(request);
 
-        // Verify - promotion succeeds and engine is never called
+        // Verify - promotion succeeds and engine was called once
         Assert.assertEquals(200, actualResponse.getStatus());
-        verify(this.engine, never()).promote(any(JsonNode.class));
+        verify(this.engine).promote(any(JsonNode.class));
     }
 
     /**


### PR DESCRIPTION
### Description
The logtest endpoint now accepts `custom` as a valid space in addition to `test` and `standard`.

### Changes
- Updated space validation in `RestPostLogtestAction.java`
- Added test `testCustomSpaceDelegatesToService` in `RestPostLogtestActionTests.java`- 

### Validations 
Custom space is accepted and delegates to `LogtestService`
```bash
[2026-05-20T13:02:29,108][INFO ][c.w.c.r.s.RestPostLogtestActionTests] [testCustomSpaceDelegatesToService] before test
[2026-05-20T13:02:29,111][INFO ][c.w.c.r.s.RestPostLogtestActionTests] [testCustomSpaceDelegatesToService] after test
```

### Issues Resolved
#1184


