### PR TITLE
Restore post-sync after swaps and stop premature offset advances

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -95,6 +95,13 @@ public class ContentIndex {
     private final ObjectMapper mapper;
 
     /**
+     * Whether this instance targets a shadow physical index during a blue/green swap. Normal
+     * instances write through the alias; shadow instances write directly to the physical name because
+     * the alias still points at the old live index until the atomic swap completes.
+     */
+    private final boolean isShadow;
+
+    /**
      * Constructor for existing indices where mapping path isn't immediately required. Reads and
      * writes go through the alias name.
      *
@@ -102,7 +109,7 @@ public class ContentIndex {
      * @param indexName The public alias name of the index.
      */
     public ContentIndex(Client client, String indexName) {
-        this(client, indexName, null);
+        this(client, indexName, indexName + SUFFIX_A, null, false);
     }
 
     /**
@@ -114,7 +121,7 @@ public class ContentIndex {
      * @param mappingsPath The classpath resource path to the JSON mapping file.
      */
     public ContentIndex(Client client, String indexName, String mappingsPath) {
-        this(client, indexName, indexName + SUFFIX_A, mappingsPath);
+        this(client, indexName, indexName + SUFFIX_A, mappingsPath, false);
     }
 
     /**
@@ -127,12 +134,18 @@ public class ContentIndex {
      * @param mappingsPath The classpath resource path to the JSON mapping file.
      */
     public ContentIndex(Client client, String indexName, String physicalName, String mappingsPath) {
+        this(client, indexName, physicalName, mappingsPath, true);
+    }
+
+    private ContentIndex(
+            Client client, String indexName, String physicalName, String mappingsPath, boolean isShadow) {
         this.pluginSettings = PluginSettings.getInstance();
         this.semaphore = new Semaphore(this.pluginSettings.getMaximumConcurrentBulks());
         this.client = client;
         this.indexName = indexName;
         this.physicalName = physicalName;
         this.mappingsPath = mappingsPath;
+        this.isShadow = isShadow;
         this.mapper = new ObjectMapper();
         this.mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     }
@@ -164,13 +177,7 @@ public class ContentIndex {
      * @return The index name to target for writes.
      */
     public String getWriteIndex() {
-        // When physicalName matches the default convention (alias + SUFFIX_A), this is a normal
-        // instance and we write through the alias. Otherwise it's a shadow instance and we must
-        // write directly to the physical name since the alias points elsewhere.
-        if (this.physicalName.equals(this.indexName + SUFFIX_A)) {
-            return this.indexName;
-        }
-        return this.physicalName;
+        return this.isShadow ? this.physicalName : this.indexName;
     }
 
     /**

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
@@ -383,6 +383,17 @@ public class ContentIndexTests extends OpenSearchTestCase {
     }
 
     /**
+     * Regression: when a shadow swap targets the {@code -a} suffix (i.e., the live alias currently
+     * points at {@code -b}), the shadow instance must still write to its physical name. Inferring
+     * shadow-vs-normal from the suffix alone would incorrectly route writes through the alias and
+     * land them in the old live index.
+     */
+    public void testGetWriteIndex_Shadow_TargetingSuffixA() {
+        ContentIndex idx = new ContentIndex(this.client, "test-alias", "test-alias-a", MAPPINGS_PATH);
+        Assert.assertEquals("test-alias-a", idx.getWriteIndex());
+    }
+
+    /**
      * Test that creating a resource produces the expected JSON schema. Validates that the indexed
      * document contains the required keys: document, hash, and space.
      */


### PR DESCRIPTION
## Description

Fixes a bug in the blue/green index swap where `typeHashes` came back empty after a swap that lands on the `-a` physical suffix (e.g., the downgrade-to-free path). The IOC live index after the swap was effectively empty, so
`ConsumerIocService.computeAllTypeHashes` scanned zero documents.

### Root cause

`ContentIndex.getWriteIndex()` inferred shadow-vs-normal purely from the physical suffix:

```java
if (this.physicalName.equals(this.indexName + SUFFIX_A)) {
    return this.indexName;            // assumed: normal, write through alias
}
return this.physicalName;             // assumed: shadow, write to physical
```

The heuristic is asymmetric. When the alias points at `-b` and we are swapping back to `-a`, the shadow `ContentIndex` has `physicalName = alias + "-a"`. The check returns the alias name — but the alias still points to the old `-b`
index during snapshot ingestion. All snapshot writes land in `-b`. The atomic alias swap then publishes the empty `-a`, and `IndexSwapHelper.deleteIndices` removes `-b`, taking the freshly ingested snapshot with it.

The first swap direction (`-a → -b`) worked because the shadow physical ends in `-b`, the heuristic correctly returned the physical name, and writes went where they should.

### Fix

Replace the suffix heuristic with an explicit `isShadow` flag set by the 4-arg constructor — the one the shadow path (`IndexSwapHelper.createShadowIndices`) already uses. Normal callers go through the 2-/3-arg constructors with
`isShadow=false` and continue to write through the alias.

### Issues Resolved

Closes https://github.com/wazuh/internal-devel-requests/issues/4904
