### PR TITLE
Add new fields to metrics comms template for wazuh-remoted stats

### DIFF
--- a/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
@@ -45,6 +45,13 @@
         },
         "events": {
           "properties": {
+            "failed": {
+              "properties": {
+                "total": {
+                  "type": "long"
+                }
+              }
+            },
             "total": {
               "type": "long"
             }
@@ -87,8 +94,22 @@
                 }
               }
             },
+            "states": {
+              "properties": {
+                "total": {
+                  "type": "long"
+                }
+              }
+            },
             "total": {
               "type": "long"
+            },
+            "upgrades": {
+              "properties": {
+                "total": {
+                  "type": "long"
+                }
+              }
             }
           }
         },

--- a/wcs/stateless/metrics/comms/docs/fields.csv
+++ b/wcs/stateless/metrics/comms/docs/fields.csv
@@ -2,8 +2,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 9.1.0,true,discarded,discarded.total,long,custom,,0,Cumulative number of discarded messages.
 9.1.0,true,event,event.module,keyword,core,,apache,Name of the module this data is coming from.
-9.1.0,true,events,events.failed.total,long,custom,,0,Cumulative number of agent events that could not be delivered to the analysis daemon.
-9.1.0,true,events,events.total,long,custom,,5697755,Cumulative number of events forwarded to downstream processing components.
+9.1.0,true,events,events.failed.total,long,custom,,0,Agent events that could not be delivered to wazuh-analysisd.
+9.1.0,true,events,events.total,long,custom,,5697755,Agent events accepted and queued for wazuh-analysisd.
 9.1.0,true,messages,messages.control.dropped_on_close.total,long,custom,,0,Cumulative number of queued messages dropped when the agent connection was closed.
 9.1.0,true,messages,messages.control.processed.total,long,custom,,2918243,Cumulative number of control messages processed from the queue.
 9.1.0,true,messages,messages.control.received.total,long,custom,,2918243,Cumulative number of control messages inserted into the control queue.

--- a/wcs/stateless/metrics/comms/docs/fields.csv
+++ b/wcs/stateless/metrics/comms/docs/fields.csv
@@ -2,13 +2,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 9.1.0,true,discarded,discarded.total,long,custom,,0,Cumulative number of discarded messages.
 9.1.0,true,event,event.module,keyword,core,,apache,Name of the module this data is coming from.
+9.1.0,true,events,events.failed.total,long,custom,,0,Cumulative number of agent events that could not be delivered to the analysis daemon.
 9.1.0,true,events,events.total,long,custom,,5697755,Cumulative number of events forwarded to downstream processing components.
 9.1.0,true,messages,messages.control.dropped_on_close.total,long,custom,,0,Cumulative number of queued messages dropped when the agent connection was closed.
 9.1.0,true,messages,messages.control.processed.total,long,custom,,2918243,Cumulative number of control messages processed from the queue.
 9.1.0,true,messages,messages.control.received.total,long,custom,,2918243,Cumulative number of control messages inserted into the control queue.
 9.1.0,true,messages,messages.control.replaced.total,long,custom,,1,Cumulative number of control messages replaced in the queue.
 9.1.0,true,messages,messages.control.usage,float,custom,,0.42,Current utilization ratio of the control message queue (0.0–1.0).
+9.1.0,true,messages,messages.states.total,long,custom,,0,Inventory-sync messages forwarded to the states router.
 9.1.0,true,messages,messages.total,long,custom,,2918262,Cumulative number of control messages received.
+9.1.0,true,messages,messages.upgrades.total,long,custom,,0,Upgrade-ack messages forwarded to the upgrades router.
 9.1.0,true,network,network.egress.bytes,long,custom,,,The number of bytes sent on all network interfaces.
 9.1.0,true,network,network.ingress.bytes,long,custom,,,The number of bytes received on all network interfaces.
 9.1.0,true,queue,queue.capacity,integer,custom,,131072,Maximum configured capacity of the message queue.

--- a/wcs/stateless/metrics/comms/docs/wcs_flat.yml
+++ b/wcs/stateless/metrics/comms/docs/wcs_flat.yml
@@ -58,6 +58,18 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+events.failed.total:
+  dashed_name: events-failed-total
+  description: Cumulative number of agent events that could not be delivered to the
+    analysis daemon.
+  example: 0
+  flat_name: events.failed.total
+  level: custom
+  name: failed.total
+  normalize: []
+  short: Cumulative number of agent events that could not be delivered to the analysis
+    daemon.
+  type: long
 events.total:
   dashed_name: events-total
   description: Cumulative number of events forwarded to downstream processing components.
@@ -120,6 +132,17 @@ messages.control.usage:
   normalize: []
   short: Current utilization ratio of the control message queue (0.0–1.0).
   type: float
+messages.states.total:
+  dashed_name: messages-states-total
+  description: Cumulative number of inventory-synchronization messages received from
+    agents and forwarded to the inventory-states router provider.
+  example: 0
+  flat_name: messages.states.total
+  level: custom
+  name: states.total
+  normalize: []
+  short: Inventory-sync messages forwarded to the states router.
+  type: long
 messages.total:
   dashed_name: messages-total
   description: Cumulative number of control messages received.
@@ -129,6 +152,17 @@ messages.total:
   name: total
   normalize: []
   short: Cumulative number of control messages received.
+  type: long
+messages.upgrades.total:
+  dashed_name: messages-upgrades-total
+  description: Cumulative number of upgrade-acknowledgement messages received from
+    agents and forwarded to the upgrade_notifications router provider.
+  example: 0
+  flat_name: messages.upgrades.total
+  level: custom
+  name: upgrades.total
+  normalize: []
+  short: Upgrade-ack messages forwarded to the upgrades router.
   type: long
 network.egress.bytes:
   dashed_name: network-egress-bytes

--- a/wcs/stateless/metrics/comms/docs/wcs_flat.yml
+++ b/wcs/stateless/metrics/comms/docs/wcs_flat.yml
@@ -60,25 +60,32 @@ event.module:
   type: keyword
 events.failed.total:
   dashed_name: events-failed-total
-  description: Cumulative number of agent events that could not be delivered to the
-    analysis daemon.
+  description: Cumulative number of agent events that wazuh-remoted could not deliver
+    to wazuh-analysisd. Includes events rejected by the internal batch queue (queue
+    full or per-agent cap exceeded) and events dropped by the HTTP dispatcher when
+    the connection to wazuh-analysisd is unavailable. An event counted here may also
+    appear in events.total, which reflects acceptance into the batch queue, not successful
+    delivery.
   example: 0
   flat_name: events.failed.total
   level: custom
   name: failed.total
   normalize: []
-  short: Cumulative number of agent events that could not be delivered to the analysis
-    daemon.
+  short: Agent events that could not be delivered to wazuh-analysisd.
   type: long
 events.total:
   dashed_name: events-total
-  description: Cumulative number of events forwarded to downstream processing components.
+  description: Cumulative number of agent events that wazuh-remoted accepted and queued
+    for delivery to wazuh-analysisd. These are stateless event payloads that drive
+    rule-based detection. Messages classified as control, inventory-sync, upgrade-ack,
+    ping, or legacy DBSYNC are counted under their own fields and do not contribute
+    here.
   example: 5697755
   flat_name: events.total
   level: custom
   name: total
   normalize: []
-  short: Cumulative number of events forwarded to downstream processing components.
+  short: Agent events accepted and queued for wazuh-analysisd.
   type: long
 messages.control.dropped_on_close.total:
   dashed_name: messages-control-dropped-on-close-total

--- a/wcs/stateless/metrics/comms/fields/custom/comms.yml
+++ b/wcs/stateless/metrics/comms/fields/custom/comms.yml
@@ -58,16 +58,26 @@
     - name: total
       type: long
       level: custom
+      short: Agent events accepted and queued for wazuh-analysisd.
       description: >
-        Cumulative number of events forwarded to downstream processing
-        components.
+        Cumulative number of agent events that wazuh-remoted accepted and
+        queued for delivery to wazuh-analysisd. These are stateless event
+        payloads that drive rule-based detection. Messages classified as
+        control, inventory-sync, upgrade-ack, ping, or legacy DBSYNC are
+        counted under their own fields and do not contribute here.
       example: 5697755
     - name: failed.total
       type: long
       level: custom
+      short: Agent events that could not be delivered to wazuh-analysisd.
       description: >
-        Cumulative number of agent events that could not be delivered
-        to the analysis daemon.
+        Cumulative number of agent events that wazuh-remoted could not
+        deliver to wazuh-analysisd. Includes events rejected by the
+        internal batch queue (queue full or per-agent cap exceeded) and
+        events dropped by the HTTP dispatcher when the connection to
+        wazuh-analysisd is unavailable. An event counted here may also
+        appear in events.total, which reflects acceptance into the batch
+        queue, not successful delivery.
       example: 0
 
 - name: messages

--- a/wcs/stateless/metrics/comms/fields/custom/comms.yml
+++ b/wcs/stateless/metrics/comms/fields/custom/comms.yml
@@ -62,6 +62,13 @@
         Cumulative number of events forwarded to downstream processing
         components.
       example: 5697755
+    - name: failed.total
+      type: long
+      level: custom
+      description: >
+        Cumulative number of agent events that could not be delivered
+        to the analysis daemon.
+      example: 0
 
 - name: messages
   title: Messages
@@ -107,6 +114,22 @@
       description: >
         Cumulative number of control messages processed from the queue.
       example: 2918243
+    - name: states.total
+      type: long
+      level: custom
+      short: Inventory-sync messages forwarded to the states router.
+      description: >
+        Cumulative number of inventory-synchronization messages received
+        from agents and forwarded to the inventory-states router provider.
+      example: 0
+    - name: upgrades.total
+      type: long
+      level: custom
+      short: Upgrade-ack messages forwarded to the upgrades router.
+      description: >
+        Cumulative number of upgrade-acknowledgement messages received from
+        agents and forwarded to the upgrade_notifications router provider.
+      example: 0
 
 - name: network
   title: Network

--- a/wcs/stateless/metrics/comms/fields/subset.yml
+++ b/wcs/stateless/metrics/comms/fields/subset.yml
@@ -13,9 +13,18 @@ fields:
   events:
     fields:
       total: {}
+      failed:
+        fields:
+          total: {}
   messages:
     fields:
       total: {}
+      states:
+        fields:
+          total: {}
+      upgrades:
+        fields:
+          total: {}
       control:
         fields:
           dropped_on_close:


### PR DESCRIPTION
### Description

This PR adds 3 new fields to the template `metrics-comms.json` as requested and accepted in the issue:
- `events.failed.total`
- `messages.states.total`
- `messages.upgrades.total`

### Issues Resolved
Closes #1235

