### PR TITLE
Fix SLF4J provider in setup plugin: use 2.x bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent index swapping on default plan [(1188)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1188)
 - Change `threat.enrichments` and `wazuh.threat.enrichments` type from `nested` to `object` and remove root-level `enrichments` field set [(#1210)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1210)
 - Fix malformed signed CTI token-exchange request [(#1206)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1206)
+- Fix SLF4J startup warning in setup plugin by replacing 1.x bridge with correct 2.x provider [(#1245)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1245)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#484)](https://github.com/wazuh/wazuh-indexer-plugins/pull/484)

--- a/plugins/setup/build.gradle
+++ b/plugins/setup/build.gradle
@@ -79,7 +79,7 @@ configurations {
 }
 
 dependencies {
-  implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.25.4"
+  runtimeOnly "org.apache.logging.log4j:log4j-slf4j2-impl:2.25.4"
   implementation "org.slf4j:slf4j-api:2.0.17"
 
   // Use Jackson provided by OpenSearch (2.21.2) - only for compile time


### PR DESCRIPTION
### Description
The setup plugin used `log4j-slf4j-impl` (SLF4J 1.x) with `implementation` scope alongside `slf4j-api` 2.x. Replaces it with `log4j-slf4j2-impl` in `runtimeOnly` scope  (the correct provider for SLF4J 2.x).

### Issues Resolved
Resolves wazuh/wazuh-indexer#1577
