### PR TITLE
Remove hardcoded beta-2 default ruleset consumer

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -59,8 +59,7 @@ public class PluginSettings {
     private static final boolean DEFAULT_CREATE_DETECTORS = true;
 
     // Default values for catalog consumer URLs
-    private static final String DEFAULT_CATALOG_RULESET =
-            "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta-2-ruleset-5/consumers/public-ruleset-5";
+    private static final String DEFAULT_CATALOG_RULESET = "";
     private static final String DEFAULT_CATALOG_IOCS = "";
     private static final String DEFAULT_CATALOG_VULNERABILITIES = "";
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
@@ -74,9 +74,7 @@ public class PluginSettingsTests extends OpenSearchTestCase {
         // Verify default values
         Assert.assertTrue(pluginSettings.isUpdateOnStart());
         Assert.assertTrue(pluginSettings.isUpdateOnSchedule());
-        Assert.assertEquals(
-                "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta-2-ruleset-5/consumers/public-ruleset-5",
-                pluginSettings.getCatalogRuleset());
+        Assert.assertEquals("", pluginSettings.getCatalogRuleset());
         Assert.assertEquals("", pluginSettings.getCatalogIocs());
         Assert.assertEquals("", pluginSettings.getCatalogVulnerabilities());
     }


### PR DESCRIPTION
### Description
The Content Manager defaulted `plugins.content_manager.catalog.ruleset` to a hardcoded pre-production consumer (`beta-2-ruleset-5/public-ruleset-5`), so instances synced against the wrong consumer.

### Issues Resolved
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1241
