### PR TITLE
Add data stream names to the index patterns of ISM policies

### DIFF
--- a/plugins/setup/src/main/resources/policies/stream-active-responses-policy.json
+++ b/plugins/setup/src/main/resources/policies/stream-active-responses-policy.json
@@ -48,9 +48,10 @@
     "ism_template": [
       {
         "index_patterns": [
-          ".ds-wazuh-active-responses*"
+          ".ds-wazuh-active-responses-*",
+          "wazuh-active-responses*"
         ],
-        "priority": 100
+        "priority": 0
       }
     ]
   }

--- a/plugins/setup/src/main/resources/policies/stream-events-policy.json
+++ b/plugins/setup/src/main/resources/policies/stream-events-policy.json
@@ -48,9 +48,10 @@
     "ism_template": [
       {
         "index_patterns": [
-          ".ds-wazuh-events-v5-*"
+          ".ds-wazuh-events-v5-*",
+          "wazuh-events-v5*"
         ],
-        "priority": 50
+        "priority": 0
       }
     ]
   }

--- a/plugins/setup/src/main/resources/policies/stream-findings-policy.json
+++ b/plugins/setup/src/main/resources/policies/stream-findings-policy.json
@@ -48,9 +48,10 @@
     "ism_template": [
       {
         "index_patterns": [
-          ".ds-wazuh-findings-v5-*"
+          ".ds-wazuh-findings-v5-*",
+          "wazuh-findings-v5*"
         ],
-        "priority": 50
+        "priority": 0
       }
     ]
   }

--- a/plugins/setup/src/main/resources/policies/stream-metrics-policy.json
+++ b/plugins/setup/src/main/resources/policies/stream-metrics-policy.json
@@ -48,9 +48,10 @@
     "ism_template": [
       {
         "index_patterns": [
-          ".ds-wazuh-metrics-*"
+          ".ds-wazuh-metrics-*",
+          "wazuh-metrics*"
         ],
-        "priority": 100
+        "priority": 0
       }
     ]
   }

--- a/plugins/setup/src/main/resources/policies/stream-raw-events-policy.json
+++ b/plugins/setup/src/main/resources/policies/stream-raw-events-policy.json
@@ -48,9 +48,10 @@
     "ism_template": [
       {
         "index_patterns": [
-          ".ds-wazuh-events-raw-v5*"
+          ".ds-wazuh-events-raw-v5-*",
+          "wazuh-events-raw-v5*"
         ],
-        "priority": 100
+        "priority": 0
       }
     ]
   }


### PR DESCRIPTION
### Description
Add data stream names to the index patterns of ISM policies

Do not seem to work without them. See https://github.com/wazuh/wazuh-indexer-plugins/issues/1279\#issuecomment-4717634810

**Validation**

Pre-requisite: AIO deployment + Wazuh agent.

1. Stop the Wazuh manager.
2. Remove data streams and ISM policies.
3. Update your environment with the latest version of the setup plugin.
4. Update the ISM policy for events to reduce the conditions: min_doc: 200, min_index_age: 5m
5. **Manually** perform the first rollover on the applications index (see image 1)
6. Start the Wazuh manager.
7. Check that:
    - the ISM policy rollovers the existing index (See image 2).
    - the new index is managed by the ISM policy (See image 2).
    - old backing index is marked for deletion (see image 3).
    - old backing index is removed after approx. 5–15 minutes (see image 4).

Image 1
<img width="2856" height="406" alt="image" src="https://github.com/user-attachments/assets/decc33e4-a66b-4aec-a885-87839dc18a2d" />

Image 2
<img width="2988" height="542" alt="image" src="https://github.com/user-attachments/assets/33bf005c-1a59-4b92-b689-d612303471ab" />

Image 3
<img width="3098" height="465" alt="image" src="https://github.com/user-attachments/assets/72ea92d9-d51d-4e7e-adf4-09363487e7df" />

Image 4
<img width="3107" height="437" alt="image" src="https://github.com/user-attachments/assets/ef0e7e49-bca5-47ec-8bbb-8764326e7bcf" />


### Issues Resolved
Closes #1279 
