### PR TITLE
Use the zstd codec by default for indices created by Wazuh plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add configuration to documentation [(#1223)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1223)
 - Improve sigma rules documentation [(#1228)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1228)
 - Improve Content Manager logging clarity and reduce redundant log output [(#1237)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1237)
+- Use the zstd codec by default for indices created by Wazuh plugins [(#)](https://github.com/wazuh/wazuh-indexer-plugins/pull/)
 
 ### Deprecated
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add configuration to documentation [(#1223)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1223)
 - Improve sigma rules documentation [(#1228)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1228)
 - Improve Content Manager logging clarity and reduce redundant log output [(#1237)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1237)
-- Use the zstd codec by default for indices created by Wazuh plugins [(#)](https://github.com/wazuh/wazuh-indexer-plugins/pull/)
+- Use the zstd codec by default for indices created by Wazuh plugins [(#1294)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1294)
 
 ### Deprecated
 -

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ConsumersIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ConsumersIndex.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeoutException;
 import com.wazuh.contentmanager.cti.catalog.model.LocalConsumer;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.ClusterInfo;
+import com.wazuh.contentmanager.utils.Constants;
 
 /** Class to manage the Context index. */
 public class ConsumersIndex {
@@ -137,7 +138,11 @@ public class ConsumersIndex {
     public CreateIndexResponse createIndex()
             throws ExecutionException, InterruptedException, TimeoutException {
         Settings settings =
-                Settings.builder().put("index.number_of_replicas", 0).put("hidden", true).build();
+                Settings.builder()
+                        .put("index.number_of_replicas", 0)
+                        .put("hidden", true)
+                        .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD)
+                        .build();
 
         String mappings;
         try {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -210,7 +210,10 @@ public class ContentIndex {
             return null;
         }
 
-        Settings.Builder settingsBuilder = Settings.builder().put("index.number_of_replicas", 0);
+        Settings.Builder settingsBuilder =
+                Settings.builder()
+                        .put("index.number_of_replicas", 0)
+                        .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD);
         if (Constants.INDEX_CVES.equals(this.indexName)) {
             settingsBuilder.put("index.hidden", true);
         }
@@ -269,7 +272,11 @@ public class ContentIndex {
         }
 
         Settings settings =
-                Settings.builder().put("index.number_of_replicas", 0).put("index.hidden", true).build();
+                Settings.builder()
+                        .put("index.number_of_replicas", 0)
+                        .put("index.hidden", true)
+                        .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD)
+                        .build();
 
         String mappings = this.readMappings();
         if (mappings == null) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/CredentialsIndex.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.ClusterInfo;
+import com.wazuh.contentmanager.utils.Constants;
 
 /** Manages the hidden .wazuh-internal-state index used to persist the CTI access token. */
 public class CredentialsIndex {
@@ -203,7 +204,11 @@ public class CredentialsIndex {
         // access.
         try (ThreadContext.StoredContext ignoredContext = this.stashContext()) {
             Settings settings =
-                    Settings.builder().put("index.number_of_replicas", 0).put("index.hidden", true).build();
+                    Settings.builder()
+                            .put("index.number_of_replicas", 0)
+                            .put("index.hidden", true)
+                            .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD)
+                            .build();
 
             String mappings;
             try {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -527,6 +527,10 @@ public class Constants {
     public static final String INDEX_CVES = ".wazuh-threatintel-vulnerabilities";
     public static final String INDEX_FILTERS = "wazuh-threatintel-filters";
 
+    // Index settings
+    public static final String KEY_INDEX_CODEC = "index.codec";
+    public static final String CODEC_ZSTD = "zstd";
+
     // Resource Types Keys
     public static final String KEY_POLICY = "policy";
     public static final String KEY_INTEGRATIONS = "integrations";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ConsumersIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ConsumersIndexTests.java
@@ -237,9 +237,10 @@ public class ConsumersIndexTests extends OpenSearchTestCase {
         CreateIndexRequest request = captor.getValue();
         Assert.assertEquals(ConsumersIndex.INDEX_NAME, request.index());
 
-        // Validate Settings (Hidden = true, Replicas = 0)
+        // Validate Settings (Hidden = true, Replicas = 0, Codec = zstd)
         Assert.assertEquals("true", request.settings().get("hidden"));
         Assert.assertEquals("0", request.settings().get("index.number_of_replicas"));
+        Assert.assertEquals("zstd", request.settings().get("index.codec"));
     }
 
     /**

--- a/plugins/setup/src/main/resources/templates/content/filters.json
+++ b/plugins/setup/src/main/resources/templates/content/filters.json
@@ -7,6 +7,7 @@
     "settings": {
       "index": {
         "auto_expand_replicas": "0-1",
+        "codec": "zstd",
         "max_docvalue_fields_search": 50,
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/content/ioc.json
+++ b/plugins/setup/src/main/resources/templates/content/ioc.json
@@ -7,6 +7,7 @@
     "settings": {
       "index": {
         "auto_expand_replicas": "0-1",
+        "codec": "zstd",
         "max_docvalue_fields_search": 200,
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/cve.json
+++ b/plugins/setup/src/main/resources/templates/cve.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/ism-config.json
+++ b/plugins/setup/src/main/resources/templates/ism-config.json
@@ -6,6 +6,7 @@
   "template": {
         "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "refresh_interval": "5s",

--- a/plugins/setup/src/main/resources/templates/settings.json
+++ b/plugins/setup/src/main/resources/templates/settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "hidden": true,
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/setup-status.json
+++ b/plugins/setup/src/main/resources/templates/setup-status.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "hidden": true,
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/states/fim-files.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-files.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-groups.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-groups.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-networks.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-networks.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-packages.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-packages.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-ports.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-ports.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-processes.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-processes.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-services.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-services.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-system.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-system.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/inventory-users.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-users.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/sca.json
+++ b/plugins/setup/src/main/resources/templates/states/sca.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
+++ b/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
@@ -7,7 +7,7 @@
     "settings": {
       "index": {
         "auto_expand_replicas": "0-1",
-        "codec": "best_compression",
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -8,6 +8,7 @@
     "settings": {
       "index": {
         "auto_expand_replicas": "0-1",
+        "codec": "zstd",
         "max_docvalue_fields_search": 50,
         "number_of_replicas": "0",
         "number_of_shards": "3",

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -8,6 +8,7 @@
     "settings": {
       "index": {
         "auto_expand_replicas": "0-1",
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "3",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "3",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/streams/raw.json
+++ b/plugins/setup/src/main/resources/templates/streams/raw.json
@@ -8,6 +8,7 @@
     "settings": {
       "index": {
         "auto_expand_replicas": "0-1",
+        "codec": "zstd",
         "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "3",

--- a/plugins/setup/src/main/resources/templates/streams/unclassified.json
+++ b/plugins/setup/src/main/resources/templates/streams/unclassified.json
@@ -8,6 +8,7 @@
     "settings": {
       "index": {
         "auto_expand_replicas": "0-1",
+        "codec": "zstd",
         "max_docvalue_fields_search": 50,
         "number_of_replicas": "0",
         "number_of_shards": "3",

--- a/wcs/content/filters/fields/template-settings-legacy.json
+++ b/wcs/content/filters/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
     
     "mapping.nested_fields.limit": 10,
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "auto_expand_replicas": "0-1",

--- a/wcs/content/filters/fields/template-settings.json
+++ b/wcs/content/filters/fields/template-settings.json
@@ -9,6 +9,7 @@
       
       "mapping.nested_fields.limit": 10,
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "auto_expand_replicas": "0-1",

--- a/wcs/content/ioc/fields/template-settings-legacy.json
+++ b/wcs/content/ioc/fields/template-settings-legacy.json
@@ -8,6 +8,7 @@
     
     "mapping.nested_fields.limit": 50,
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "auto_expand_replicas": "0-1",

--- a/wcs/content/ioc/fields/template-settings.json
+++ b/wcs/content/ioc/fields/template-settings.json
@@ -9,6 +9,7 @@
       "plugins.index_state_management.rollover_alias": "wazuh-threatintel-enrichments",
       "mapping.nested_fields.limit": 50,
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "auto_expand_replicas": "0-1",

--- a/wcs/cve/fields/template-settings-legacy.json
+++ b/wcs/cve/fields/template-settings-legacy.json
@@ -5,6 +5,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "5s",

--- a/wcs/cve/fields/template-settings.json
+++ b/wcs/cve/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "5s",

--- a/wcs/settings/fields/template-settings-legacy.json
+++ b/wcs/settings/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/settings/fields/template-settings.json
+++ b/wcs/settings/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/fim/files/fields/template-settings-legacy.json
+++ b/wcs/stateful/fim/files/fields/template-settings-legacy.json
@@ -5,6 +5,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/fim/files/fields/template-settings.json
+++ b/wcs/stateful/fim/files/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/fim/windows-registry-keys/fields/template-settings-legacy.json
+++ b/wcs/stateful/fim/windows-registry-keys/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/fim/windows-registry-keys/fields/template-settings.json
+++ b/wcs/stateful/fim/windows-registry-keys/fields/template-settings.json
@@ -4,6 +4,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/fim/windows-registry-values/fields/template-settings-legacy.json
+++ b/wcs/stateful/fim/windows-registry-values/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/fim/windows-registry-values/fields/template-settings.json
+++ b/wcs/stateful/fim/windows-registry-values/fields/template-settings.json
@@ -4,6 +4,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/browser-extensions/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/browser-extensions/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/browser-extensions/fields/template-settings.json
+++ b/wcs/stateful/inventory/browser-extensions/fields/template-settings.json
@@ -6,6 +6,7 @@
     "template": {
         "settings": {
             "index": {
+              "codec": "zstd",
                 "number_of_shards": "1",
                 "number_of_replicas": "0",
                 "refresh_interval": "2s",

--- a/wcs/stateful/inventory/groups/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/groups/fields/template-settings-legacy.json
@@ -5,6 +5,7 @@
     "order": 1,
     "settings": {
         "index": {
+          "codec": "zstd",
             "number_of_shards": "1",
             "number_of_replicas": "0",
             "refresh_interval": "2s",

--- a/wcs/stateful/inventory/groups/fields/template-settings.json
+++ b/wcs/stateful/inventory/groups/fields/template-settings.json
@@ -6,6 +6,7 @@
     "template": {
         "settings": {
             "index": {
+              "codec": "zstd",
                 "number_of_shards": "1",
                 "number_of_replicas": "0",
                 "refresh_interval": "2s",

--- a/wcs/stateful/inventory/hardware/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/hardware/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/hardware/fields/template-settings.json
+++ b/wcs/stateful/inventory/hardware/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/hotfixes/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/hotfixes/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/hotfixes/fields/template-settings.json
+++ b/wcs/stateful/inventory/hotfixes/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/interfaces/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/interfaces/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/interfaces/fields/template-settings.json
+++ b/wcs/stateful/inventory/interfaces/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/networks/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/networks/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/networks/fields/template-settings.json
+++ b/wcs/stateful/inventory/networks/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/packages/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/packages/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/packages/fields/template-settings.json
+++ b/wcs/stateful/inventory/packages/fields/template-settings.json
@@ -4,6 +4,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/ports/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/ports/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/ports/fields/template-settings.json
+++ b/wcs/stateful/inventory/ports/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/processes/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/processes/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/processes/fields/template-settings.json
+++ b/wcs/stateful/inventory/processes/fields/template-settings.json
@@ -4,6 +4,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/protocols/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/protocols/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/protocols/fields/template-settings.json
+++ b/wcs/stateful/inventory/protocols/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/services/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/services/fields/template-settings-legacy.json
@@ -5,6 +5,7 @@
     "order": 1,
     "settings": {
         "index": {
+          "codec": "zstd",
             "number_of_shards": "1",
             "number_of_replicas": "0",
             "refresh_interval": "2s",

--- a/wcs/stateful/inventory/services/fields/template-settings.json
+++ b/wcs/stateful/inventory/services/fields/template-settings.json
@@ -6,6 +6,7 @@
     "template": {
         "settings": {
             "index": {
+              "codec": "zstd",
                 "number_of_shards": "1",
                 "number_of_replicas": "0",
                 "refresh_interval": "2s",

--- a/wcs/stateful/inventory/system/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/system/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateful/inventory/system/fields/template-settings.json
+++ b/wcs/stateful/inventory/system/fields/template-settings.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateful/inventory/users/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/users/fields/template-settings-legacy.json
@@ -5,6 +5,7 @@
     "order": 1,
     "settings": {
         "index": {
+          "codec": "zstd",
             "number_of_shards": "1",
             "number_of_replicas": "0",
             "refresh_interval": "2s",

--- a/wcs/stateful/inventory/users/fields/template-settings.json
+++ b/wcs/stateful/inventory/users/fields/template-settings.json
@@ -6,6 +6,7 @@
     "template": {
         "settings": {
             "index": {
+              "codec": "zstd",
                 "number_of_shards": "1",
                 "number_of_replicas": "0",
                 "refresh_interval": "2s",

--- a/wcs/stateful/sca/fields/template-settings-legacy.json
+++ b/wcs/stateful/sca/fields/template-settings-legacy.json
@@ -3,6 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "5s",

--- a/wcs/stateful/sca/fields/template-settings.json
+++ b/wcs/stateful/sca/fields/template-settings.json
@@ -4,6 +4,7 @@
   "template": {
     "settings": {
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "5s",

--- a/wcs/stateful/vulnerabilities/fields/template-settings-legacy.json
+++ b/wcs/stateful/vulnerabilities/fields/template-settings-legacy.json
@@ -3,7 +3,7 @@
   "order": 1,
   "settings": {
     "index": {
-      "codec": "best_compression",
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "auto_expand_replicas": "0-1",

--- a/wcs/stateful/vulnerabilities/fields/template-settings.json
+++ b/wcs/stateful/vulnerabilities/fields/template-settings.json
@@ -4,7 +4,7 @@
   "template": {
     "settings": {
       "index": {
-        "codec": "best_compression",
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "auto_expand_replicas": "0-1",

--- a/wcs/stateless/active-responses/fields/template-settings-legacy.json
+++ b/wcs/stateless/active-responses/fields/template-settings-legacy.json
@@ -9,6 +9,7 @@
     "plugins.index_state_management.policy_id": "stream-active-responses-policy",
     "mapping.nested_fields.limit": 10,
     "index": {
+      "codec": "zstd",
       "number_of_shards": "3",
       "number_of_replicas": "0",
       "auto_expand_replicas": "0-1",

--- a/wcs/stateless/active-responses/fields/template-settings.json
+++ b/wcs/stateless/active-responses/fields/template-settings.json
@@ -10,6 +10,7 @@
       "plugins.index_state_management.policy_id": "stream-active-responses-policy",
       "mapping.nested_fields.limit": 10,
       "index": {
+        "codec": "zstd",
         "number_of_shards": "3",
         "number_of_replicas": "0",
         "auto_expand_replicas": "0-1",

--- a/wcs/stateless/events/findings/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/findings/fields/template-settings-legacy.json
@@ -8,6 +8,7 @@
     "plugins.index_state_management.policy_id": "stream-findings-policy",
     "mapping.total_fields.limit": 3000,
     "index": {
+      "codec": "zstd",
       "number_of_shards": "3",
       "number_of_replicas": "0",
       "refresh_interval": "2s",

--- a/wcs/stateless/events/findings/fields/template-settings.json
+++ b/wcs/stateless/events/findings/fields/template-settings.json
@@ -10,6 +10,7 @@
       "plugins.index_state_management.policy_id": "stream-findings-policy",
       "mapping.total_fields.limit": 3000,
       "index": {
+        "codec": "zstd",
         "number_of_shards": "3",
         "number_of_replicas": "0",
         "refresh_interval": "2s",

--- a/wcs/stateless/events/main/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/main/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
     "plugins.index_state_management.rollover_alias": "wazuh-events-v5",
     "plugins.index_state_management.policy_id": "stream-events-policy",
     "index": {
+      "codec": "zstd",
       "number_of_shards": "3",
       "number_of_replicas": "0",
       "auto_expand_replicas": "0-1",

--- a/wcs/stateless/events/main/fields/template-settings.json
+++ b/wcs/stateless/events/main/fields/template-settings.json
@@ -9,6 +9,7 @@
       "plugins.index_state_management.rollover_alias": "wazuh-events-v5",
       "plugins.index_state_management.policy_id": "stream-events-policy",
       "index": {
+        "codec": "zstd",
         "number_of_shards": "3",
         "number_of_replicas": "0",
         "auto_expand_replicas": "0-1",

--- a/wcs/stateless/events/raw/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/raw/fields/template-settings-legacy.json
@@ -8,6 +8,7 @@
     "plugins.index_state_management.policy_id": "stream-raw-events-policy",
     "mapping.nested_fields.limit": 10,
     "index": {
+      "codec": "zstd",
       "number_of_shards": "3",
       "number_of_replicas": "0",
       "auto_expand_replicas": "0-1",

--- a/wcs/stateless/events/raw/fields/template-settings.json
+++ b/wcs/stateless/events/raw/fields/template-settings.json
@@ -10,6 +10,7 @@
       "plugins.index_state_management.policy_id": "stream-raw-events-policy",
       "mapping.nested_fields.limit": 10,
       "index": {
+        "codec": "zstd",
         "number_of_shards": "3",
         "number_of_replicas": "0",
         "auto_expand_replicas": "0-1",

--- a/wcs/stateless/events/unclassified/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/unclassified/fields/template-settings-legacy.json
@@ -9,6 +9,7 @@
     "mapping.total_fields.limit": 1000,
     "mapping.nested_fields.limit": 10,
     "index": {
+      "codec": "zstd",
       "number_of_shards": "3",
       "number_of_replicas": "0",
       "auto_expand_replicas": "0-1",

--- a/wcs/stateless/events/unclassified/fields/template-settings.json
+++ b/wcs/stateless/events/unclassified/fields/template-settings.json
@@ -11,6 +11,7 @@
       "mapping.total_fields.limit": 1000,
       "mapping.nested_fields.limit": 10,
       "index": {
+        "codec": "zstd",
         "number_of_shards": "3",
         "number_of_replicas": "0",
         "auto_expand_replicas": "0-1",

--- a/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
@@ -8,6 +8,7 @@
     "plugins.index_state_management.rollover_alias": "wazuh-metrics-agents",
     "plugins.index_state_management.policy_id": "stream-metrics-policy",
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "5s",

--- a/wcs/stateless/metrics/agents/fields/template-settings.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings.json
@@ -9,6 +9,7 @@
       "plugins.index_state_management.rollover_alias": "wazuh-metrics-agents",
       "plugins.index_state_management.policy_id": "stream-metrics-policy",
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "5s",

--- a/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
@@ -8,6 +8,7 @@
     "plugins.index_state_management.rollover_alias": "wazuh-metrics-comms",
     "plugins.index_state_management.policy_id": "stream-metrics-policy",
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "5s",

--- a/wcs/stateless/metrics/comms/fields/template-settings.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings.json
@@ -9,6 +9,7 @@
       "plugins.index_state_management.rollover_alias": "wazuh-metrics-comms",
       "plugins.index_state_management.policy_id": "stream-metrics-policy",
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "5s",

--- a/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
@@ -8,6 +8,7 @@
     "plugins.index_state_management.rollover_alias": "wazuh-metrics-normalization",
     "plugins.index_state_management.policy_id": "stream-metrics-policy",
     "index": {
+      "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
       "refresh_interval": "5s",

--- a/wcs/stateless/metrics/engine/fields/template-settings.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings.json
@@ -9,6 +9,7 @@
       "plugins.index_state_management.rollover_alias": "wazuh-metrics-normalization",
       "plugins.index_state_management.policy_id": "stream-metrics-policy",
       "index": {
+        "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
         "refresh_interval": "5s",


### PR DESCRIPTION
### Description

Sets `index.codec: zstd` as the default codec for every index created by the Wazuh plugins (setup + content-manager), replacing the implicit `default` (LZ4) codec. 

### Issues Resolved
Closes #1271
