### PR TITLE
Fix unzip to manage larger zips

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/Unzip.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/Unzip.java
@@ -18,13 +18,16 @@ package com.wazuh.contentmanager.cti.catalog.utils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.SuppressForbidden;
 
 import java.io.BufferedOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.*;
+import java.util.Enumeration;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.zip.ZipFile;
 
 import reactor.util.annotation.NonNull;
 
@@ -37,34 +40,41 @@ public class Unzip {
      *
      * @param source path of the file to unzip.
      * @param destination folder to extract to.
-     * @throws IOException rethrown from getNextEntry()
+     * @throws IOException if the source is missing or the archive cannot be opened/read.
      */
+    @SuppressForbidden(reason = "ZipFile is needed for ZIP64 support; it reads via the archive path")
     public static void unzip(@NonNull Path source, @NonNull Path destination) throws IOException {
         if (!Files.exists(source)) {
             throw new FileNotFoundException("ZIP does not exist: " + source);
         }
 
-        try (ZipInputStream zipInputStream = new ZipInputStream(Files.newInputStream(source))) {
-            ZipEntry zipEntry;
-            while ((zipEntry = zipInputStream.getNextEntry()) != null) {
+        try (ZipFile zipFile = new ZipFile(source.toFile())) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry zipEntry = entries.nextElement();
                 Path destinationFile = destination.resolve(zipEntry.getName()).normalize();
                 if (!destinationFile.startsWith(destination)) {
                     throw new IOException("Bad zip entry: " + zipEntry.getName());
                 }
-                Unzip.extract(zipInputStream, destinationFile);
-                zipInputStream.closeEntry();
+                if (zipEntry.isDirectory()) {
+                    Files.createDirectories(destinationFile);
+                    continue;
+                }
+                Unzip.extract(zipFile, zipEntry, destinationFile);
             }
         }
         log.info("[{}] unzipped to [{}]", source.getFileName().toString(), destination.toString());
     }
 
     /**
-     * Extracts a file from a ZIP input stream.
+     * Extracts a single entry from a ZIP file.
      *
-     * @param zipInputStream ZIP input stream.
-     * @param destinationFile Path (directory) where the file will be extracted.
+     * @param zipFile the opened ZIP file.
+     * @param zipEntry the entry to extract.
+     * @param destinationFile Path (file) where the entry will be written.
      */
-    private static void extract(ZipInputStream zipInputStream, Path destinationFile) {
+    @SuppressForbidden(reason = "ZipFile is needed for ZIP64 support; it reads via the archive path")
+    private static void extract(ZipFile zipFile, ZipEntry zipEntry, Path destinationFile) {
         byte[] buffer = new byte[1024];
         // Ensure parent directories exist
         try {
@@ -73,14 +83,15 @@ public class Unzip {
             log.error("Destination directory does not exist: {}", e.getMessage());
         }
 
-        try (BufferedOutputStream bufferedOutputStream =
-                new BufferedOutputStream(
-                        Files.newOutputStream(
-                                destinationFile,
-                                StandardOpenOption.CREATE,
-                                StandardOpenOption.TRUNCATE_EXISTING))) {
+        try (InputStream entryStream = zipFile.getInputStream(zipEntry);
+                BufferedOutputStream bufferedOutputStream =
+                        new BufferedOutputStream(
+                                Files.newOutputStream(
+                                        destinationFile,
+                                        StandardOpenOption.CREATE,
+                                        StandardOpenOption.TRUNCATE_EXISTING))) {
             int size;
-            while ((size = zipInputStream.read(buffer)) > 0) {
+            while ((size = entryStream.read(buffer)) > 0) {
                 bufferedOutputStream.write(buffer, 0, size);
             }
         } catch (IOException e) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/Unzip.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/Unzip.java
@@ -48,12 +48,15 @@ public class Unzip {
             throw new FileNotFoundException("ZIP does not exist: " + source);
         }
 
+        // Resolve the destination root to its real path
+        Path destinationRoot = destination.toRealPath();
+
         try (ZipFile zipFile = new ZipFile(source.toFile())) {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry zipEntry = entries.nextElement();
-                Path destinationFile = destination.resolve(zipEntry.getName()).normalize();
-                if (!destinationFile.startsWith(destination)) {
+                Path destinationFile = destinationRoot.resolve(zipEntry.getName()).normalize();
+                if (!destinationFile.startsWith(destinationRoot)) {
                     throw new IOException("Bad zip entry: " + zipEntry.getName());
                 }
                 if (zipEntry.isDirectory()) {
@@ -72,30 +75,33 @@ public class Unzip {
      * @param zipFile the opened ZIP file.
      * @param zipEntry the entry to extract.
      * @param destinationFile Path (file) where the entry will be written.
+     * @throws IOException if the entry cannot be read or written. Propagated so the caller can
+     *     abort/retry/cleanup instead of proceeding with a truncated or missing file.
      */
     @SuppressForbidden(reason = "ZipFile is needed for ZIP64 support; it reads via the archive path")
-    private static void extract(ZipFile zipFile, ZipEntry zipEntry, Path destinationFile) {
+    private static void extract(ZipFile zipFile, ZipEntry zipEntry, Path destinationFile)
+            throws IOException {
         byte[] buffer = new byte[1024];
-        // Ensure parent directories exist
-        try {
-            Files.createDirectories(destinationFile.getParent());
-        } catch (IOException e) {
-            log.error("Destination directory does not exist: {}", e.getMessage());
-        }
 
-        try (InputStream entryStream = zipFile.getInputStream(zipEntry);
-                BufferedOutputStream bufferedOutputStream =
-                        new BufferedOutputStream(
-                                Files.newOutputStream(
-                                        destinationFile,
-                                        StandardOpenOption.CREATE,
-                                        StandardOpenOption.TRUNCATE_EXISTING))) {
-            int size;
-            while ((size = entryStream.read(buffer)) > 0) {
-                bufferedOutputStream.write(buffer, 0, size);
+        try {
+            // Ensure parent directories exist
+            Files.createDirectories(destinationFile.getParent());
+
+            try (InputStream entryStream = zipFile.getInputStream(zipEntry);
+                    BufferedOutputStream bufferedOutputStream =
+                            new BufferedOutputStream(
+                                    Files.newOutputStream(
+                                            destinationFile,
+                                            StandardOpenOption.CREATE,
+                                            StandardOpenOption.TRUNCATE_EXISTING))) {
+                int size;
+                while ((size = entryStream.read(buffer)) > 0) {
+                    bufferedOutputStream.write(buffer, 0, size);
+                }
             }
         } catch (IOException e) {
-            log.error("Zip extraction failed: {}", e.getMessage());
+            log.error("Zip extraction failed for entry [{}]: {}", zipEntry.getName(), e.getMessage());
+            throw e;
         }
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/utils/UnzipTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/utils/UnzipTests.java
@@ -103,7 +103,7 @@ public class UnzipTests extends OpenSearchTestCase {
     }
 
     /**
-     * Regression test for the CTI vulnerabilities snapshot failure (issue #1278): large snapshots are
+     * Regression test for the CTI vulnerabilities snapshot failure: large snapshots are
      * ZIP64 archives. An archive with more than {@code 0xFFFF} entries forces the writer to emit a
      * ZIP64 end-of-central-directory record, which can only be read by traversing the central
      * directory ({@link java.util.zip.ZipFile}). The previous streaming {@code ZipInputStream}
@@ -111,13 +111,20 @@ public class UnzipTests extends OpenSearchTestCase {
      * back buffer is full". This guards against a regression to a streaming reader.
      */
     public void testZip64ArchiveExtraction() throws IOException {
-        final int entryCount = 70_000; // exceeds the 0xFFFF (65535) entry limit -> forces ZIP64 EOCD
+        // Just over the 0xFFFF (65535) entry limit -> forces the writer to emit a ZIP64 EOCD record.
+        // The exact count only needs to exceed the limit, so we keep it minimal. Entries are empty
+        // except for two sentinels that carry content we assert on, to keep filesystem cost low.
+        final int entryCount = 0xFFFF + 1; // 65536
+        final int firstSentinel = 0;
+        final int lastSentinel = entryCount - 1;
         Path zip = this.tempDestinationDirectory.resolve("zip64.zip");
         try (ZipOutputStream zipOutputStream =
                 new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(zip)))) {
             for (int i = 0; i < entryCount; i++) {
                 zipOutputStream.putNextEntry(new ZipEntry("entries/file_" + i + ".txt"));
-                zipOutputStream.write(Integer.toString(i).getBytes(StandardCharsets.UTF_8));
+                if (i == firstSentinel || i == lastSentinel) {
+                    zipOutputStream.write(Integer.toString(i).getBytes(StandardCharsets.UTF_8));
+                }
                 zipOutputStream.closeEntry();
             }
         }
@@ -128,13 +135,19 @@ public class UnzipTests extends OpenSearchTestCase {
 
         Path extractedDir = out.resolve("entries");
         Assert.assertTrue("ZIP64 entries directory should exist", Files.isDirectory(extractedDir));
+        // Count only the entries we wrote: the Lucene test filesystem (ExtrasFS) randomly injects
+        // "extraN" files/dirs into new directories, so a raw count would be seed-dependent.
         try (Stream<Path> files = Files.list(extractedDir)) {
-            Assert.assertEquals("All ZIP64 entries should be extracted", entryCount, files.count());
+            long extracted =
+                    files.filter(p -> p.getFileName().toString().matches("file_\\d+\\.txt")).count();
+            Assert.assertEquals("All ZIP64 entries should be extracted", entryCount, extracted);
         }
-        Assert.assertEquals("0", Files.readString(extractedDir.resolve("file_0.txt")));
         Assert.assertEquals(
-                Integer.toString(entryCount - 1),
-                Files.readString(extractedDir.resolve("file_" + (entryCount - 1) + ".txt")));
+                Integer.toString(firstSentinel),
+                Files.readString(extractedDir.resolve("file_" + firstSentinel + ".txt")));
+        Assert.assertEquals(
+                Integer.toString(lastSentinel),
+                Files.readString(extractedDir.resolve("file_" + lastSentinel + ".txt")));
     }
 
     /** Nested directories and multiple files extract with the correct layout and content. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/utils/UnzipTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/utils/UnzipTests.java
@@ -28,6 +28,9 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -97,5 +100,94 @@ public class UnzipTests extends OpenSearchTestCase {
                 () ->
                         Unzip.unzip(
                                 this.environment.tmpDir().resolve("fake.txt"), this.tempDestinationDirectory));
+    }
+
+    /**
+     * Regression test for the CTI vulnerabilities snapshot failure (issue #1278): large snapshots are
+     * ZIP64 archives. An archive with more than {@code 0xFFFF} entries forces the writer to emit a
+     * ZIP64 end-of-central-directory record, which can only be read by traversing the central
+     * directory ({@link java.util.zip.ZipFile}). The previous streaming {@code ZipInputStream}
+     * implementation could not handle ZIP64 metadata and failed with "invalid entry size" / "Push
+     * back buffer is full". This guards against a regression to a streaming reader.
+     */
+    public void testZip64ArchiveExtraction() throws IOException {
+        final int entryCount = 70_000; // exceeds the 0xFFFF (65535) entry limit -> forces ZIP64 EOCD
+        Path zip = this.tempDestinationDirectory.resolve("zip64.zip");
+        try (ZipOutputStream zipOutputStream =
+                new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(zip)))) {
+            for (int i = 0; i < entryCount; i++) {
+                zipOutputStream.putNextEntry(new ZipEntry("entries/file_" + i + ".txt"));
+                zipOutputStream.write(Integer.toString(i).getBytes(StandardCharsets.UTF_8));
+                zipOutputStream.closeEntry();
+            }
+        }
+
+        Path out = this.tempDestinationDirectory.resolve("zip64-out");
+        Files.createDirectories(out);
+        Unzip.unzip(zip, out);
+
+        Path extractedDir = out.resolve("entries");
+        Assert.assertTrue("ZIP64 entries directory should exist", Files.isDirectory(extractedDir));
+        try (Stream<Path> files = Files.list(extractedDir)) {
+            Assert.assertEquals("All ZIP64 entries should be extracted", entryCount, files.count());
+        }
+        Assert.assertEquals("0", Files.readString(extractedDir.resolve("file_0.txt")));
+        Assert.assertEquals(
+                Integer.toString(entryCount - 1),
+                Files.readString(extractedDir.resolve("file_" + (entryCount - 1) + ".txt")));
+    }
+
+    /** Nested directories and multiple files extract with the correct layout and content. */
+    public void testNestedDirectoriesAndMultipleFiles() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("root.txt", "root");
+        entries.put("dir/", null); // explicit directory entry
+        entries.put("dir/child.txt", "child");
+        entries.put("dir/sub/deep.txt", "deep"); // parent dirs created implicitly
+        Path zip = this.createZip("nested.zip", entries);
+
+        Path out = this.tempDestinationDirectory.resolve("nested-out");
+        Files.createDirectories(out);
+        Unzip.unzip(zip, out);
+
+        Assert.assertEquals("root", Files.readString(out.resolve("root.txt")));
+        Assert.assertTrue(Files.isDirectory(out.resolve("dir")));
+        Assert.assertEquals("child", Files.readString(out.resolve("dir/child.txt")));
+        Assert.assertEquals("deep", Files.readString(out.resolve("dir/sub/deep.txt")));
+    }
+
+    /**
+     * Path-traversal ("zip slip") entries must be rejected without writing outside the destination.
+     */
+    public void testZipSlipEntryIsRejected() throws IOException {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("../escaped.txt", "evil");
+        Path zip = this.createZip("slip.zip", entries);
+
+        Path out = this.tempDestinationDirectory.resolve("slip-out");
+        Files.createDirectories(out);
+
+        Assert.assertThrows(IOException.class, () -> Unzip.unzip(zip, out));
+        Assert.assertFalse(
+                "Traversal entry must not be written outside the destination",
+                Files.exists(this.tempDestinationDirectory.resolve("escaped.txt")));
+    }
+
+    /**
+     * Helper that builds a ZIP file from an ordered map of entry name to content. A {@code null}
+     * content value writes a directory entry (the name should end with {@code /}).
+     */
+    private Path createZip(String zipName, Map<String, String> entries) throws IOException {
+        Path zip = this.tempDestinationDirectory.resolve(zipName);
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zip))) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                zipOutputStream.putNextEntry(new ZipEntry(entry.getKey()));
+                if (entry.getValue() != null) {
+                    zipOutputStream.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                }
+                zipOutputStream.closeEntry();
+            }
+        }
+        return zip;
     }
 }


### PR DESCRIPTION
### Description
This PR updates `Unzip.java` to use the random-access `java.util.zip.ZipFile` instead of `ZipInputStream`. By opening the file on disk and reading the archive's Central Directory first, `ZipFile` accesses the correct ZIP64 sizes for every entry, accurately bounds the inflater, and natively handles ZIP64 archives.
And since the snapshot is already fully downloaded to a local file prior to extraction, this approach works without any problem.

A suppression was added for the `forbiddenApis` rule that bans `java.util.zip.ZipFile` and `Path#toFile()`. 

### Issues Resolved
Closes #1308
