### PR TITLE
Add new transport action names

### DIFF
--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -140,7 +140,7 @@ Some endpoints modify configuration with a high impact on the platform and are p
 
 | Endpoint | Method | Permission (cluster action) |
 | --- | --- | --- |
-| `/_plugins/_content_manager/policy/{space}` | `PUT` | `indices:data/write/content_manager/policy/update` |
+| `/_plugins/_content_manager/policy/{space}` | `PUT` | `cluster:admin/content_manager/policy/update` |
 | `/_plugins/_content_manager/update` | `POST` | `cluster:admin/content_manager/update/trigger` |
 | `/_plugins/_setup/settings` | `PUT` | `cluster:admin/setup/settings/update` |
 

--- a/docs/ref/security/access-control.md
+++ b/docs/ref/security/access-control.md
@@ -39,7 +39,7 @@ A small set of endpoints modify configuration with a high impact on the platform
 
 | Endpoint                                      | Method | Permission (cluster action)           |
 |-----------------------------------------------|--------|---------------------------------------|
-| `/_plugins/_content_manager/policy/{space}`   | `PUT`  | `indices:data/write/content_manager/policy/update`   |
+| `/_plugins/_content_manager/policy/{space}`   | `PUT`  | `cluster:admin/content_manager/policy/update`   |
 | `/_plugins/_content_manager/update`           | `POST` | `cluster:admin/content_manager/update/trigger`  |
 | `/_plugins/_setup/settings`                   | `PUT`  | `cluster:admin/setup/settings/update`         |
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateDecoderAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateDecoderAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for CreateDecoder transport action. */
 public class CreateDecoderAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/decoder/create";
+    public static final String NAME = "cluster:admin/content_manager/decoder/create";
     public static final CreateDecoderAction INSTANCE = new CreateDecoderAction();
 
     public CreateDecoderAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateFilterAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for CreateFilter transport action. */
 public class CreateFilterAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/filter/create";
+    public static final String NAME = "cluster:admin/content_manager/filter/create";
     public static final CreateFilterAction INSTANCE = new CreateFilterAction();
 
     public CreateFilterAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateIntegrationAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for CreateIntegration transport action. */
 public class CreateIntegrationAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/integration/create";
+    public static final String NAME = "cluster:admin/content_manager/integration/create";
     public static final CreateIntegrationAction INSTANCE = new CreateIntegrationAction();
 
     public CreateIntegrationAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateKvdbAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateKvdbAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for CreateKvdb transport action. */
 public class CreateKvdbAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/kvdb/create";
+    public static final String NAME = "cluster:admin/content_manager/kvdb/create";
     public static final CreateKvdbAction INSTANCE = new CreateKvdbAction();
 
     public CreateKvdbAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateRuleAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/CreateRuleAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for CreateRule transport action. */
 public class CreateRuleAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/rule/create";
+    public static final String NAME = "cluster:admin/content_manager/rule/create";
     public static final CreateRuleAction INSTANCE = new CreateRuleAction();
 
     public CreateRuleAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteDecoderAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteDecoderAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for DeleteDecoder transport action. */
 public class DeleteDecoderAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/decoder/delete";
+    public static final String NAME = "cluster:admin/content_manager/decoder/delete";
     public static final DeleteDecoderAction INSTANCE = new DeleteDecoderAction();
 
     public DeleteDecoderAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteFilterAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for DeleteFilter transport action. */
 public class DeleteFilterAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/filter/delete";
+    public static final String NAME = "cluster:admin/content_manager/filter/delete";
     public static final DeleteFilterAction INSTANCE = new DeleteFilterAction();
 
     public DeleteFilterAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteIntegrationAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for DeleteIntegration transport action. */
 public class DeleteIntegrationAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/integration/delete";
+    public static final String NAME = "cluster:admin/content_manager/integration/delete";
     public static final DeleteIntegrationAction INSTANCE = new DeleteIntegrationAction();
 
     public DeleteIntegrationAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteKvdbAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteKvdbAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for DeleteKvdb transport action. */
 public class DeleteKvdbAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/kvdb/delete";
+    public static final String NAME = "cluster:admin/content_manager/kvdb/delete";
     public static final DeleteKvdbAction INSTANCE = new DeleteKvdbAction();
 
     public DeleteKvdbAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteRuleAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteRuleAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for DeleteRule transport action. */
 public class DeleteRuleAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/rule/delete";
+    public static final String NAME = "cluster:admin/content_manager/rule/delete";
     public static final DeleteRuleAction INSTANCE = new DeleteRuleAction();
 
     public DeleteRuleAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteSpaceAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteSpaceAction.java
@@ -19,7 +19,7 @@ package com.wazuh.contentmanager.action;
 import org.opensearch.action.ActionType;
 
 public class DeleteSpaceAction extends ActionType<MessageStatusResponse> {
-    public static final String NAME = "indices:data/write/content_manager/space/delete";
+    public static final String NAME = "cluster:admin/content_manager/space/delete";
     public static final DeleteSpaceAction INSTANCE = new DeleteSpaceAction();
 
     public DeleteSpaceAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/DeleteSubscriptionAction.java
@@ -19,7 +19,7 @@ package com.wazuh.contentmanager.action;
 import org.opensearch.action.ActionType;
 
 public class DeleteSubscriptionAction extends ActionType<MessageStatusResponse> {
-    public static final String NAME = "indices:data/write/content_manager/subscription/delete";
+    public static final String NAME = "cluster:admin/content_manager/subscription/delete";
     public static final DeleteSubscriptionAction INSTANCE = new DeleteSubscriptionAction();
 
     public DeleteSubscriptionAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/LogtestAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/LogtestAction.java
@@ -19,7 +19,7 @@ package com.wazuh.contentmanager.action;
 import org.opensearch.action.ActionType;
 
 public class LogtestAction extends ActionType<LogtestResponse> {
-    public static final String NAME = "indices:data/read/content_manager/logtest";
+    public static final String NAME = "cluster:monitor/content_manager/logtest";
     public static final LogtestAction INSTANCE = new LogtestAction();
 
     public LogtestAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/LogtestDetectionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/LogtestDetectionAction.java
@@ -19,7 +19,7 @@ package com.wazuh.contentmanager.action;
 import org.opensearch.action.ActionType;
 
 public class LogtestDetectionAction extends ActionType<LogtestResponse> {
-    public static final String NAME = "indices:data/read/content_manager/logtest_detection";
+    public static final String NAME = "cluster:monitor/content_manager/logtest/detection";
     public static final LogtestDetectionAction INSTANCE = new LogtestDetectionAction();
 
     public LogtestDetectionAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/LogtestNormalizationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/LogtestNormalizationAction.java
@@ -19,7 +19,7 @@ package com.wazuh.contentmanager.action;
 import org.opensearch.action.ActionType;
 
 public class LogtestNormalizationAction extends ActionType<LogtestResponse> {
-    public static final String NAME = "indices:data/read/content_manager/logtest_normalization";
+    public static final String NAME = "cluster:monitor/content_manager/logtest/normalization";
     public static final LogtestNormalizationAction INSTANCE = new LogtestNormalizationAction();
 
     public LogtestNormalizationAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateDecoderAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateDecoderAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for UpdateDecoder transport action. */
 public class UpdateDecoderAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/decoder/update";
+    public static final String NAME = "cluster:admin/content_manager/decoder/update";
     public static final UpdateDecoderAction INSTANCE = new UpdateDecoderAction();
 
     public UpdateDecoderAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateFilterAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for UpdateFilter transport action. */
 public class UpdateFilterAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/filter/update";
+    public static final String NAME = "cluster:admin/content_manager/filter/update";
     public static final UpdateFilterAction INSTANCE = new UpdateFilterAction();
 
     public UpdateFilterAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateIntegrationAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for UpdateIntegration transport action. */
 public class UpdateIntegrationAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/integration/update";
+    public static final String NAME = "cluster:admin/content_manager/integration/update";
     public static final UpdateIntegrationAction INSTANCE = new UpdateIntegrationAction();
 
     public UpdateIntegrationAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateKvdbAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateKvdbAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for UpdateKvdb transport action. */
 public class UpdateKvdbAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/kvdb/update";
+    public static final String NAME = "cluster:admin/content_manager/kvdb/update";
     public static final UpdateKvdbAction INSTANCE = new UpdateKvdbAction();
 
     public UpdateKvdbAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdatePolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdatePolicyAction.java
@@ -19,7 +19,7 @@ package com.wazuh.contentmanager.action;
 import org.opensearch.action.ActionType;
 
 public class UpdatePolicyAction extends ActionType<MessageStatusResponse> {
-    public static final String NAME = "indices:data/write/content_manager/policy/update";
+    public static final String NAME = "cluster:admin/content_manager/policy/update";
     public static final UpdatePolicyAction INSTANCE = new UpdatePolicyAction();
 
     public UpdatePolicyAction() {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateRuleAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/UpdateRuleAction.java
@@ -20,7 +20,7 @@ import org.opensearch.action.ActionType;
 
 /** Action type for UpdateRule transport action. */
 public class UpdateRuleAction extends ActionType<ContentResponse> {
-    public static final String NAME = "indices:data/write/content_manager/rule/update";
+    public static final String NAME = "cluster:admin/content_manager/rule/update";
     public static final UpdateRuleAction INSTANCE = new UpdateRuleAction();
 
     public UpdateRuleAction() {

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/filter/SensitiveConfigActionFilterTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/filter/SensitiveConfigActionFilterTests.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.verify;
 /** Unit tests for {@link SensitiveConfigActionFilter}. */
 public class SensitiveConfigActionFilterTests extends OpenSearchTestCase {
 
-    private static final String POLICY_ACTION = "indices:data/write/content_manager/policy/update";
+    private static final String POLICY_ACTION = "cluster:admin/content_manager/policy/update";
     private static final String UPDATE_ACTION = "cluster:admin/content_manager/update/trigger";
 
     private final SensitiveConfigActionFilter filter = new SensitiveConfigActionFilter();
@@ -99,6 +99,6 @@ public class SensitiveConfigActionFilterTests extends OpenSearchTestCase {
 
     public void testIgnoresUnprotectedAction() {
         this.configure(false, false);
-        this.assertAllowed("indices:data/write/index");
+        this.assertAllowed("cluster:admin/");
     }
 }


### PR DESCRIPTION
### Description

Renamed action names:

- `indices:data/write/content_manager/*` → `cluster:admin/content_manager/*`
- `indices:data/read/content_manager/logtest*` → `cluster:monitor/content_manager/logtest*`


Packages:
- https://github.com/wazuh/wazuh-indexer/actions/runs/28451624874

<img width="1834" height="416" alt="image" src="https://github.com/user-attachments/assets/df0b2828-e328-4ad0-a85a-b5d222c8d5c1" />


```
root@default:/home/vagrant# echo ""^C $LOG && systemctl restart wazuh-indexer
root@default:/home/vagrant# grep -iE "SystemIndexAccessEvaluator" $LOG
root@default:/home/vagrant# grep -iE "invalid action name" $LOG
root@default:/home/vagrant# grep -iE "error" $LOG
[2026-06-30T14:54:49,002][INFO ][o.o.n.Node               ] [indexer] JVM arguments [-Xshare:auto, -Dopensearch.networkaddress.cache.ttl=60, -Dopensearch.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -XX:+ShowCodeDetailsInExceptionMessages, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dio.netty.allocator.numDirectArenas=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Djava.locale.providers=SPI,CLDR, -Xms3969m, -Xmx3969m, -XX:+UseG1GC, -XX:G1ReservePercent=25, -XX:InitiatingHeapOccupancyPercent=30, -Djava.io.tmpdir=/var/lib/wazuh-indexer/tmp, -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=/var/lib/wazuh-indexer, -XX:ErrorFile=/var/log/wazuh-indexer/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=/var/log/wazuh-indexer/gc.log:utctime,pid,tags:filecount=32,filesize=64m, --add-modules=jdk.incubator.vector, -javaagent:agent/opensearch-agent.jar, --add-opens=java.base/java.nio=ALL-UNNAMED, --enable-native-access=ALL-UNNAMED, --sun-misc-unsafe-memory-access=allow, -Dorg.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits=1, -XX:+UseCompactObjectHeaders, --enable-native-access=ALL-UNNAMED, -XX:MaxDirectMemorySize=2081423360, -Dopensearch.path.home=/usr/share/wazuh-indexer, -Dopensearch.path.conf=/etc/wazuh-indexer, -Dopensearch.distribution.type=deb, -Dopensearch.bundled_jdk=true]
[2026-06-30T14:54:54,020][ERROR][o.o.s.a.s.SinkProvider   ] [indexer] Default endpoint could not be created, auditlog will not work properly.
[2026-06-30T14:54:57,038][ERROR][o.o.i.i.ManagedIndexCoordinator] [indexer] get managed-index failed: NoShardAvailableActionException[No shard available for [org.opensearch.action.get.MultiGetShardRequest@4e4d4d5a]]
[2026-06-30T14:54:57,085][ERROR][o.o.i.i.ManagedIndexCoordinator] [indexer] Failed to get ISM policies with templates: Failed to execute phase [query], all shards failed
[2026-06-30T14:54:57,685][ERROR][o.o.s.a.BackendRegistry  ] [indexer] OpenSearch Security not initialized. (you may need to run securityadmin)
[2026-06-30T14:54:57,722][ERROR][o.o.s.a.BackendRegistry  ] [indexer] OpenSearch Security not initialized. (you may need to run securityadmin)
[2026-06-30T14:54:57,724][ERROR][o.o.s.a.BackendRegistry  ] [indexer] OpenSearch Security not initialized. (you may need to run securityadmin)
[2026-06-30T14:54:57,727][ERROR][o.o.s.a.BackendRegistry  ] [indexer] OpenSearch Security not initialized. (you may need to run securityadmin)
root@default:/home/vagrant# grep -iE "warn" $LOG
[2026-06-30T14:54:48,985][WARN ][stderr                   ] [indexer] Jun 30, 2026 2:54:48 PM org.opensearch.javaagent.bootstrap.AgentPolicy setPolicy
[2026-06-30T14:54:48,989][WARN ][stderr                   ] [indexer] INFO: Policy attached successfully: org.opensearch.bootstrap.OpenSearchPolicy@d8d9199
[2026-06-30T14:54:49,185][WARN ][stderr                   ] [indexer] Jun 30, 2026 2:54:49 PM org.apache.lucene.internal.vectorization.PanamaVectorizationProvider <init>
[2026-06-30T14:54:49,185][WARN ][stderr                   ] [indexer] INFO: Java vector incubator API enabled; uses preferredBitSize=256; FMA enabled
[2026-06-30T14:54:54,021][WARN ][o.o.s.a.r.AuditMessageRouter] [indexer] No default storage available, audit log may not work properly. Please check configuration.
[2026-06-30T14:54:54,047][WARN ][o.o.s.c.Salt             ] [indexer] If you plan to use field masking pls configure compliance salt e1ukloTsQlOgPquJ to be a random string of 16 chars length identical on all nodes
[2026-06-30T14:54:54,047][WARN ][o.o.s.c.Salt             ] [indexer] If you plan to use field masking pls configure compliance salt e1ukloTsQlOgPquJ to be a random string of 16 chars length identical on all nodes
[2026-06-30T14:54:54,072][WARN ][o.o.s.c.Salt             ] [indexer] If you plan to use field masking pls configure compliance salt e1ukloTsQlOgPquJ to be a random string of 16 chars length identical on all nodes
[2026-06-30T14:55:26,855][WARN ][o.o.c.InternalClusterInfoService] [indexer] No resource usage stats available for node: indexer
[2026-06-30T14:55:56,860][WARN ][o.o.c.InternalClusterInfoService] [indexer] No resource usage stats available for node: indexer
[2026-06-30T14:56:26,869][WARN ][o.o.c.InternalClusterInfoService] [indexer] No resource usage stats available for node: indexer
```

### Issues Resolved
Closes #1325 
