### PR TITLE
Fix missing root decoder upon space reset

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Policy.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Policy.java
@@ -72,6 +72,7 @@ public class Policy {
     @JsonProperty(METADATA_KEY)
     private ResourceMetadata metadata;
 
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonProperty(ROOT_DECODER_KEY)
     private String rootDecoder;
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
@@ -133,7 +133,7 @@ public class TransportPostPromoteAction
             // 3. Validation Phase - Invoke engine validation
             Space targetSpace = spaceDiff.getSpace().promote();
             if ((targetSpace == Space.TEST || targetSpace == Space.CUSTOM)
-                    && (hasEngineRelatedChanges(context)
+                    && (this.hasEngineRelatedChanges(context)
                             || this.spaceService.hasEngineResources(targetSpace))) {
                 RestResponse engineResponse = this.engine.promote(context.enginePayload);
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/model/PolicyTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/model/PolicyTests.java
@@ -264,7 +264,9 @@ public class PolicyTests extends OpenSearchTestCase {
         Map<String, Object> map = minimalPolicy.toMap();
 
         // Assert
-        Assert.assertFalse(map.containsKey("root_decoder"));
+        Assert.assertTrue(
+                "root_decoder must always be present, even when null", map.containsKey("root_decoder"));
+        Assert.assertNull(map.get("root_decoder"));
         Assert.assertTrue(map.containsKey("integrations")); // Empty list are included
         Assert.assertTrue(map.containsKey("metadata")); // Metadata is always present
     }
@@ -492,5 +494,21 @@ public class PolicyTests extends OpenSearchTestCase {
         Assert.assertFalse(json.has("enabled"));
         Assert.assertFalse(json.has("index_unclassified_events"));
         Assert.assertFalse(json.has("index_discarded_events"));
+    }
+
+    /**
+     * Test that a null root_decoder is still serialized as an explicit JSON null (verified by
+     * {@code @JsonInclude(ALWAYS)} on the field, overriding the class-level {@code NON_NULL}), so
+     * clearing the field is distinguishable from never having set it.
+     */
+    public void testToJson_RootDecoderNull_StillSerialized() {
+        // Arrange — rootDecoder is null by default
+
+        // Act
+        ObjectNode json = this.policy.toJson();
+
+        // Assert
+        Assert.assertTrue(json.has("root_decoder"));
+        Assert.assertTrue(json.get("root_decoder").isNull());
     }
 }


### PR DESCRIPTION
### Description
This is a **partial** fix for the bug described in #1332.

This pull request fixes the Indexer's side problem where after resetting the draft space, the draft policy has no `root_decoder` field. The changes in this PR ensures the `root_decoder` field is always indexer, even when it is `null`.

> [!NOTE]
> An engine's side fix is also required to allow promoting an empty / default policy. 
> - https://github.com/wazuh/wazuh/issues/37344

### Issues Resolved
Closes #1332 
