### PR TITLE
Allow dates on Content Manager's REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Unify Setup and Content Manager plugin states into running/ready/failed [(#1293)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1293)
 - Use the zstd codec by default for indices created by Wazuh plugins [(#1294)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1294)
 - Disable automatic refresh for low-activity indices [(#1304)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1304)
+- Allow dates on Content Manager's REST API [(#1359)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1359)
 
 ### Deprecated
 -

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -1541,11 +1541,21 @@ components:
         date:
           type: string
           format: date-time
-          description: Creation timestamp (ISO-8601)
+          description: |
+            Creation timestamp (ISO-8601). Optional on create/update requests: if omitted,
+            the server generates it. If provided, the value is stored as-is and is not
+            validated or reformatted by the plugin — it must match the underlying index
+            field's `date` mapping format (`strict_date_optional_time||epoch_millis`), or
+            the request fails with `400 Bad Request`.
         modified:
           type: string
           format: date-time
-          description: Last modification timestamp (ISO-8601)
+          description: |
+            Last modification timestamp (ISO-8601). Optional on create/update requests: if
+            omitted, the server generates it. If provided, the value is stored as-is and is
+            not validated or reformatted by the plugin — it must match the underlying index
+            field's `date` mapping format (`strict_date_optional_time||epoch_millis`), or
+            the request fails with `400 Bad Request`.
         description:
           type: string
           description: Brief description
@@ -1577,11 +1587,19 @@ components:
         date:
           type: string
           format: date-time
-          description: Creation timestamp (ISO-8601)
+          description: |
+            Creation timestamp (ISO-8601). Read-only in practice: on update, any
+            caller-supplied value is ignored and the existing policy's original creation
+            date is preserved.
         modified:
           type: string
           format: date-time
-          description: Last modification timestamp (ISO-8601)
+          description: |
+            Last modification timestamp (ISO-8601). Optional on update requests: if
+            omitted, the server generates it. If provided, the value is stored as-is and is
+            not validated or reformatted by the plugin — it must match the underlying index
+            field's `date` mapping format (`strict_date_optional_time||epoch_millis`), or
+            the request fails with `400 Bad Request`.
         description:
           type: string
           description: Brief description

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
@@ -276,26 +276,42 @@ public class Resource {
     }
 
     /**
-     * Sets the creation time on the given resource JSON node, inside {@code metadata.date}.
+     * Sets the creation time on the given resource JSON node, inside {@code metadata.date}, unless a
+     * caller-supplied value is already present.
      *
      * @param resourceNode The resource JSON node.
      * @param timestamp The timestamp to set.
      */
     public static void setCreationTime(ObjectNode resourceNode, String timestamp) {
         ObjectNode metadataNode = Resource.getOrCreateMetadataNode(resourceNode);
-        metadataNode.put(Constants.KEY_DATE, timestamp);
+        if (!Resource.hasNonBlankValue(metadataNode, Constants.KEY_DATE)) {
+            metadataNode.put(Constants.KEY_DATE, timestamp);
+        }
     }
 
     /**
      * Sets the last modification time on the given resource JSON node, inside {@code
-     * metadata.modified}.
+     * metadata.modified}, unless a caller-supplied value is already present.
      *
      * @param resourceNode The resource JSON node.
      * @param timestamp The timestamp to set.
      */
     public static void setLastModificationTime(ObjectNode resourceNode, String timestamp) {
         ObjectNode metadataNode = Resource.getOrCreateMetadataNode(resourceNode);
-        metadataNode.put(Constants.KEY_MODIFIED, timestamp);
+        if (!Resource.hasNonBlankValue(metadataNode, Constants.KEY_MODIFIED)) {
+            metadataNode.put(Constants.KEY_MODIFIED, timestamp);
+        }
+    }
+
+    /**
+     * Checks whether the given field is present on the node with a non-null, non-blank value.
+     *
+     * @param node The JSON object node to inspect.
+     * @param field The field name to check.
+     * @return {@code true} if the field holds a non-blank value.
+     */
+    private static boolean hasNonBlankValue(ObjectNode node, String field) {
+        return node.has(field) && !node.get(field).isNull() && !node.get(field).asText("").isBlank();
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateAction.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -276,6 +277,10 @@ public abstract class AbstractTransportCreateAction
             OpenSearchSecurityException secEx = TransportActionHelper.extractSecurityException(e);
             if (secEx != null) {
                 return new RestResponse(secEx.getMessage(), secEx.status().getStatus());
+            }
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null) {
+                return new RestResponse(osEx.getMessage(), osEx.status().getStatus());
             }
             log.error(
                     Constants.E_LOG_OPERATION_FAILED,

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -265,6 +266,10 @@ public abstract class AbstractTransportCreateActionSpaces
             OpenSearchSecurityException secEx = TransportActionHelper.extractSecurityException(e);
             if (secEx != null) {
                 return new RestResponse(secEx.getMessage(), secEx.status().getStatus());
+            }
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null) {
+                return new RestResponse(osEx.getMessage(), osEx.status().getStatus());
             }
             log.error(
                     Constants.E_LOG_OPERATION_FAILED,

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateAction.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -292,6 +293,10 @@ public abstract class AbstractTransportUpdateAction
             OpenSearchSecurityException secEx = TransportActionHelper.extractSecurityException(e);
             if (secEx != null) {
                 return new RestResponse(secEx.getMessage(), secEx.status().getStatus());
+            }
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null) {
+                return new RestResponse(osEx.getMessage(), osEx.status().getStatus());
             }
             log.error(Constants.E_LOG_UNEXPECTED, "updating", this.getResourceType(), id, e.getMessage());
             return new RestResponse(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -292,6 +293,10 @@ public abstract class AbstractTransportUpdateActionSpaces
             OpenSearchSecurityException secEx = TransportActionHelper.extractSecurityException(e);
             if (secEx != null) {
                 return new RestResponse(secEx.getMessage(), secEx.status().getStatus());
+            }
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null) {
+                return new RestResponse(osEx.getMessage(), osEx.status().getStatus());
             }
             log.error(Constants.E_LOG_UNEXPECTED, "updating", this.getResourceType(), id, e.getMessage());
             return new RestResponse(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
@@ -18,6 +18,7 @@ package com.wazuh.contentmanager.transport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -76,6 +77,24 @@ public final class TransportActionHelper {
         while (cause != null) {
             if (cause instanceof OpenSearchSecurityException) {
                 return (OpenSearchSecurityException) cause;
+            }
+            cause = cause.getCause();
+        }
+        return null;
+    }
+
+    /**
+     * Walks the exception cause chain looking for an OpenSearchException, e.g. a {@code
+     * MapperParsingException} raised when a caller-supplied value (such as a malformed date) fails
+     * index mapping validation. OpenSearchException subclasses carry their own correct {@link
+     * org.opensearch.core.rest.RestStatus} (400 for mapping/parsing failures), so callers should
+     * prefer it over a hardcoded Internal Server Error.
+     */
+    public static OpenSearchException extractOpenSearchException(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (cause instanceof OpenSearchException) {
+                return (OpenSearchException) cause;
             }
             cause = cause.getCause();
         }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateRuleAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateRuleAction.java
@@ -18,6 +18,7 @@ package com.wazuh.contentmanager.transport;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -131,6 +132,12 @@ public class TransportCreateRuleAction extends AbstractTransportCreateAction {
             OpenSearchSecurityException secEx = TransportActionHelper.extractSecurityException(e);
             if (secEx != null) {
                 return new RestResponse(secEx.getMessage(), secEx.status().getStatus());
+            }
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null) {
+                return new RestResponse(
+                        Constants.E_SECURITY_ANALYTICS_ERROR + " " + osEx.getMessage(),
+                        osEx.status().getStatus());
             }
             String msg = e.getMessage() != null ? e.getMessage() : "Unknown error";
             return new RestResponse(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -261,10 +262,14 @@ public class TransportUpdatePolicyAction
         if (dateObj == null) dateObj = currentPolicyDoc.get(Constants.KEY_DATE);
         String docCreationDate = dateObj != null ? dateObj.toString() : "";
 
+        String incomingModified = incomingPolicy.getModified();
         Policy mergedPolicy = new Policy();
         mergedPolicy.setId(docId);
         mergedPolicy.setDate(docCreationDate);
-        mergedPolicy.setModified(Instant.now().toString());
+        mergedPolicy.setModified(
+                incomingModified != null && !incomingModified.isBlank()
+                        ? incomingModified
+                        : Instant.now().toString());
 
         Object titleObj = existingMetadata.get(Constants.KEY_TITLE);
         if (titleObj == null) titleObj = currentPolicyDoc.get(Constants.KEY_TITLE);
@@ -332,6 +337,10 @@ public class TransportUpdatePolicyAction
             IndexResponse indexResponse = index.create(standardPolicyId, document);
             return indexResponse.getId();
         } catch (Exception e) {
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null && osEx.status().getStatus() < 500) {
+                throw new IllegalArgumentException(osEx.getMessage());
+            }
             throw new IllegalStateException("Standard policy not found: " + e.getMessage());
         }
     }
@@ -380,7 +389,11 @@ public class TransportUpdatePolicyAction
         Object dateObj = existingMeta.get(Constants.KEY_DATE);
         if (dateObj == null) dateObj = currentPolicyDoc.get(Constants.KEY_DATE);
         String docCreationDate = dateObj != null ? dateObj.toString() : "";
-        String docModificationDate = Instant.now().toString();
+        String incomingModified = policy.getModified();
+        String docModificationDate =
+                incomingModified != null && !incomingModified.isBlank()
+                        ? incomingModified
+                        : Instant.now().toString();
 
         policy.setId(docId);
         policy.setDate(docCreationDate);
@@ -414,6 +427,10 @@ public class TransportUpdatePolicyAction
             IndexResponse indexResponse = index.create(draftPolicyId, document);
             return indexResponse.getId();
         } catch (Exception e) {
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null && osEx.status().getStatus() < 500) {
+                throw new IllegalArgumentException(osEx.getMessage());
+            }
             throw new IllegalStateException("Draft policy not found: " + e.getMessage());
         }
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateRuleAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateRuleAction.java
@@ -18,6 +18,7 @@ package com.wazuh.contentmanager.transport;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.common.inject.Inject;
@@ -90,6 +91,12 @@ public class TransportUpdateRuleAction extends AbstractTransportUpdateAction {
             OpenSearchSecurityException secEx = TransportActionHelper.extractSecurityException(e);
             if (secEx != null) {
                 return new RestResponse(secEx.getMessage(), secEx.status().getStatus());
+            }
+            OpenSearchException osEx = TransportActionHelper.extractOpenSearchException(e);
+            if (osEx != null) {
+                return new RestResponse(
+                        Constants.E_SECURITY_ANALYTICS_ERROR + " " + osEx.getMessage(),
+                        osEx.status().getStatus());
             }
             String msg = e.getMessage() != null ? e.getMessage() : "Unknown error";
             return new RestResponse(

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerRestTestCase.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerRestTestCase.java
@@ -111,6 +111,8 @@ public abstract class ContentManagerRestTestCase extends OpenSearchRestTestCase 
                                         "properties": {
                                             "title":    {"type": "keyword"},
                                             "author":   {"type": "keyword"},
+                                            "date":     {"type": "date"},
+                                            "modified": {"type": "date"},
                                             "description": {"type": "text"},
                                             "references":  {"type": "keyword"},
                                             "documentation": {"type": "keyword"}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/ResourceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/ResourceTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024-2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import com.wazuh.contentmanager.utils.Constants;
+
+/** Unit tests for {@link Resource}'s timestamp-generation helpers. */
+public class ResourceTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String GENERATED_TIMESTAMP = "2026-01-01T00:00:00Z";
+
+    public void testSetCreationTime_generatesWhenAbsent() {
+        ObjectNode resourceNode = MAPPER.createObjectNode();
+        Resource.setCreationTime(resourceNode, GENERATED_TIMESTAMP);
+        assertEquals(
+                GENERATED_TIMESTAMP,
+                resourceNode.get(Constants.KEY_METADATA).get(Constants.KEY_DATE).asText());
+    }
+
+    public void testSetCreationTime_preservesCallerSuppliedValue() {
+        ObjectNode resourceNode = MAPPER.createObjectNode();
+        ObjectNode metadata = resourceNode.putObject(Constants.KEY_METADATA);
+        String callerDate = "2020-05-17T10:00:00Z";
+        metadata.put(Constants.KEY_DATE, callerDate);
+
+        Resource.setCreationTime(resourceNode, GENERATED_TIMESTAMP);
+
+        assertEquals(callerDate, metadata.get(Constants.KEY_DATE).asText());
+    }
+
+    public void testSetCreationTime_generatesWhenCallerValueIsBlank() {
+        ObjectNode resourceNode = MAPPER.createObjectNode();
+        ObjectNode metadata = resourceNode.putObject(Constants.KEY_METADATA);
+        metadata.put(Constants.KEY_DATE, "  ");
+
+        Resource.setCreationTime(resourceNode, GENERATED_TIMESTAMP);
+
+        assertEquals(GENERATED_TIMESTAMP, metadata.get(Constants.KEY_DATE).asText());
+    }
+
+    public void testSetLastModificationTime_generatesWhenAbsent() {
+        ObjectNode resourceNode = MAPPER.createObjectNode();
+        Resource.setLastModificationTime(resourceNode, GENERATED_TIMESTAMP);
+        assertEquals(
+                GENERATED_TIMESTAMP,
+                resourceNode.get(Constants.KEY_METADATA).get(Constants.KEY_MODIFIED).asText());
+    }
+
+    public void testSetLastModificationTime_preservesCallerSuppliedValue() {
+        ObjectNode resourceNode = MAPPER.createObjectNode();
+        ObjectNode metadata = resourceNode.putObject(Constants.KEY_METADATA);
+        String callerModified = "2021-08-09T12:30:00Z";
+        metadata.put(Constants.KEY_MODIFIED, callerModified);
+
+        Resource.setLastModificationTime(resourceNode, GENERATED_TIMESTAMP);
+
+        assertEquals(callerModified, metadata.get(Constants.KEY_MODIFIED).asText());
+    }
+
+    public void testSetLastModificationTime_generatesWhenCallerValueIsBlank() {
+        ObjectNode resourceNode = MAPPER.createObjectNode();
+        ObjectNode metadata = resourceNode.putObject(Constants.KEY_METADATA);
+        metadata.put(Constants.KEY_MODIFIED, "  ");
+
+        Resource.setLastModificationTime(resourceNode, GENERATED_TIMESTAMP);
+
+        assertEquals(GENERATED_TIMESTAMP, metadata.get(Constants.KEY_MODIFIED).asText());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/DecoderCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/DecoderCUDIT.java
@@ -101,6 +101,102 @@ public class DecoderCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
+     * Create a decoder with caller-supplied {@code metadata.date} and {@code metadata.modified}
+     * timestamps.
+     *
+     * <p>Verifies: The caller-supplied timestamps are stored as-is instead of being replaced by
+     * plugin-generated ones.
+     *
+     * @throws IOException On failure to communicate with OpenSearch or parse responses.
+     */
+    public void testPostDecoder_honorsCallerSuppliedTimestamps() throws IOException {
+        String integrationId = this.createIntegration("test-decoder-caller-timestamps");
+        String callerDate = "2020-01-01T00:00:00Z";
+        String callerModified = "2020-06-15T12:30:00Z";
+
+        // spotless:off
+        String payload = """
+                {
+                    "integration": "%s",
+                    "resource": {
+                        "enabled": true,
+                        "metadata": {
+                            "author": "Wazuh, Inc.",
+                            "date": "%s",
+                            "modified": "%s",
+                            "description": "Test decoder with explicit timestamps.",
+                            "references": ["https://wazuh.com"],
+                            "title": "Test decoder with explicit timestamps"
+                        },
+                        "name": "decoder/test-decoder-timestamps/0",
+                        "check": [{"tmp_json.event.action": "string_equal(\\"test\\")"}],
+                        "normalize": [{"map": [{"@timestamp": "get_date()"}]}]
+                    }
+                }
+                """;
+        payload = String.format(Locale.ROOT, payload, integrationId, callerDate, callerModified);
+        // spotless:on
+
+        Response response = this.makeRequest("POST", PluginSettings.DECODERS_URI, payload);
+        assertEquals(RestStatus.CREATED.getStatus(), this.getStatusCode(response));
+        String decoderId = (String) this.parseResponseAsMap(response).get("message");
+
+        JsonNode source = this.getResourceByDocumentId(Constants.INDEX_DECODERS, decoderId, "draft");
+        JsonNode metadata = source.path(Constants.KEY_DOCUMENT).path(Constants.KEY_METADATA);
+        assertEquals(
+                "Caller-supplied 'date' should be honored", callerDate, metadata.path("date").asText());
+        assertEquals(
+                "Caller-supplied 'modified' should be honored",
+                callerModified,
+                metadata.path("modified").asText());
+    }
+
+    /**
+     * Create a decoder with a caller-supplied {@code metadata.date} that is not a valid date.
+     *
+     * <p>No plugin-side format validation is performed on caller-supplied dates; the malformed value
+     * is expected to fail index mapping validation ({@code MapperParsingException}).
+     *
+     * <p>Verifies: Response status code is 400 (Bad Request), not 500 (Internal Server Error).
+     *
+     * @throws IOException On failure to communicate with OpenSearch or parse responses.
+     */
+    public void testPostDecoder_malformedDateReturnsBadRequest() throws IOException {
+        String integrationId = this.createIntegration("test-decoder-malformed-date");
+
+        // spotless:off
+        String payload = """
+                {
+                    "integration": "%s",
+                    "resource": {
+                        "enabled": true,
+                        "metadata": {
+                            "author": "Wazuh, Inc.",
+                            "date": "not-a-valid-date",
+                            "description": "Test decoder with a malformed date.",
+                            "references": ["https://wazuh.com"],
+                            "title": "Test decoder with a malformed date"
+                        },
+                        "name": "decoder/test-decoder-malformed-date/0",
+                        "check": [{"tmp_json.event.action": "string_equal(\\"test\\")"}],
+                        "normalize": [{"map": [{"@timestamp": "get_date()"}]}]
+                    }
+                }
+                """;
+        String body = String.format(Locale.ROOT, payload, integrationId);
+        // spotless:on
+
+        ResponseException e =
+                expectThrows(
+                        ResponseException.class,
+                        () -> this.makeRequest("POST", PluginSettings.DECODERS_URI, body));
+        assertEquals(
+                "Malformed date should surface as 400, not 500",
+                RestStatus.BAD_REQUEST.getStatus(),
+                e.getResponse().getStatusLine().getStatusCode());
+    }
+
+    /**
      * Create a decoder without an integration reference.
      *
      * <p>Verifies: Response status code is 400 with "Missing [integration] field."

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/FilterCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/FilterCUDIT.java
@@ -130,6 +130,45 @@ public class FilterCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
+     * Create a filter with a caller-supplied {@code metadata.date} that is not a valid date.
+     *
+     * <p>No plugin-side format validation is performed on caller-supplied dates; the malformed value
+     * is expected to fail index mapping validation ({@code MapperParsingException}).
+     *
+     * <p>Verifies: Response status code is 400 (Bad Request), not 500 (Internal Server Error).
+     */
+    public void testPostFilter_malformedDateReturnsBadRequest() {
+        // spotless:off
+        String payload = """
+                {
+                    "space": "draft",
+                    "resource": {
+                        "name": "filter/test-filter-malformed-date/0",
+                        "enabled": true,
+                        "metadata": {
+                            "title": "Test filter with a malformed date",
+                            "description": "Test filter with a malformed date.",
+                            "author": "Wazuh, Inc.",
+                            "date": "not-a-valid-date"
+                        },
+                        "check": "$host.os.platform == 'ubuntu'",
+                        "type": "pre-filter"
+                    }
+                }
+                """;
+        // spotless:on
+
+        ResponseException e =
+                expectThrows(
+                        ResponseException.class,
+                        () -> this.makeRequest("POST", PluginSettings.FILTERS_URI, payload));
+        assertEquals(
+                "Malformed date should surface as 400, not 500",
+                RestStatus.BAD_REQUEST.getStatus(),
+                e.getResponse().getStatusLine().getStatusCode());
+    }
+
+    /**
      * Create a filter with an explicit id in the resource.
      *
      * <p>Verifies: Response status code is 400.

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
@@ -92,6 +92,44 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
+     * Create an integration with a caller-supplied {@code metadata.date} that is not a valid date.
+     *
+     * <p>No plugin-side format validation is performed on caller-supplied dates; the malformed value
+     * is expected to fail index mapping validation ({@code MapperParsingException}).
+     *
+     * <p>Verifies: Response status code is 400 (Bad Request), not 500 (Internal Server Error).
+     */
+    public void testPostIntegration_malformedDateReturnsBadRequest() {
+        // spotless:off
+        String payload = """
+                {
+                    "resource": {
+                        "category": "cloud-services",
+                        "enabled": true,
+                        "metadata": {
+                            "title": "test-integration-malformed-date",
+                            "author": "Wazuh Inc.",
+                            "date": "not-a-valid-date",
+                            "description": "Integration with a malformed date.",
+                            "documentation": "test-doc",
+                            "references": ["https://wazuh.com"]
+                        }
+                    }
+                }
+                """;
+        // spotless:on
+
+        ResponseException e =
+                expectThrows(
+                        ResponseException.class,
+                        () -> this.makeRequest("POST", PluginSettings.INTEGRATIONS_URI, payload));
+        assertEquals(
+                "Malformed date should surface as 400, not 500",
+                RestStatus.BAD_REQUEST.getStatus(),
+                e.getResponse().getStatusLine().getStatusCode());
+    }
+
+    /**
      * Create an integration with the same title as an existing integration.
      *
      * <p>Verifies: Response status code is 400.

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/KvdbCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/KvdbCUDIT.java
@@ -129,6 +129,49 @@ public class KvdbCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
+     * Create a KVDB with a caller-supplied {@code metadata.date} that is not a valid date.
+     *
+     * <p>No plugin-side format validation is performed on caller-supplied dates; the malformed value
+     * is expected to fail index mapping validation ({@code MapperParsingException}).
+     *
+     * <p>Verifies: Response status code is 400 (Bad Request), not 500 (Internal Server Error).
+     *
+     * @throws IOException On request failure.
+     */
+    public void testPostKvdb_malformedDateReturnsBadRequest() throws IOException {
+        String integrationId = this.createIntegration("test-kvdb-malformed-date");
+
+        // spotless:off
+        String payload = """
+                {
+                    "integration": "%s",
+                    "resource": {
+                        "name": "test",
+                        "enabled": true,
+                        "content": {"key": "value"},
+                        "metadata": {
+                            "title": "Test KVDB with a malformed date",
+                            "author": "Wazuh Inc.",
+                            "date": "not-a-valid-date",
+                            "description": "Test KVDB with a malformed date."
+                        }
+                    }
+                }
+                """;
+        String body = String.format(Locale.ROOT, payload, integrationId);
+        // spotless:on
+
+        ResponseException e =
+                expectThrows(
+                        ResponseException.class,
+                        () -> this.makeRequest("POST", PluginSettings.KVDBS_URI, body));
+        assertEquals(
+                "Malformed date should surface as 400, not 500",
+                RestStatus.BAD_REQUEST.getStatus(),
+                e.getResponse().getStatusLine().getStatusCode());
+    }
+
+    /**
      * Create a KVDB with missing author.
      *
      * <p>Verifies: Response status code is 400.

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/PolicyIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/PolicyIT.java
@@ -210,6 +210,8 @@ public class PolicyIT extends ContentManagerRestTestCase {
      *   <li>Response status code is 200 OK.
      *   <li>The draft policy in wazuh-threatintel-policies is updated.
      *   <li>Its space.hash.sha256 field is updated.
+     *   <li>The caller-supplied {@code modified} timestamp is honored.
+     *   <li>The caller-supplied {@code date} is ignored; the original creation date is preserved.
      * </ul>
      *
      * @throws IOException On parsing or request error.
@@ -220,6 +222,12 @@ public class PolicyIT extends ContentManagerRestTestCase {
         String decoderId = this.createDecoder(integrationId);
 
         String policyHashBefore = this.getDraftPolicySpaceHash();
+        String creationDateBefore =
+                this.getDraftPolicy()
+                        .path(Constants.KEY_DOCUMENT)
+                        .path(Constants.KEY_METADATA)
+                        .path(Constants.KEY_DATE)
+                        .asText();
 
         // Get current integrations list (it should have the new integration)
         List<String> currentIntegrations = this.getDraftPolicyIntegrations();
@@ -241,6 +249,18 @@ public class PolicyIT extends ContentManagerRestTestCase {
         String policyHashAfter = this.getDraftPolicySpaceHash();
         assertNotEquals(
                 "Draft policy space hash should have been updated", policyHashBefore, policyHashAfter);
+
+        // The caller-supplied "modified" timestamp should be honored, while "date" stays immutable
+        JsonNode updatedMetadata =
+                this.getDraftPolicy().path(Constants.KEY_DOCUMENT).path(Constants.KEY_METADATA);
+        assertEquals(
+                "Caller-supplied 'modified' timestamp should be honored",
+                "2026-02-03T18:57:33.931731040Z",
+                updatedMetadata.path(Constants.KEY_MODIFIED).asText());
+        assertEquals(
+                "Original creation 'date' should be preserved, not overwritten by the request body",
+                creationDateBefore,
+                updatedMetadata.path(Constants.KEY_DATE).asText());
     }
 
     private static String getString(String decoderId, StringBuilder intListJson) {
@@ -271,6 +291,53 @@ public class PolicyIT extends ContentManagerRestTestCase {
         // spotless:on
         payload = String.format(Locale.ROOT, payload, decoderId, intListJson);
         return payload;
+    }
+
+    /**
+     * Update policy with a caller-supplied {@code metadata.modified} that is not a valid date.
+     *
+     * <p>No plugin-side format validation is performed on caller-supplied dates; the malformed value
+     * is expected to fail index mapping validation ({@code MapperParsingException}). Note:
+     * {@code metadata.date} is always overwritten with the existing policy's creation date on update
+     * (see {@link #testPutPolicy_success}), so a malformed {@code date} would never reach indexing —
+     * {@code modified} is used here instead since it is the field actually honored from the request.
+     *
+     * <p>Verifies: Response status code is 400 (Bad Request), not 500 (Internal Server Error).
+     */
+    public void testPutPolicy_malformedModifiedReturnsBadRequest() {
+        // spotless:off
+        String payload = """
+                {
+                    "type": "policy",
+                    "resource": {
+                        "root_decoder": "",
+                        "integrations": [],
+                        "filters": [],
+                        "enrichments": [],
+                        "enabled": true,
+                        "index_unclassified_events": false,
+                        "index_discarded_events": false,
+                        "metadata": {
+                            "title": "Policy with malformed modified",
+                            "modified": "not-a-valid-date",
+                            "author": "Test",
+                            "description": "Policy with a malformed modified timestamp.",
+                            "documentation": "",
+                            "references": []
+                        }
+                    }
+                }
+                """;
+        // spotless:on
+
+        ResponseException e =
+                expectThrows(
+                        ResponseException.class,
+                        () -> this.makeRequest("PUT", PluginSettings.POLICY_URI + "/draft", payload));
+        assertEquals(
+                "Malformed modified timestamp should surface as 400, not 500",
+                RestStatus.BAD_REQUEST.getStatus(),
+                e.getResponse().getStatusLine().getStatusCode());
     }
 
     /**

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/RuleCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/RuleCUDIT.java
@@ -90,6 +90,61 @@ public class RuleCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
+     * Create a rule with a caller-supplied {@code metadata.date} that is not a valid date.
+     *
+     * <p>No plugin-side format validation is performed on caller-supplied dates; the malformed value
+     * is expected to fail index mapping validation ({@code MapperParsingException}).
+     *
+     * <p>Verifies: Response status code is 400 (Bad Request), not 500 (Internal Server Error).
+     *
+     * @throws IOException On failure to create integration fixture.
+     */
+    public void testPostRule_malformedDateReturnsBadRequest() throws IOException {
+        String integrationId = this.createIntegration("test-rule-malformed-date");
+
+        // spotless:off
+        String payload = """
+                {
+                    "integration": "%s",
+                    "resource": {
+                        "metadata": {
+                            "title": "Test rule with a malformed date",
+                            "description": "Test rule with a malformed date.",
+                            "author": "Tester",
+                            "date": "not-a-valid-date",
+                            "references": ["https://wazuh.com"]
+                        },
+                        "sigma_id": "test-sigma-malformed-date",
+                        "enabled": true,
+                        "status": "experimental",
+                        "logsource": {
+                            "product": "system",
+                            "category": "system"
+                        },
+                        "detection": {
+                            "condition": "selection",
+                            "selection": {
+                                "event.action": ["test"]
+                            }
+                        },
+                        "level": "low"
+                    }
+                }
+                """;
+        String body = String.format(Locale.ROOT, payload, integrationId);
+        // spotless:on
+
+        ResponseException e =
+                expectThrows(
+                        ResponseException.class,
+                        () -> this.makeRequest("POST", PluginSettings.RULES_URI, body));
+        assertEquals(
+                "Malformed date should surface as 400, not 500",
+                RestStatus.BAD_REQUEST.getStatus(),
+                e.getResponse().getStatusLine().getStatusCode());
+    }
+
+    /**
      * Create a rule with missing title.
      *
      * <p>Verifies: Response status code is 400.

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.SuppressForbidden;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.wazuh.contentmanager.action.MessageStatusResponse;
+import com.wazuh.contentmanager.action.UpdatePolicyRequest;
+import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
+import com.wazuh.contentmanager.engine.service.EngineService;
+import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link TransportUpdatePolicyAction}'s {@code metadata.date}/{@code
+ * metadata.modified} handling: unlike the shared {@code Resource.setCreationTime}/{@code
+ * setLastModificationTime} helpers used by other resource types, policy updates merge these fields
+ * inline against the existing document rather than through that shared code path.
+ */
+public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
+
+    private static final String EXISTING_CREATION_DATE = "2020-01-01T00:00:00.000Z";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private Client client;
+    private SpaceService spaceService;
+    private TransportUpdatePolicyAction action;
+    private IndexResponse indexResponse;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        clearPluginSettingsInstance();
+        PluginSettings.getInstance(Settings.EMPTY);
+
+        this.client = mock(Client.class);
+        this.spaceService = mock(SpaceService.class);
+        EngineService engineService = mock(EngineService.class);
+        this.indexResponse = mock(IndexResponse.class);
+
+        this.action =
+                new TransportUpdatePolicyAction(
+                        mock(TransportService.class),
+                        mock(ActionFilters.class),
+                        this.spaceService,
+                        engineService,
+                        this.client);
+
+        when(this.spaceService.getKnownEnrichmentTypes()).thenReturn(Collections.emptySet());
+        when(this.spaceService.findDocumentId(any(), any(), any())).thenReturn("draft-doc-id");
+        when(this.spaceService.calculateAndUpdate(any())).thenReturn(Collections.emptySet());
+
+        when(this.indexResponse.getId()).thenReturn("draft-doc-id");
+        PlainActionFuture<IndexResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(this.indexResponse);
+        when(this.client.index(any(IndexRequest.class))).thenReturn(future);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clearPluginSettingsInstance();
+        super.tearDown();
+    }
+
+    @SuppressForbidden(reason = "Unit test reset")
+    private static void clearPluginSettingsInstance() throws Exception {
+        Field instance = PluginSettings.class.getDeclaredField("INSTANCE");
+        instance.setAccessible(true);
+        instance.set(null, null);
+    }
+
+    /** Builds the {@code getPolicy()} return value: a draft policy with a known creation date. */
+    private Map<String, Object> currentDraftPolicy() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(Constants.KEY_DATE, EXISTING_CREATION_DATE);
+        metadata.put(Constants.KEY_TITLE, "Existing policy");
+        metadata.put(Constants.KEY_AUTHOR, "Wazuh Inc.");
+        metadata.put(Constants.KEY_DESCRIPTION, "Existing description");
+        metadata.put(Constants.KEY_DOCUMENTATION, "");
+        metadata.put(Constants.KEY_REFERENCES, Collections.emptyList());
+
+        Map<String, Object> document = new HashMap<>();
+        document.put(Constants.KEY_ID, "policy-doc-id");
+        document.put(Constants.KEY_METADATA, metadata);
+        document.put(Constants.KEY_INTEGRATIONS, Collections.emptyList());
+        document.put(Constants.KEY_FILTERS, Collections.emptyList());
+
+        Map<String, Object> policy = new HashMap<>();
+        policy.put(Constants.KEY_DOCUMENT, document);
+        return policy;
+    }
+
+    private String draftUpdateBody(String modifiedField) {
+        String modifiedLine =
+                modifiedField == null ? "" : "\"modified\": \"" + modifiedField + "\",";
+        return "{"
+                + "\"type\": \"policy\","
+                + "\"resource\": {"
+                + "\"root_decoder\": \"\","
+                + "\"integrations\": [],"
+                + "\"filters\": [],"
+                + "\"enrichments\": [],"
+                + "\"enabled\": true,"
+                + "\"index_unclassified_events\": false,"
+                + "\"index_discarded_events\": false,"
+                + "\"metadata\": {"
+                + "\"title\": \"Updated policy\","
+                + modifiedLine
+                + "\"author\": \"Test\","
+                + "\"description\": \"Updated description\","
+                + "\"documentation\": \"\","
+                + "\"references\": []"
+                + "}"
+                + "}"
+                + "}";
+    }
+
+    /** Captures the {@code document.metadata} node actually sent to the indexing client. */
+    private JsonNode capturedIndexedMetadata() throws Exception {
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(this.client).index(captor.capture());
+        JsonNode source = MAPPER.readTree(captor.getValue().source().utf8ToString());
+        return source.path(Constants.KEY_DOCUMENT).path(Constants.KEY_METADATA);
+    }
+
+    public void testUpdatePolicy_honorsCallerSuppliedModified() throws Exception {
+        when(this.spaceService.getPolicy(com.wazuh.contentmanager.cti.catalog.model.Space.DRAFT.toString()))
+                .thenReturn(currentDraftPolicy());
+
+        String callerModified = "2021-05-05T00:00:00.000Z";
+        UpdatePolicyRequest request =
+                new UpdatePolicyRequest("draft", draftUpdateBody(callerModified));
+
+        @SuppressWarnings("unchecked")
+        ActionListener<MessageStatusResponse> listener = mock(ActionListener.class);
+        this.action.doExecute(mock(Task.class), request, listener);
+
+        verify(listener)
+                .onResponse(
+                        argThat(
+                                response -> {
+                                    Assert.assertEquals(RestStatus.OK, response.getStatus());
+                                    return true;
+                                }));
+
+        JsonNode metadata = capturedIndexedMetadata();
+        Assert.assertEquals(
+                "Caller-supplied 'modified' should be honored",
+                callerModified,
+                metadata.path(Constants.KEY_MODIFIED).asText());
+        Assert.assertEquals(
+                "'date' should always be preserved from the existing document, never the request body",
+                EXISTING_CREATION_DATE,
+                metadata.path(Constants.KEY_DATE).asText());
+    }
+
+    public void testUpdatePolicy_generatesModifiedWhenAbsent() throws Exception {
+        when(this.spaceService.getPolicy(com.wazuh.contentmanager.cti.catalog.model.Space.DRAFT.toString()))
+                .thenReturn(currentDraftPolicy());
+
+        UpdatePolicyRequest request = new UpdatePolicyRequest("draft", draftUpdateBody(null));
+
+        @SuppressWarnings("unchecked")
+        ActionListener<MessageStatusResponse> listener = mock(ActionListener.class);
+        this.action.doExecute(mock(Task.class), request, listener);
+
+        verify(listener)
+                .onResponse(
+                        argThat(
+                                response -> {
+                                    Assert.assertEquals(RestStatus.OK, response.getStatus());
+                                    return true;
+                                }));
+
+        JsonNode metadata = capturedIndexedMetadata();
+        Assert.assertFalse(
+                "'modified' should be generated when absent from the request",
+                metadata.path(Constants.KEY_MODIFIED).asText("").isBlank());
+        Assert.assertEquals(
+                "'date' should always be preserved from the existing document",
+                EXISTING_CREATION_DATE,
+                metadata.path(Constants.KEY_DATE).asText());
+    }
+}


### PR DESCRIPTION
### Description
Allows callers to supply metadata.date / metadata.modified on Content Manager's create/update REST endpoints (decoders, rules, kvdbs, filters, integrations, policies) instead of always overwriting them server-side. 

### Issues Resolved
https://github.com/wazuh/wazuh-indexer-plugins/issues/1349

