### PR TITLE
Removed step upload test results

### DIFF
--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -163,11 +163,3 @@ jobs:
           chown -R builder:builder "$GITHUB_WORKSPACE" /home/builder
           runuser -u builder -- env "JAVA_HOME=$JAVA_HOME" "PATH=$PATH" "GRADLE_USER_HOME=/home/builder/.gradle" \
             ./gradlew check
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: test-results-${{ matrix.project }}
-          overwrite: 'true'
-          path: plugins/${{ matrix.project }}/build/test-results/


### PR DESCRIPTION
### Description
Due to issue https://github.com/wazuh/internal-devel-requests/issues/5304, we need to migrate the artifacts uploaded by our workflows to S3. Since the test results upload step in` 5_testintegration_gradlecheck.yml `isn't working correctly, it has been removed from the workflow, so we don't need to migrate it to S3.

### Issues Resolved
https://github.com/wazuh/internal-devel-requests/issues/5304

