### PR TITLE
Use async client methods in reset-draft enpoint dependencies

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsService.java
@@ -166,4 +166,12 @@ public interface SecurityAnalyticsService {
      * @param space The space whose resources should be deleted.
      */
     void deleteSpaceResources(Space space);
+
+    /**
+     * Asynchronously deletes all Security Analytics resources belonging to the given space.
+     *
+     * @param space The space whose resources should be deleted.
+     * @param listener The listener to be notified when the operation completes.
+     */
+    void deleteSpaceResourcesAsync(Space space, ActionListener<? extends ActionResponse> listener);
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImpl.java
@@ -565,6 +565,40 @@ public class SecurityAnalyticsServiceImpl implements SecurityAnalyticsService {
         }
     }
 
+    @Override
+    public void deleteSpaceResourcesAsync(
+            Space space, ActionListener<? extends ActionResponse> listener) {
+        String source = space.toString();
+        ActionListener<WDeleteSpaceResourcesResponse> wrappedListener =
+                ActionListener.wrap(
+                        response -> {
+                            if (response.hasFailures()) {
+                                log.warn(
+                                        Constants.W_LOG_SAP_SPACE_DELETE_PARTIAL, space, response.getFailureMessage());
+                            }
+                            log.info(
+                                    Constants.I_LOG_SAP_SPACE_DELETED,
+                                    response.getDeletedIntegrations(),
+                                    response.getDeletedRules(),
+                                    space);
+                            listener.onResponse(null);
+                        },
+                        e -> {
+                            String message =
+                                    String.format(
+                                            Locale.ROOT,
+                                            "Failed to delete Security Analytics resources for space [%s]: %s",
+                                            space,
+                                            e.getMessage());
+                            log.error(message);
+                            listener.onFailure(new OpenSearchException(message, e));
+                        });
+        this.executeAsync(
+                WDeleteSpaceResourcesAction.INSTANCE,
+                new WDeleteSpaceResourcesRequest(source, WriteRequest.RefreshPolicy.IMMEDIATE),
+                wrappedListener);
+    }
+
     /**
      * Executes an action asynchronously, bridging between the wildcard listener from the interface
      * and the concrete response type required by {@link Client#execute}.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -146,6 +146,94 @@ public class SpaceService {
     }
 
     /**
+     * Asynchronously deletes all documents related to a specific space across all resource indices.
+     *
+     * @param space The space to wipe.
+     * @param listener notified on completion or failure.
+     */
+    public void deleteSpaceResourcesAsync(Space space, ActionListener<Void> listener) {
+        String spaceName = space.toString();
+        List<String> indexNames = new ArrayList<>(Constants.RESOURCE_INDICES.values());
+        BulkRequest bulkRequest = new BulkRequest();
+        collectDeleteRequestsAsync(
+                spaceName,
+                indexNames,
+                0,
+                bulkRequest,
+                ActionListener.wrap(
+                        v -> {
+                            if (bulkRequest.numberOfActions() == 0) {
+                                listener.onResponse(null);
+                                return;
+                            }
+                            bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                            this.client.bulk(
+                                    bulkRequest,
+                                    ActionListener.wrap(
+                                            bulkResponse -> {
+                                                if (bulkResponse.hasFailures()) {
+                                                    listener.onFailure(
+                                                            new IOException(
+                                                                    "Bulk deletion failed: " + bulkResponse.buildFailureMessage()));
+                                                } else {
+                                                    listener.onResponse(null);
+                                                }
+                                            },
+                                            listener::onFailure));
+                        },
+                        e -> {
+                            log.error(Constants.E_LOG_DELETE_SPACE_RESOURCES_FAILED, spaceName, e.getMessage());
+                            listener.onFailure(
+                                    new IOException("Failed to delete space resources: " + e.getMessage(), e));
+                        }));
+    }
+
+    private void collectDeleteRequestsAsync(
+            String spaceName,
+            List<String> indexNames,
+            int idx,
+            BulkRequest bulkRequest,
+            ActionListener<Void> listener) {
+        if (idx >= indexNames.size()) {
+            listener.onResponse(null);
+            return;
+        }
+        String indexName = indexNames.get(idx);
+        this.client
+                .admin()
+                .indices()
+                .exists(
+                        new IndicesExistsRequest(indexName),
+                        ActionListener.wrap(
+                                existsResponse -> {
+                                    if (!existsResponse.isExists()) {
+                                        collectDeleteRequestsAsync(
+                                                spaceName, indexNames, idx + 1, bulkRequest, listener);
+                                        return;
+                                    }
+                                    SearchRequest searchRequest = new SearchRequest(indexName);
+                                    SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+                                    sourceBuilder.query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName));
+                                    sourceBuilder.size(10000);
+                                    sourceBuilder.fetchSource(false);
+                                    searchRequest.source(sourceBuilder);
+
+                                    this.client.search(
+                                            searchRequest,
+                                            ActionListener.wrap(
+                                                    searchResponse -> {
+                                                        for (SearchHit hit : searchResponse.getHits().getHits()) {
+                                                            bulkRequest.add(new DeleteRequest(indexName, hit.getId()));
+                                                        }
+                                                        collectDeleteRequestsAsync(
+                                                                spaceName, indexNames, idx + 1, bulkRequest, listener);
+                                                    },
+                                                    listener::onFailure));
+                                },
+                                listener::onFailure));
+    }
+
+    /**
      * Creates a single space policy document if it does not already exist.
      *
      * <p>Uses a deterministic, space-specific OpenSearch document ID so that {@link
@@ -214,6 +302,84 @@ public class SpaceService {
             log.debug(Constants.D_LOG_SPACE_ALREADY_INITIALIZED, spaceName);
         } catch (Exception e) {
             log.error(Constants.E_LOG_INITIALIZE_SPACE_FAILED, spaceName, e.getMessage());
+        }
+    }
+
+    /**
+     * Asynchronously creates a single space policy document if it does not already exist.
+     *
+     * @param spaceName The space name.
+     * @param documentId Shared policy ID stored inside the document to link all default spaces.
+     * @param listener notified on completion or failure.
+     */
+    public void initializeSpaceAsync(
+            String spaceName, String documentId, ActionListener<Void> listener) {
+        String spaceDocId =
+                UUID.nameUUIDFromBytes(("wazuh-space-" + spaceName).getBytes(StandardCharsets.UTF_8))
+                        .toString();
+        try {
+            String date = Instant.now().truncatedTo(ChronoUnit.SECONDS).toString();
+            String title = "Custom space";
+
+            Policy policy = new Policy();
+            policy.setId(documentId);
+            policy.setTitle(title);
+            policy.setDescription(title);
+            policy.setAuthor("Custom");
+            policy.setRootDecoder(null);
+            policy.setDocumentation("");
+            policy.setIntegrations(Collections.emptyList());
+            policy.setFilters(Collections.emptyList());
+            policy.setEnrichments(Collections.emptyList());
+            policy.setReferences(Collections.emptyList());
+            policy.setDate(date);
+            policy.setModified(date);
+            policy.setEnabled(Space.DRAFT.toString().equals(spaceName));
+            policy.setIndexUnclassifiedEvents(false);
+            policy.setIndexDiscardedEvents(false);
+
+            ObjectNode docNode = this.objectMapper.valueToTree(policy);
+            Resource.nestMetadataFields(docNode);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> docMap = this.objectMapper.convertValue(docNode, Map.class);
+
+            String docJson = this.objectMapper.writeValueAsString(docMap);
+            String docHash = Resource.computeSha256(docJson);
+
+            Map<String, Object> space = new HashMap<>();
+            space.put(Constants.KEY_NAME, spaceName);
+            space.put(Constants.KEY_HASH, Map.of(Constants.KEY_SHA256, docHash));
+
+            Map<String, Object> source = new HashMap<>();
+            source.put(Constants.KEY_DOCUMENT, docMap);
+            source.put(Constants.KEY_SPACE, space);
+            source.put(Constants.KEY_HASH, Map.of(Constants.KEY_SHA256, docHash));
+
+            IndexRequest request =
+                    new IndexRequest(Constants.INDEX_POLICIES)
+                            .id(spaceDocId)
+                            .source(this.objectMapper.writeValueAsString(source), XContentType.JSON)
+                            .opType(DocWriteRequest.OpType.CREATE)
+                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            this.client.index(
+                    request,
+                    ActionListener.wrap(
+                            indexResponse -> {
+                                log.info(Constants.I_LOG_SPACE_INITIALIZED, spaceName);
+                                listener.onResponse(null);
+                            },
+                            e -> {
+                                if (e instanceof VersionConflictEngineException) {
+                                    log.debug(Constants.D_LOG_SPACE_ALREADY_INITIALIZED, spaceName);
+                                } else {
+                                    log.error(Constants.E_LOG_INITIALIZE_SPACE_FAILED, spaceName, e.getMessage());
+                                }
+                                listener.onResponse(null);
+                            }));
+        } catch (Exception e) {
+            log.error(Constants.E_LOG_INITIALIZE_SPACE_FAILED, spaceName, e.getMessage());
+            listener.onResponse(null);
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -228,9 +228,24 @@ public class SpaceService {
                                                         collectDeleteRequestsAsync(
                                                                 spaceName, indexNames, idx + 1, bulkRequest, listener);
                                                     },
-                                                    listener::onFailure));
+                                                    e -> {
+                                                        log.warn(
+                                                                "Failed to search index [{}] for space [{}] during delete, skipping: {}",
+                                                                indexName,
+                                                                spaceName,
+                                                                e.getMessage());
+                                                        collectDeleteRequestsAsync(
+                                                                spaceName, indexNames, idx + 1, bulkRequest, listener);
+                                                    }));
                                 },
-                                listener::onFailure));
+                                e -> {
+                                    log.warn(
+                                            "Failed to check existence of index [{}] for space [{}] during delete, skipping: {}",
+                                            indexName,
+                                            spaceName,
+                                            e.getMessage());
+                                    collectDeleteRequestsAsync(spaceName, indexNames, idx + 1, bulkRequest, listener);
+                                }));
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportDeleteSpaceAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportDeleteSpaceAction.java
@@ -84,36 +84,64 @@ public class TransportDeleteSpaceAction
             return;
         }
 
-        try {
-            log.info("Starting reset operation for space [{}]", space);
+        log.info("Starting reset operation for space [{}]", space);
 
-            // 1. Remove resources belonging to the space in Security Analytics.
-            this.securityAnalyticsService.deleteSpaceResources(space);
-            // 2. Remove resources belonging to space in the wazuh-threatintel-* indices.
-            this.spaceService.deleteSpaceResources(space);
+        // 1. Remove resources belonging to the space in Security Analytics.
+        this.securityAnalyticsService.deleteSpaceResourcesAsync(
+                space,
+                ActionListener.wrap(
+                        sapResponse -> {
+                            // 2. Remove resources belonging to space in the wazuh-threatintel-*
+                            // indices.
+                            this.spaceService.deleteSpaceResourcesAsync(
+                                    space,
+                                    ActionListener.wrap(
+                                            v -> {
+                                                // 3. Re-generate the default policy for the space
+                                                String sharedDocumentId =
+                                                        UUID.nameUUIDFromBytes(
+                                                                        "wazuh-default-policy".getBytes(StandardCharsets.UTF_8))
+                                                                .toString();
+                                                this.spaceService.initializeSpaceAsync(
+                                                        space.toString(),
+                                                        sharedDocumentId,
+                                                        ActionListener.wrap(
+                                                                v2 -> {
+                                                                    String message =
+                                                                            String.format(
+                                                                                    Locale.ROOT, "Successfully reset space [%s].", space);
+                                                                    log.info(message);
+                                                                    listener.onResponse(
+                                                                            new MessageStatusResponse(message, RestStatus.OK));
+                                                                },
+                                                                e -> respondWithError(listener, space, e)));
+                                            },
+                                            e -> respondWithError(listener, space, e)));
+                        },
+                        e -> respondWithError(listener, space, e)));
+    }
 
-            // Re-generate the default policy for the space
-            String sharedDocumentId =
-                    UUID.nameUUIDFromBytes("wazuh-default-policy".getBytes(StandardCharsets.UTF_8))
-                            .toString();
-            this.spaceService.initializeSpace(space.toString(), sharedDocumentId);
-
-            String message = String.format(Locale.ROOT, "Successfully reset space [%s].", space);
-            log.info(message);
-            listener.onResponse(new MessageStatusResponse(message, RestStatus.OK));
-        } catch (Exception e) {
-            Throwable cause = e;
-            while (cause != null) {
-                if (cause instanceof OpenSearchSecurityException secEx) {
-                    listener.onResponse(new MessageStatusResponse(secEx.getMessage(), secEx.status()));
-                    return;
-                }
-                cause = cause.getCause();
-            }
-            log.error("Failed to reset space [{}]: {}", space, e.getMessage());
-            listener.onResponse(
-                    new MessageStatusResponse(
-                            "Internal Server Error: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+    private void respondWithError(
+            ActionListener<MessageStatusResponse> listener, Space space, Exception e) {
+        OpenSearchSecurityException secEx = extractSecurityException(e);
+        if (secEx != null) {
+            listener.onResponse(new MessageStatusResponse(secEx.getMessage(), secEx.status()));
+            return;
         }
+        log.error("Failed to reset space [{}]: {}", space, e.getMessage());
+        listener.onResponse(
+                new MessageStatusResponse(
+                        "Internal Server Error: " + e.getMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    private static OpenSearchSecurityException extractSecurityException(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (cause instanceof OpenSearchSecurityException) {
+                return (OpenSearchSecurityException) cause;
+            }
+            cause = cause.getCause();
+        }
+        return null;
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockSecurityAnalyticsService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockSecurityAnalyticsService.java
@@ -128,4 +128,11 @@ public class MockSecurityAnalyticsService implements SecurityAnalyticsService {
     public void deleteSpaceResources(Space space) {
         log.debug("MockSecurityAnalyticsService.deleteSpaceResources called for space: {}", space);
     }
+
+    @Override
+    public void deleteSpaceResourcesAsync(
+            Space space, ActionListener<? extends ActionResponse> listener) {
+        log.debug("MockSecurityAnalyticsService.deleteSpaceResourcesAsync called for space: {}", space);
+        listener.onResponse(null);
+    }
 }


### PR DESCRIPTION
### Description
This PR migrates /reset/draft endpoint to use async versions of Client methods.

### Issues Resolved
Resolves #1331 
