### PR TITLE
Use async client methods in logtest enpoints' dependencies

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.QueryBuilders;
@@ -193,69 +192,72 @@ public class LogtestService {
      * @param integrationId the integration document ID to look up
      * @param space the space to search in (test or standard)
      * @param inputEvent the normalized event JSON object to evaluate
-     * @return a {@link RestResponse} with the SAP detection result
+     * @param listener the listener to be notified with the SAP detection result
      */
-    public RestResponse executeDetection(String integrationId, Space space, JsonNode inputEvent) {
-        ObjectMapper mapper = new ObjectMapper();
-
-        // 1. Look up integration
-        SearchResponse integrationSearchResponse;
-        try {
-            integrationSearchResponse =
-                    this.client
-                            .prepareSearch(Constants.INDEX_INTEGRATIONS)
-                            .setSource(
-                                    new SearchSourceBuilder()
-                                            .query(
-                                                    QueryBuilders.boolQuery()
-                                                            .must(QueryBuilders.termQuery(Constants.Q_DOCUMENT_ID, integrationId))
-                                                            .must(
-                                                                    QueryBuilders.termQuery(
-                                                                            Constants.Q_SPACE_NAME, space.toString())))
-                                            .size(1))
-                            .get();
-        } catch (Exception e) {
-            log.error("Failed to look up integration [{}]: {}", integrationId, e.getMessage());
-            return new RestResponse(
-                    Constants.E_500_INTERNAL_SERVER_ERROR, RestStatus.INTERNAL_SERVER_ERROR.getStatus());
-        }
-
-        if (Objects.requireNonNull(integrationSearchResponse.getHits().getTotalHits()).value() == 0) {
-            return new RestResponse(
-                    String.format(Locale.ROOT, Constants.E_400_INTEGRATION_NOT_FOUND, integrationId, space),
-                    RestStatus.BAD_REQUEST.getStatus());
-        }
-
-        // 2. Fetch rule IDs from integration
-        Map<String, Object> integrationSource =
-                integrationSearchResponse.getHits().getAt(0).getSourceAsMap();
-        List<String> ruleIds = extractRuleIds(integrationSource);
-        List<String> ruleBodies =
-                ruleIds.isEmpty() ? List.of() : fetchRuleBodies(integrationId, ruleIds, space);
-
-        // 3. Convert input event to JSON string for SAP
+    public void executeDetectionAsync(
+            String integrationId,
+            Space space,
+            JsonNode inputEvent,
+            ActionListener<RestResponse> listener) {
         String eventJson = inputEvent.toString();
 
-        // 4. Evaluate rules
-        Map<String, Object> sapResult;
-        if (ruleBodies.isEmpty()) {
-            sapResult = createEmptySapResult();
-        } else {
-            String saResultJson = this.securityAnalytics.evaluateRules(eventJson, ruleBodies);
-            try {
-                sapResult = mapper.readValue(saResultJson, Map.class);
-            } catch (Exception e) {
-                sapResult = createErrorSapResult();
-            }
-        }
+        this.client
+                .prepareSearch(Constants.INDEX_INTEGRATIONS)
+                .setSource(
+                        new SearchSourceBuilder()
+                                .query(
+                                        QueryBuilders.boolQuery()
+                                                .must(QueryBuilders.termQuery(Constants.Q_DOCUMENT_ID, integrationId))
+                                                .must(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, space.toString())))
+                                .size(1))
+                .execute(
+                        ActionListener.wrap(
+                                integrationSearchResponse -> {
+                                    if (Objects.requireNonNull(integrationSearchResponse.getHits().getTotalHits())
+                                                    .value()
+                                            == 0) {
+                                        listener.onResponse(
+                                                new RestResponse(
+                                                        String.format(
+                                                                Locale.ROOT,
+                                                                Constants.E_400_INTEGRATION_NOT_FOUND,
+                                                                integrationId,
+                                                                space),
+                                                        RestStatus.BAD_REQUEST.getStatus()));
+                                        return;
+                                    }
 
-        try {
-            String json = mapper.writeValueAsString(sapResult);
-            return new RestResponse(json, RestStatus.OK.getStatus()).parseMessageAsJson();
-        } catch (Exception e) {
-            return new RestResponse(
-                    Constants.E_500_INTERNAL_SERVER_ERROR, RestStatus.INTERNAL_SERVER_ERROR.getStatus());
-        }
+                                    Map<String, Object> integrationSource =
+                                            integrationSearchResponse.getHits().getAt(0).getSourceAsMap();
+                                    List<String> ruleIds = extractRuleIds(integrationSource);
+
+                                    if (ruleIds.isEmpty()) {
+                                        listener.onResponse(buildDetectionResponse(createEmptySapResult()));
+                                        return;
+                                    }
+
+                                    fetchRuleBodiesAsync(
+                                            integrationId,
+                                            ruleIds,
+                                            space,
+                                            ActionListener.wrap(
+                                                    ruleBodies -> evaluateDetectionRules(eventJson, ruleBodies, listener),
+                                                    e -> {
+                                                        log.warn(
+                                                                "Failed to fetch rules for" + " integration [{}]: {}",
+                                                                integrationId,
+                                                                e.getMessage());
+                                                        listener.onResponse(buildDetectionResponse(createEmptySapResult()));
+                                                    }));
+                                },
+                                e -> {
+                                    log.error(
+                                            "Failed to look up integration [{}]: {}", integrationId, e.getMessage());
+                                    listener.onResponse(
+                                            new RestResponse(
+                                                    Constants.E_500_INTERNAL_SERVER_ERROR,
+                                                    RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+                                }));
     }
 
     /**
@@ -386,50 +388,6 @@ public class LogtestService {
         return ruleIds;
     }
 
-    /**
-     * Fetches Sigma rule bodies from the {@code wazuh-threatintel-rules} index by document ID.
-     *
-     * <p>Each rule document's {@code document} field contains the raw Sigma rule content (JSON or
-     * YAML). If a rule cannot be fetched, it is silently skipped.
-     *
-     * @param integrationId the integration ID (used for logging on failure)
-     * @param ruleIds the list of rule document IDs to fetch
-     * @param space the space to filter rules by
-     * @return list of rule body strings (may be smaller than ruleIds if some rules were not found)
-     */
-    private List<String> fetchRuleBodies(String integrationId, List<String> ruleIds, Space space) {
-        ObjectMapper mapper = new ObjectMapper();
-        List<String> ruleBodies = new ArrayList<>();
-        try {
-            SearchResponse rulesSearchResponse =
-                    this.client
-                            .prepareSearch(Constants.INDEX_RULES)
-                            .setSource(
-                                    new SearchSourceBuilder()
-                                            .query(
-                                                    QueryBuilders.boolQuery()
-                                                            .must(QueryBuilders.termsQuery(Constants.Q_DOCUMENT_ID, ruleIds))
-                                                            .must(
-                                                                    QueryBuilders.termQuery(
-                                                                            Constants.Q_SPACE_NAME, space.toString())))
-                                            .size(ruleIds.size()))
-                            .get();
-            for (SearchHit hit : rulesSearchResponse.getHits().getHits()) {
-                Map<String, Object> ruleSource = hit.getSourceAsMap();
-                Object ruleDocObj = ruleSource.get(Constants.KEY_DOCUMENT);
-                if (ruleDocObj != null) {
-                    ruleBodies.add(
-                            ruleDocObj instanceof Map
-                                    ? mapper.writeValueAsString(ruleDocObj)
-                                    : ruleDocObj.toString());
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to fetch rules for integration [{}]: {}", integrationId, e.getMessage());
-        }
-        return ruleBodies;
-    }
-
     private void fetchRuleBodiesAsync(
             String integrationId,
             List<String> ruleIds,
@@ -493,6 +451,45 @@ public class LogtestService {
                             log.error("Failed to evaluate rules: {}", e.getMessage());
                             listener.onResponse(buildCombinedResponse(engineResult, createErrorSapResult()));
                         }));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void evaluateDetectionRules(
+            String eventJson, List<String> ruleBodies, ActionListener<RestResponse> listener) {
+        if (ruleBodies.isEmpty()) {
+            listener.onResponse(buildDetectionResponse(createEmptySapResult()));
+            return;
+        }
+
+        this.securityAnalytics.evaluateRulesAsync(
+                eventJson,
+                ruleBodies,
+                ActionListener.wrap(
+                        saResultJson -> {
+                            ObjectMapper mapper = new ObjectMapper();
+                            Map<String, Object> sapResult;
+                            try {
+                                sapResult = mapper.readValue(saResultJson, Map.class);
+                            } catch (Exception e) {
+                                sapResult = createErrorSapResult();
+                            }
+                            listener.onResponse(buildDetectionResponse(sapResult));
+                        },
+                        e -> {
+                            log.error("Failed to evaluate rules: {}", e.getMessage());
+                            listener.onResponse(buildDetectionResponse(createErrorSapResult()));
+                        }));
+    }
+
+    private RestResponse buildDetectionResponse(Map<String, Object> sapResult) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            String json = mapper.writeValueAsString(sapResult);
+            return new RestResponse(json, RestStatus.OK.getStatus()).parseMessageAsJson();
+        } catch (Exception e) {
+            return new RestResponse(
+                    Constants.E_500_INTERNAL_SERVER_ERROR, RestStatus.INTERNAL_SERVER_ERROR.getStatus());
+        }
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
@@ -84,78 +85,89 @@ public class LogtestService {
      * @param space the space to search in (test or standard)
      * @param enginePayload the request payload to forward to the Engine (without the integration
      *     field)
-     * @return a {@link RestResponse} containing the combined engine and SAP results as JSON
+     * @param listener the listener to be notified with the combined engine and SAP results
      */
-    public RestResponse executeLogtest(String integrationId, Space space, ObjectNode enginePayload) {
-        // If no integration provided, run engine only and skip detection
+    public void executeLogtest(
+            String integrationId,
+            Space space,
+            ObjectNode enginePayload,
+            ActionListener<RestResponse> listener) {
         if (integrationId == null) {
-            return executeEngineOnly(enginePayload);
+            listener.onResponse(executeEngineOnly(enginePayload));
+            return;
         }
 
-        // 1. Look up integration from wazuh-threatintel-integrations by document.id + space
-        SearchResponse integrationSearchResponse;
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            integrationSearchResponse =
-                    this.client
-                            .prepareSearch(Constants.INDEX_INTEGRATIONS)
-                            .setSource(
-                                    new SearchSourceBuilder()
-                                            .query(
-                                                    QueryBuilders.boolQuery()
-                                                            .must(QueryBuilders.termQuery(Constants.Q_DOCUMENT_ID, integrationId))
-                                                            .must(
-                                                                    QueryBuilders.termQuery(
-                                                                            Constants.Q_SPACE_NAME, space.toString())))
-                                            .size(1))
-                            .get();
-        } catch (Exception e) {
-            log.error("Failed to look up integration [{}]: {}", integrationId, e.getMessage());
-            return new RestResponse(
-                    Constants.E_500_INTERNAL_SERVER_ERROR, RestStatus.INTERNAL_SERVER_ERROR.getStatus());
-        }
+        this.client
+                .prepareSearch(Constants.INDEX_INTEGRATIONS)
+                .setSource(
+                        new SearchSourceBuilder()
+                                .query(
+                                        QueryBuilders.boolQuery()
+                                                .must(QueryBuilders.termQuery(Constants.Q_DOCUMENT_ID, integrationId))
+                                                .must(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, space.toString())))
+                                .size(1))
+                .execute(
+                        ActionListener.wrap(
+                                integrationSearchResponse -> {
+                                    if (Objects.requireNonNull(integrationSearchResponse.getHits().getTotalHits())
+                                                    .value()
+                                            == 0) {
+                                        listener.onResponse(
+                                                new RestResponse(
+                                                        String.format(
+                                                                Locale.ROOT,
+                                                                Constants.E_400_INTEGRATION_NOT_FOUND,
+                                                                integrationId,
+                                                                space),
+                                                        RestStatus.BAD_REQUEST.getStatus()));
+                                        return;
+                                    }
 
-        if (Objects.requireNonNull(integrationSearchResponse.getHits().getTotalHits()).value() == 0) {
-            return new RestResponse(
-                    String.format(Locale.ROOT, Constants.E_400_INTEGRATION_NOT_FOUND, integrationId, space),
-                    RestStatus.BAD_REQUEST.getStatus());
-        }
+                                    Map<String, Object> engineResult = executeEngine(enginePayload);
+                                    if ("error".equals(engineResult.get(Constants.KEY_STATUS))) {
+                                        Map<String, Object> sapResult = new LinkedHashMap<>();
+                                        sapResult.put(Constants.KEY_STATUS, "skipped");
+                                        sapResult.put("reason", "Engine processing failed");
+                                        listener.onResponse(buildCombinedResponse(engineResult, sapResult));
+                                        return;
+                                    }
 
-        // 2. Send event to Engine
-        Map<String, Object> engineResult = executeEngine(enginePayload);
+                                    Map<String, Object> integrationSource =
+                                            integrationSearchResponse.getHits().getAt(0).getSourceAsMap();
+                                    List<String> ruleIds = extractRuleIds(integrationSource);
+                                    String normalizedEventJson = (String) engineResult.remove("_normalized_event");
 
-        // If engine failed, skip SAP evaluation
-        if ("error".equals(engineResult.get(Constants.KEY_STATUS))) {
-            Map<String, Object> sapResult = new LinkedHashMap<>();
-            sapResult.put(Constants.KEY_STATUS, "skipped");
-            sapResult.put("reason", "Engine processing failed");
-            return buildCombinedResponse(engineResult, sapResult);
-        }
+                                    if (ruleIds.isEmpty()) {
+                                        listener.onResponse(
+                                                buildCombinedResponse(engineResult, createEmptySapResult()));
+                                        return;
+                                    }
 
-        // 3. Fetch rule IDs from integration
-        Map<String, Object> integrationSource =
-                integrationSearchResponse.getHits().getAt(0).getSourceAsMap();
-        List<String> ruleIds = extractRuleIds(integrationSource);
-        List<String> ruleBodies =
-                ruleIds.isEmpty() ? List.of() : fetchRuleBodies(integrationId, ruleIds, space);
-
-        // 4. Extract normalized event for SAP evaluation
-        String normalizedEventJson = (String) engineResult.remove("_normalized_event");
-
-        // 5. Evaluate rules
-        Map<String, Object> sapResult;
-        if (ruleBodies.isEmpty()) {
-            sapResult = createEmptySapResult();
-        } else {
-            String saResultJson = this.securityAnalytics.evaluateRules(normalizedEventJson, ruleBodies);
-            try {
-                sapResult = mapper.readValue(saResultJson, Map.class);
-            } catch (Exception e) {
-                sapResult = createErrorSapResult();
-            }
-        }
-
-        return buildCombinedResponse(engineResult, sapResult);
+                                    fetchRuleBodiesAsync(
+                                            integrationId,
+                                            ruleIds,
+                                            space,
+                                            ActionListener.wrap(
+                                                    ruleBodies ->
+                                                            evaluateAndRespond(
+                                                                    engineResult, normalizedEventJson, ruleBodies, listener),
+                                                    e -> {
+                                                        log.warn(
+                                                                "Failed to fetch rules for" + " integration [{}]: {}",
+                                                                integrationId,
+                                                                e.getMessage());
+                                                        listener.onResponse(
+                                                                buildCombinedResponse(engineResult, createEmptySapResult()));
+                                                    }));
+                                },
+                                e -> {
+                                    log.error(
+                                            "Failed to look up integration [{}]: {}", integrationId, e.getMessage());
+                                    listener.onResponse(
+                                            new RestResponse(
+                                                    Constants.E_500_INTERNAL_SERVER_ERROR,
+                                                    RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+                                }));
     }
 
     /**
@@ -416,6 +428,71 @@ public class LogtestService {
             log.warn("Failed to fetch rules for integration [{}]: {}", integrationId, e.getMessage());
         }
         return ruleBodies;
+    }
+
+    private void fetchRuleBodiesAsync(
+            String integrationId,
+            List<String> ruleIds,
+            Space space,
+            ActionListener<List<String>> listener) {
+        this.client
+                .prepareSearch(Constants.INDEX_RULES)
+                .setSource(
+                        new SearchSourceBuilder()
+                                .query(
+                                        QueryBuilders.boolQuery()
+                                                .must(QueryBuilders.termsQuery(Constants.Q_DOCUMENT_ID, ruleIds))
+                                                .must(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, space.toString())))
+                                .size(ruleIds.size()))
+                .execute(
+                        ActionListener.wrap(
+                                rulesSearchResponse -> {
+                                    ObjectMapper mapper = new ObjectMapper();
+                                    List<String> ruleBodies = new ArrayList<>();
+                                    for (SearchHit hit : rulesSearchResponse.getHits().getHits()) {
+                                        Map<String, Object> ruleSource = hit.getSourceAsMap();
+                                        Object ruleDocObj = ruleSource.get(Constants.KEY_DOCUMENT);
+                                        if (ruleDocObj != null) {
+                                            ruleBodies.add(
+                                                    ruleDocObj instanceof Map
+                                                            ? mapper.writeValueAsString(ruleDocObj)
+                                                            : ruleDocObj.toString());
+                                        }
+                                    }
+                                    listener.onResponse(ruleBodies);
+                                },
+                                listener::onFailure));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void evaluateAndRespond(
+            Map<String, Object> engineResult,
+            String normalizedEventJson,
+            List<String> ruleBodies,
+            ActionListener<RestResponse> listener) {
+        if (ruleBodies.isEmpty()) {
+            listener.onResponse(buildCombinedResponse(engineResult, createEmptySapResult()));
+            return;
+        }
+
+        this.securityAnalytics.evaluateRulesAsync(
+                normalizedEventJson,
+                ruleBodies,
+                ActionListener.wrap(
+                        saResultJson -> {
+                            ObjectMapper mapper = new ObjectMapper();
+                            Map<String, Object> sapResult;
+                            try {
+                                sapResult = mapper.readValue(saResultJson, Map.class);
+                            } catch (Exception e) {
+                                sapResult = createErrorSapResult();
+                            }
+                            listener.onResponse(buildCombinedResponse(engineResult, sapResult));
+                        },
+                        e -> {
+                            log.error("Failed to evaluate rules: {}", e.getMessage());
+                            listener.onResponse(buildCombinedResponse(engineResult, createErrorSapResult()));
+                        }));
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsService.java
@@ -160,6 +160,16 @@ public interface SecurityAnalyticsService {
     String evaluateRules(String eventJson, List<String> ruleBodies);
 
     /**
+     * Asynchronously evaluates a list of Sigma rules against a normalized event.
+     *
+     * @param eventJson The normalized event as a JSON string.
+     * @param ruleBodies The list of Sigma rule bodies to evaluate.
+     * @param listener The listener to be notified with the evaluation result JSON string.
+     */
+    void evaluateRulesAsync(
+            String eventJson, List<String> ruleBodies, ActionListener<String> listener);
+
+    /**
      * Deletes all Security Analytics resources (integrations, rules, and detectors) belonging to the
      * given space. Sends a single bulk-delete action to SAP, which handles the deletion internally.
      *

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImpl.java
@@ -594,6 +594,17 @@ public class SecurityAnalyticsServiceImpl implements SecurityAnalyticsService {
         }
     }
 
+    @Override
+    public void evaluateRulesAsync(
+            String eventJson, java.util.List<String> ruleBodies, ActionListener<String> listener) {
+        WEvaluateRulesRequest request = new WEvaluateRulesRequest(eventJson, ruleBodies);
+        this.client.execute(
+                WEvaluateRulesAction.INSTANCE,
+                request,
+                ActionListener.wrap(
+                        response -> listener.onResponse(response.getResultJson()), listener::onFailure));
+    }
+
     /**
      * Formats category strings from CTI documents. Transforms raw category identifiers into
      * human-readable format. This method was moved from CategoryFormatter.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestAction.java
@@ -114,11 +114,23 @@ public class TransportLogtestAction
             enginePayload.remove(Constants.KEY_INTEGRATION);
 
             // 6. Delegate execution to Service
-            RestResponse serviceResponse =
-                    this.logtestService.executeLogtest(integrationId, spaceEnum, enginePayload);
-            listener.onResponse(
-                    new LogtestResponse(
-                            serviceResponse.getMessage(), RestStatus.fromCode(serviceResponse.getStatus())));
+            this.logtestService.executeLogtest(
+                    integrationId,
+                    spaceEnum,
+                    enginePayload,
+                    ActionListener.wrap(
+                            serviceResponse ->
+                                    listener.onResponse(
+                                            new LogtestResponse(
+                                                    serviceResponse.getMessage(),
+                                                    RestStatus.fromCode(serviceResponse.getStatus()))),
+                            e ->
+                                    listener.onResponse(
+                                            new LogtestResponse(
+                                                    e.getMessage() != null
+                                                            ? e.getMessage()
+                                                            : "An unexpected error occurred while" + " processing your request.",
+                                                    RestStatus.INTERNAL_SERVER_ERROR))));
         } catch (Exception e) {
             listener.onResponse(
                     new LogtestResponse(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionAction.java
@@ -119,11 +119,23 @@ public class TransportLogtestDetectionAction
             }
 
             // 6. Delegate execution to Service
-            RestResponse serviceResponse =
-                    this.logtestService.executeDetection(integrationId, spaceEnum, inputEvent);
-            listener.onResponse(
-                    new LogtestResponse(
-                            serviceResponse.getMessage(), RestStatus.fromCode(serviceResponse.getStatus())));
+            this.logtestService.executeDetectionAsync(
+                    integrationId,
+                    spaceEnum,
+                    inputEvent,
+                    ActionListener.wrap(
+                            serviceResponse ->
+                                    listener.onResponse(
+                                            new LogtestResponse(
+                                                    serviceResponse.getMessage(),
+                                                    RestStatus.fromCode(serviceResponse.getStatus()))),
+                            e ->
+                                    listener.onResponse(
+                                            new LogtestResponse(
+                                                    e.getMessage() != null
+                                                            ? e.getMessage()
+                                                            : "An unexpected error occurred while" + " processing your request.",
+                                                    RestStatus.INTERNAL_SERVER_ERROR))));
         } catch (Exception e) {
             listener.onResponse(
                     new LogtestResponse(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockSecurityAnalyticsService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockSecurityAnalyticsService.java
@@ -125,6 +125,14 @@ public class MockSecurityAnalyticsService implements SecurityAnalyticsService {
     }
 
     @Override
+    public void evaluateRulesAsync(
+            String eventJson, java.util.List<String> ruleBodies, ActionListener<String> listener) {
+        log.debug("MockSecurityAnalyticsService.evaluateRulesAsync called");
+        listener.onResponse(
+                "{\"status\":\"success\",\"rules_evaluated\":0,\"rules_matched\":0,\"matches\":[]}");
+    }
+
+    @Override
     public void deleteSpaceResources(Space space) {
         log.debug("MockSecurityAnalyticsService.deleteSpaceResources called for space: {}", space);
     }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.SearchHit;
@@ -37,10 +38,12 @@ import org.junit.Before;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -124,18 +127,35 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         return response;
     }
 
-    private void mockClientSearch(SearchResponse... responses) {
+    @SuppressWarnings("unchecked")
+    private void mockClientSearchAsync(SearchResponse... responses) {
         when(this.client.prepareSearch(anyString())).thenReturn(this.searchRequestBuilder);
         when(this.searchRequestBuilder.setSource(any(SearchSourceBuilder.class)))
                 .thenReturn(this.searchRequestBuilder);
-        if (responses.length == 1) {
-            when(this.searchRequestBuilder.get()).thenReturn(responses[0]);
-        } else {
-            var stub = when(this.searchRequestBuilder.get());
-            for (SearchResponse r : responses) {
-                stub = stub.thenReturn(r);
-            }
-        }
+        AtomicInteger callCount = new AtomicInteger(0);
+        doAnswer(
+                        invocation -> {
+                            ActionListener<SearchResponse> l = invocation.getArgument(0);
+                            l.onResponse(responses[callCount.getAndIncrement()]);
+                            return null;
+                        })
+                .when(this.searchRequestBuilder)
+                .execute(any(ActionListener.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockClientSearchAsyncFailure(Exception exception) {
+        when(this.client.prepareSearch(anyString())).thenReturn(this.searchRequestBuilder);
+        when(this.searchRequestBuilder.setSource(any(SearchSourceBuilder.class)))
+                .thenReturn(this.searchRequestBuilder);
+        doAnswer(
+                        invocation -> {
+                            ActionListener<SearchResponse> l = invocation.getArgument(0);
+                            l.onFailure(exception);
+                            return null;
+                        })
+                .when(this.searchRequestBuilder)
+                .execute(any(ActionListener.class));
     }
 
     private RestResponse createEngineSuccess(String outputJson) {
@@ -152,12 +172,20 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         return response;
     }
 
+    @SuppressWarnings("unchecked")
+    private RestResponse executeAndCapture(String integrationId, Space space, ObjectNode payload) {
+        ActionListener<RestResponse> listener = mock(ActionListener.class);
+        this.service.executeLogtest(integrationId, space, payload, listener);
+        ArgumentCaptor<RestResponse> captor = ArgumentCaptor.forClass(RestResponse.class);
+        verify(listener).onResponse(captor.capture());
+        return captor.getValue();
+    }
+
     /** Integration not found returns 400. */
     public void testIntegrationNotFound() throws Exception {
-        mockClientSearch(createEmptySearchResponse());
+        mockClientSearchAsync(createEmptySearchResponse());
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains(INTEGRATION_ID));
         verify(this.engine, never()).logtest(any());
@@ -165,13 +193,9 @@ public class LogtestServiceTests extends OpenSearchTestCase {
 
     /** Integration search failure returns 500. */
     public void testIntegrationSearchFailure() throws Exception {
-        when(this.client.prepareSearch(anyString())).thenReturn(this.searchRequestBuilder);
-        when(this.searchRequestBuilder.setSource(any(SearchSourceBuilder.class)))
-                .thenReturn(this.searchRequestBuilder);
-        when(this.searchRequestBuilder.get()).thenThrow(new RuntimeException("search failed"));
+        mockClientSearchAsyncFailure(new RuntimeException("search failed"));
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.INTERNAL_SERVER_ERROR.getStatus(), response.getStatus());
         verify(this.engine, never()).logtest(any());
     }
@@ -188,17 +212,16 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             {"document": {"detection": {"selection": {"event.kind": "event"}, "condition": "selection"}, "logsource": {"product": "test"}, "level": "low", "status": "experimental"}}
             """);
         // spotless:on
-        mockClientSearch(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
+        mockClientSearchAsync(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
 
         when(this.engine.logtest(any(JsonNode.class)))
                 .thenReturn(createEngineError("Engine processing failed"));
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"skipped\""));
         Assert.assertTrue(response.getMessage().contains("Engine processing failed"));
-        verify(this.securityAnalytics, never()).evaluateRules(anyString(), anyList());
+        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
     }
 
     /** When engine throws exception, SAP is skipped. */
@@ -209,17 +232,16 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             {"document": {"rules": []}}
             """);
         // spotless:on
-        mockClientSearch(createSearchResponse(integrationHit));
+        mockClientSearchAsync(createSearchResponse(integrationHit));
 
         when(this.engine.logtest(any(JsonNode.class)))
                 .thenThrow(new RuntimeException("socket timeout"));
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"skipped\""));
         Assert.assertTrue(response.getMessage().contains("socket timeout"));
-        verify(this.securityAnalytics, never()).evaluateRules(anyString(), anyList());
+        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
     }
 
     /** Integration with no rules returns success with zero matches. */
@@ -230,7 +252,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             {"document": {}}
             """);
         // spotless:on
-        mockClientSearch(createSearchResponse(integrationHit));
+        mockClientSearchAsync(createSearchResponse(integrationHit));
 
         // spotless:off
         when(this.engine.logtest(any(JsonNode.class)))
@@ -241,16 +263,16 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             ));
         // spotless:on
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
         Assert.assertTrue(response.getMessage().contains("\"rules_matched\":0"));
         Assert.assertTrue(response.getMessage().contains("\"success\""));
-        verify(this.securityAnalytics, never()).evaluateRules(anyString(), anyList());
+        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
     }
 
     /** Full flow: engine success + SAP evaluation. */
+    @SuppressWarnings("unchecked")
     public void testFullFlowWithRules() throws Exception {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
@@ -262,7 +284,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             {"document": {"detection": {"selection": {"event.kind": "event"}, "condition": "selection"}, "logsource": {"product": "test"}, "level": "low", "status": "experimental"}}
             """);
         // spotless:on
-        mockClientSearch(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
+        mockClientSearchAsync(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
 
         // spotless:off
         when(this.engine.logtest(any(JsonNode.class)))
@@ -271,24 +293,27 @@ public class LogtestServiceTests extends OpenSearchTestCase {
                 {"output": {"event": {"kind": "event", "category": ["database"]}}, "asset_traces": []}
                 """
             ));
-        when(this.securityAnalytics.evaluateRules(anyString(), anyList()))
-            .thenReturn(
+        doAnswer(invocation -> {
+            ActionListener<String> l = invocation.getArgument(2);
+            l.onResponse(
                 """
                 {"status":"success","rules_evaluated":1,"rules_matched":1,"matches":[{"rule_name":"Test Rule"}],"evaluation_time_ms":10}
                 """
             );
+            return null;
+        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
         // spotless:on
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("normalization"));
         Assert.assertTrue(response.getMessage().contains("detection"));
         Assert.assertTrue(response.getMessage().contains("\"rules_matched\":1"));
-        verify(this.securityAnalytics, times(1)).evaluateRules(anyString(), anyList());
+        verify(this.securityAnalytics, times(1)).evaluateRulesAsync(anyString(), anyList(), any());
     }
 
     /** Normalized event from engine output is passed to SAP. */
+    @SuppressWarnings("unchecked")
     public void testNormalizedEventPassedToSA() throws Exception {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
@@ -300,7 +325,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             {"document": {"detection": {"selection": {"event.kind": "event"}, "condition": "selection"}, "logsource": {"product": "test"}, "level": "low", "status": "experimental"}}
             """);
         // spotless:on
-        mockClientSearch(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
+        mockClientSearchAsync(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
 
         // spotless:off
         when(this.engine.logtest(any(JsonNode.class)))
@@ -309,15 +334,18 @@ public class LogtestServiceTests extends OpenSearchTestCase {
                 {"output": {"event": {"kind": "event"}, "custom_field": "value"}, "asset_traces": []}
                 """
             ));
-        when(this.securityAnalytics.evaluateRules(anyString(), anyList()))
-            .thenReturn("{\"status\":\"success\",\"rules_evaluated\":0,\"rules_matched\":0,\"matches\":[]}");
+        doAnswer(invocation -> {
+            ActionListener<String> l = invocation.getArgument(2);
+            l.onResponse("{\"status\":\"success\",\"rules_evaluated\":0,\"rules_matched\":0,\"matches\":[]}");
+            return null;
+        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
         // spotless:on
 
-        this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        ActionListener<RestResponse> listener = mock(ActionListener.class);
+        this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload(), listener);
 
-        // Verify the normalized event (output node) was passed to SAP
-        var eventCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
-        verify(this.securityAnalytics).evaluateRules(eventCaptor.capture(), anyList());
+        var eventCaptor = ArgumentCaptor.forClass(String.class);
+        verify(this.securityAnalytics).evaluateRulesAsync(eventCaptor.capture(), anyList(), any());
         String normalizedEvent = eventCaptor.getValue();
         Assert.assertTrue(normalizedEvent.contains("custom_field"));
         Assert.assertTrue(normalizedEvent.contains("event"));
@@ -333,7 +361,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             """, RULE_ID));
         // spotless:on
         // Return integration, then empty rules (simulates no rules found)
-        mockClientSearch(createSearchResponse(integrationHit), createEmptySearchResponse());
+        mockClientSearchAsync(createSearchResponse(integrationHit), createEmptySearchResponse());
 
         // spotless:off
         when(this.engine.logtest(any(JsonNode.class)))
@@ -344,14 +372,14 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             ));
         // spotless:on
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
-        verify(this.securityAnalytics, never()).evaluateRules(anyString(), anyList());
+        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
     }
 
     /** SAP evaluation error returns error SAP result but still 200. */
+    @SuppressWarnings("unchecked")
     public void testSAEvaluationErrorReturns200() throws Exception {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
@@ -363,7 +391,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             {"document": {"detection": {"selection": {"event.kind": "event"}, "condition": "selection"}, "logsource": {"product": "test"}, "level": "low", "status": "experimental"}}
             """);
         // spotless:on
-        mockClientSearch(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
+        mockClientSearchAsync(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
 
         // spotless:off
         when(this.engine.logtest(any(JsonNode.class)))
@@ -374,10 +402,16 @@ public class LogtestServiceTests extends OpenSearchTestCase {
             ));
         // spotless:on
         // SAP returns unparseable response
-        when(this.securityAnalytics.evaluateRules(anyString(), anyList())).thenReturn("not valid json");
+        doAnswer(
+                        invocation -> {
+                            ActionListener<String> l = invocation.getArgument(2);
+                            l.onResponse("not valid json");
+                            return null;
+                        })
+                .when(this.securityAnalytics)
+                .evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
 
-        RestResponse response =
-                this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload());
+        RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"error\""));
     }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
@@ -415,4 +415,121 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"error\""));
     }
+
+    // --- Detection-only tests (executeDetectionAsync) ---
+
+    @SuppressWarnings("unchecked")
+    private RestResponse executeDetectionAndCapture(
+            String integrationId, Space space, JsonNode inputEvent) {
+        ActionListener<RestResponse> listener = mock(ActionListener.class);
+        this.service.executeDetectionAsync(integrationId, space, inputEvent, listener);
+        ArgumentCaptor<RestResponse> captor = ArgumentCaptor.forClass(RestResponse.class);
+        verify(listener).onResponse(captor.capture());
+        return captor.getValue();
+    }
+
+    /** Detection: integration not found returns 400. */
+    public void testDetection_IntegrationNotFound() throws Exception {
+        mockClientSearchAsync(createEmptySearchResponse());
+        JsonNode inputEvent = MAPPER.readTree("{\"key\":\"value\"}");
+
+        RestResponse response = executeDetectionAndCapture(INTEGRATION_ID, Space.TEST, inputEvent);
+        Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains(INTEGRATION_ID));
+    }
+
+    /** Detection: integration search failure returns 500. */
+    public void testDetection_IntegrationSearchFailure() throws Exception {
+        mockClientSearchAsyncFailure(new RuntimeException("search failed"));
+        JsonNode inputEvent = MAPPER.readTree("{\"key\":\"value\"}");
+
+        RestResponse response = executeDetectionAndCapture(INTEGRATION_ID, Space.TEST, inputEvent);
+        Assert.assertEquals(RestStatus.INTERNAL_SERVER_ERROR.getStatus(), response.getStatus());
+    }
+
+    /** Detection: integration with no rules returns empty matches. */
+    public void testDetection_NoRulesReturnsEmptyMatches() throws Exception {
+        // spotless:off
+        SearchHit integrationHit = createHit(1, "int-1",
+            """
+            {"document": {}}
+            """);
+        // spotless:on
+        mockClientSearchAsync(createSearchResponse(integrationHit));
+        JsonNode inputEvent = MAPPER.readTree("{\"key\":\"value\"}");
+
+        RestResponse response = executeDetectionAndCapture(INTEGRATION_ID, Space.TEST, inputEvent);
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
+        Assert.assertTrue(response.getMessage().contains("\"rules_matched\":0"));
+        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+    }
+
+    /** Detection: full flow with SAP evaluation. */
+    @SuppressWarnings("unchecked")
+    public void testDetection_FullFlowWithRules() throws Exception {
+        // spotless:off
+        SearchHit integrationHit = createHit(1, "int-1",
+            String.format(Locale.ROOT, """
+            {"document": {"rules": ["%s"]}}
+            """, RULE_ID));
+        SearchHit ruleHit = createHit(2, "rule-1",
+            """
+            {"document": {"detection": {"selection": {"event.kind": "event"}, "condition": "selection"}, "logsource": {"product": "test"}, "level": "low", "status": "experimental"}}
+            """);
+        // spotless:on
+        mockClientSearchAsync(createSearchResponse(integrationHit), createSearchResponse(ruleHit));
+
+        // spotless:off
+        doAnswer(invocation -> {
+            ActionListener<String> l = invocation.getArgument(2);
+            l.onResponse(
+                """
+                {"status":"success","rules_evaluated":1,"rules_matched":1,"matches":[{"rule_name":"Test Rule"}],"evaluation_time_ms":10}
+                """
+            );
+            return null;
+        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
+        // spotless:on
+
+        JsonNode inputEvent = MAPPER.readTree("{\"event\":{\"kind\":\"event\"}}");
+        RestResponse response = executeDetectionAndCapture(INTEGRATION_ID, Space.TEST, inputEvent);
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("\"rules_matched\":1"));
+        verify(this.securityAnalytics, times(1)).evaluateRulesAsync(anyString(), anyList(), any());
+    }
+
+    /** Detection: rule fetch failure returns empty matches. */
+    @SuppressWarnings("unchecked")
+    public void testDetection_RuleFetchFailureReturnsEmptyMatches() throws Exception {
+        // spotless:off
+        SearchHit integrationHit = createHit(1, "int-1",
+            String.format(Locale.ROOT, """
+            {"document": {"rules": ["%s"]}}
+            """, RULE_ID));
+        // spotless:on
+        // Integration succeeds, rule fetch fails
+        when(this.client.prepareSearch(anyString())).thenReturn(this.searchRequestBuilder);
+        when(this.searchRequestBuilder.setSource(any(SearchSourceBuilder.class)))
+                .thenReturn(this.searchRequestBuilder);
+        AtomicInteger callCount = new AtomicInteger(0);
+        doAnswer(
+                        invocation -> {
+                            ActionListener<SearchResponse> l = invocation.getArgument(0);
+                            if (callCount.getAndIncrement() == 0) {
+                                l.onResponse(createSearchResponse(integrationHit));
+                            } else {
+                                l.onFailure(new RuntimeException("rule fetch failed"));
+                            }
+                            return null;
+                        })
+                .when(this.searchRequestBuilder)
+                .execute(any(ActionListener.class));
+
+        JsonNode inputEvent = MAPPER.readTree("{\"key\":\"value\"}");
+        RestResponse response = executeDetectionAndCapture(INTEGRATION_ID, Space.TEST, inputEvent);
+        Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
+        Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
+        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+    }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestActionTests.java
@@ -49,13 +49,19 @@ public class TransportLogtestActionTests extends OpenSearchTestCase {
                         mock(TransportService.class), mock(ActionFilters.class), this.logtestService);
     }
 
+    @SuppressWarnings("unchecked")
     public void testDoExecute_Success() {
-        when(this.logtestService.executeLogtest(isNull(), eq(Space.TEST), any(ObjectNode.class)))
-                .thenReturn(new RestResponse("OK", RestStatus.OK.getStatus()));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<RestResponse> l = invocation.getArgument(3);
+                            l.onResponse(new RestResponse("OK", RestStatus.OK.getStatus()));
+                            return null;
+                        })
+                .when(this.logtestService)
+                .executeLogtest(isNull(), eq(Space.TEST), any(ObjectNode.class), any(ActionListener.class));
 
         LogtestRequest request = new LogtestRequest("{\"space\":\"test\"}");
 
-        @SuppressWarnings("unchecked")
         ActionListener<LogtestResponse> listener = mock(ActionListener.class);
         this.action.doExecute(mock(Task.class), request, listener);
 
@@ -69,15 +75,24 @@ public class TransportLogtestActionTests extends OpenSearchTestCase {
                                 }));
     }
 
+    @SuppressWarnings("unchecked")
     public void testDoExecute_SuccessWithIntegration() {
-        when(this.logtestService.executeLogtest(
-                        eq("my-integration"), eq(Space.STANDARD), any(ObjectNode.class)))
-                .thenReturn(new RestResponse("OK", RestStatus.OK.getStatus()));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<RestResponse> l = invocation.getArgument(3);
+                            l.onResponse(new RestResponse("OK", RestStatus.OK.getStatus()));
+                            return null;
+                        })
+                .when(this.logtestService)
+                .executeLogtest(
+                        eq("my-integration"),
+                        eq(Space.STANDARD),
+                        any(ObjectNode.class),
+                        any(ActionListener.class));
 
         LogtestRequest request =
                 new LogtestRequest("{\"space\":\"standard\",\"integration\":\"my-integration\"}");
 
-        @SuppressWarnings("unchecked")
         ActionListener<LogtestResponse> listener = mock(ActionListener.class);
         this.action.doExecute(mock(Task.class), request, listener);
 
@@ -154,13 +169,19 @@ public class TransportLogtestActionTests extends OpenSearchTestCase {
                                 }));
     }
 
+    @SuppressWarnings("unchecked")
     public void testDoExecute_Exception() {
-        when(this.logtestService.executeLogtest(any(), any(), any()))
-                .thenThrow(new RuntimeException("Unexpected failure"));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<RestResponse> l = invocation.getArgument(3);
+                            l.onFailure(new RuntimeException("Unexpected failure"));
+                            return null;
+                        })
+                .when(this.logtestService)
+                .executeLogtest(any(), any(), any(), any(ActionListener.class));
 
         LogtestRequest request = new LogtestRequest("{\"space\":\"test\"}");
 
-        @SuppressWarnings("unchecked")
         ActionListener<LogtestResponse> listener = mock(ActionListener.class);
         this.action.doExecute(mock(Task.class), request, listener);
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionActionTests.java
@@ -33,6 +33,7 @@ import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class TransportLogtestDetectionActionTests extends OpenSearchTestCase {
@@ -49,16 +50,22 @@ public class TransportLogtestDetectionActionTests extends OpenSearchTestCase {
                         mock(TransportService.class), mock(ActionFilters.class), this.logtestService);
     }
 
+    @SuppressWarnings("unchecked")
     public void testDoExecute_Success() {
-        when(this.logtestService.executeDetection(
-                        eq("my-integration"), eq(Space.TEST), any(JsonNode.class)))
-                .thenReturn(new RestResponse("OK", RestStatus.OK.getStatus()));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<RestResponse> l = invocation.getArgument(3);
+                            l.onResponse(new RestResponse("OK", RestStatus.OK.getStatus()));
+                            return null;
+                        })
+                .when(this.logtestService)
+                .executeDetectionAsync(
+                        eq("my-integration"), eq(Space.TEST), any(JsonNode.class), any(ActionListener.class));
 
         String body =
                 "{\"space\":\"test\",\"integration\":\"my-integration\",\"input\":{\"key\":\"value\"}}";
         LogtestDetectionRequest request = new LogtestDetectionRequest(body);
 
-        @SuppressWarnings("unchecked")
         ActionListener<LogtestResponse> listener = mock(ActionListener.class);
         this.action.doExecute(mock(Task.class), request, listener);
 
@@ -154,14 +161,20 @@ public class TransportLogtestDetectionActionTests extends OpenSearchTestCase {
                                 }));
     }
 
+    @SuppressWarnings("unchecked")
     public void testDoExecute_Exception() {
-        when(this.logtestService.executeDetection(any(), any(), any()))
-                .thenThrow(new RuntimeException("Unexpected"));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<RestResponse> l = invocation.getArgument(3);
+                            l.onFailure(new RuntimeException("Unexpected"));
+                            return null;
+                        })
+                .when(this.logtestService)
+                .executeDetectionAsync(any(), any(), any(), any(ActionListener.class));
 
         String body = "{\"space\":\"test\",\"integration\":\"int-1\",\"input\":{\"key\":\"value\"}}";
         LogtestDetectionRequest request = new LogtestDetectionRequest(body);
 
-        @SuppressWarnings("unchecked")
         ActionListener<LogtestResponse> listener = mock(ActionListener.class);
         this.action.doExecute(mock(Task.class), request, listener);
 


### PR DESCRIPTION
### Description
This PR migrates the logtest endpoints to use Client's async method versions.

### Issues Resolved
Resolves #1331 