### PR TITLE
Removed auto expand replicas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *   @wazuh/devel-xdrsiem-indexer
+*   @wazuh/devel-xdrsiem-indexer-bots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,7 +202,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove ECS object from WCS definitions [(#612)](https://github.com/wazuh/wazuh-indexer-plugins/pull/612)
 - Remove alerts and archives index creation [(#693)](https://github.com/wazuh/wazuh-indexer-plugins/pull/693)
 - Remove `unclassified` module from WCS and index templates [(#1358)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1358)
-- Remove auto expand replicas [(#1355)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1355)
+- Remove auto expand replicas [(#1371)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1371)
 
 ### Fixed
 - Improve ECS folder structure [(#473)](https://github.com/wazuh/wazuh-indexer-plugins/pull/473)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove ECS object from WCS definitions [(#612)](https://github.com/wazuh/wazuh-indexer-plugins/pull/612)
 - Remove alerts and archives index creation [(#693)](https://github.com/wazuh/wazuh-indexer-plugins/pull/693)
 - Remove `unclassified` module from WCS and index templates [(#1358)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1358)
+- Remove auto expand replicas [(#1355)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1355)
 
 ### Fixed
 - Improve ECS folder structure [(#473)](https://github.com/wazuh/wazuh-indexer-plugins/pull/473)

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/PolicyIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/PolicyIT.java
@@ -297,9 +297,9 @@ public class PolicyIT extends ContentManagerRestTestCase {
      * Update policy with a caller-supplied {@code metadata.modified} that is not a valid date.
      *
      * <p>No plugin-side format validation is performed on caller-supplied dates; the malformed value
-     * is expected to fail index mapping validation ({@code MapperParsingException}). Note:
-     * {@code metadata.date} is always overwritten with the existing policy's creation date on update
-     * (see {@link #testPutPolicy_success}), so a malformed {@code date} would never reach indexing —
+     * is expected to fail index mapping validation ({@code MapperParsingException}). Note: {@code
+     * metadata.date} is always overwritten with the existing policy's creation date on update (see
+     * {@link #testPutPolicy_success}), so a malformed {@code date} would never reach indexing —
      * {@code modified} is used here instead since it is the field actually honored from the request.
      *
      * <p>Verifies: Response status code is 400 (Bad Request), not 500 (Internal Server Error).

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
@@ -34,7 +34,6 @@ import org.opensearch.transport.client.Client;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -47,6 +46,7 @@ import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
+import org.mockito.ArgumentCaptor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -135,8 +135,7 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
     }
 
     private String draftUpdateBody(String modifiedField) {
-        String modifiedLine =
-                modifiedField == null ? "" : "\"modified\": \"" + modifiedField + "\",";
+        String modifiedLine = modifiedField == null ? "" : "\"modified\": \"" + modifiedField + "\",";
         return "{"
                 + "\"type\": \"policy\","
                 + "\"resource\": {"
@@ -168,12 +167,12 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
     }
 
     public void testUpdatePolicy_honorsCallerSuppliedModified() throws Exception {
-        when(this.spaceService.getPolicy(com.wazuh.contentmanager.cti.catalog.model.Space.DRAFT.toString()))
+        when(this.spaceService.getPolicy(
+                        com.wazuh.contentmanager.cti.catalog.model.Space.DRAFT.toString()))
                 .thenReturn(currentDraftPolicy());
 
         String callerModified = "2021-05-05T00:00:00.000Z";
-        UpdatePolicyRequest request =
-                new UpdatePolicyRequest("draft", draftUpdateBody(callerModified));
+        UpdatePolicyRequest request = new UpdatePolicyRequest("draft", draftUpdateBody(callerModified));
 
         @SuppressWarnings("unchecked")
         ActionListener<MessageStatusResponse> listener = mock(ActionListener.class);
@@ -199,7 +198,8 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
     }
 
     public void testUpdatePolicy_generatesModifiedWhenAbsent() throws Exception {
-        when(this.spaceService.getPolicy(com.wazuh.contentmanager.cti.catalog.model.Space.DRAFT.toString()))
+        when(this.spaceService.getPolicy(
+                        com.wazuh.contentmanager.cti.catalog.model.Space.DRAFT.toString()))
                 .thenReturn(currentDraftPolicy());
 
         UpdatePolicyRequest request = new UpdatePolicyRequest("draft", draftUpdateBody(null));

--- a/plugins/setup/src/main/resources/templates/content/filters.json
+++ b/plugins/setup/src/main/resources/templates/content/filters.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 50,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/content/ioc.json
+++ b/plugins/setup/src/main/resources/templates/content/ioc.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 200,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
+++ b/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
@@ -6,7 +6,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -7,7 +7,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 50,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -7,7 +7,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/streams/raw.json
+++ b/plugins/setup/src/main/resources/templates/streams/raw.json
@@ -7,7 +7,6 @@
   "template": {
     "settings": {
       "index": {
-        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",

--- a/wcs/content/filters/fields/template-settings-legacy.json
+++ b/wcs/content/filters/fields/template-settings-legacy.json
@@ -10,7 +10,6 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
-      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "document.name",

--- a/wcs/content/filters/fields/template-settings.json
+++ b/wcs/content/filters/fields/template-settings.json
@@ -12,7 +12,6 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
-        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "document.name",

--- a/wcs/content/ioc/fields/template-settings-legacy.json
+++ b/wcs/content/ioc/fields/template-settings-legacy.json
@@ -11,7 +11,6 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
-      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "document.confidence",

--- a/wcs/content/ioc/fields/template-settings.json
+++ b/wcs/content/ioc/fields/template-settings.json
@@ -12,7 +12,6 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
-        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "document.confidence",

--- a/wcs/stateful/vulnerabilities/fields/template-settings-legacy.json
+++ b/wcs/stateful/vulnerabilities/fields/template-settings-legacy.json
@@ -7,7 +7,6 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
-      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateless/active-responses/fields/template-settings-legacy.json
+++ b/wcs/stateless/active-responses/fields/template-settings-legacy.json
@@ -12,7 +12,6 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
-      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "wazuh.agent.id",

--- a/wcs/stateless/active-responses/fields/template-settings.json
+++ b/wcs/stateless/active-responses/fields/template-settings.json
@@ -13,7 +13,6 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
-        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "wazuh.agent.id",

--- a/wcs/stateless/events/main/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/main/fields/template-settings-legacy.json
@@ -10,7 +10,6 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
-      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateless/events/main/fields/template-settings.json
+++ b/wcs/stateless/events/main/fields/template-settings.json
@@ -12,7 +12,6 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
-        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateless/events/raw/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/raw/fields/template-settings-legacy.json
@@ -11,7 +11,6 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
-      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "wazuh.agent.id",

--- a/wcs/stateless/events/raw/fields/template-settings.json
+++ b/wcs/stateless/events/raw/fields/template-settings.json
@@ -13,7 +13,6 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
-        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "wazuh.agent.id",


### PR DESCRIPTION
### Description
- Removes `auto_expand_replicas: "0-1"` from the index templates for `active-responses`, `events/main` (access-management, applications, cloud-services, network-activity, other, security, system-activity), `events/raw`, and `events/unclassified`.
- These templates already set `number_of_replicas: "0"`, but the `auto_expand_replicas` setting was overriding it and expanding replicas to 1 as soon as a second node joined the cluster.
- Changes were made in the `wcs/` source templates (`template-settings.json` and `template-settings-legacy.json`) so they aren't overwritten by the generator tooling, and mirrored in the corresponding deployed templates under `plugins/setup/src/main/resources/templates/streams/`.


### Issues Resolved
Closes #1354 
