### PR TITLE
Fix promotion changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix race condition between Content Manager and Setup plugin initialization [(#1262)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1262)
 - Fix invalid action name warning messages [(#1313)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1313)
 - Fix consumer offset left behind the remote head after a plan-change content swap [(#1343)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1343)
+- Fix promotion changes on fresh install [(#1377)](https://github.com/wazuh/wazuh-indexer-plugins/pull/1377)
 
 ### Security
 - Reduce risk of GITHUB_TOKEN exposure [(#484)](https://github.com/wazuh/wazuh-indexer-plugins/pull/484)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -177,8 +177,9 @@ public class SpaceService {
             policy.setReferences(Collections.emptyList());
             policy.setDate(date);
             policy.setModified(date);
-            // Enable the policy by default for the draft space only
-            policy.setEnabled(Space.DRAFT.toString().equals(spaceName));
+            // Enabled by default for every space: draft and test must match, otherwise the
+            // promote preview reports the "enabled" mismatch itself as an unpromoted change.
+            policy.setEnabled(true);
             policy.setIndexUnclassifiedEvents(false);
             policy.setIndexDiscardedEvents(false);
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SpaceServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SpaceServiceTests.java
@@ -137,10 +137,7 @@ public class SpaceServiceTests extends OpenSearchTestCase {
         this.policyHashService.calculateAndUpdate(List.of(Space.DRAFT.toString()));
     }
 
-    /**
-     * Tests that initializeSpace sets enabled=true only for the draft space and enabled=false for
-     * other spaces (test, custom, standard).
-     */
+    /** Tests that initializeSpace sets enabled=true for the draft space. */
     public void testInitializeSpace_DraftPolicyEnabledTrue() {
         // Arrange
         org.mockito.ArgumentCaptor<IndexRequest> captor =
@@ -164,9 +161,11 @@ public class SpaceServiceTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests that initializeSpace sets enabled=false for non-draft spaces (test, custom, standard).
+     * Tests that initializeSpace also sets enabled=true for non-draft spaces (test, custom,
+     * standard), matching the draft space so the promote preview does not surface the "enabled"
+     * mismatch as a false unpromoted change on a fresh installation.
      */
-    public void testInitializeSpace_NonDraftPoliciesEnabledFalse() {
+    public void testInitializeSpace_NonDraftPoliciesEnabledTrue() {
         // Test for all non-draft spaces
         for (String spaceName : new String[] {"test", "custom", "standard"}) {
             // Reinitialize mocks for each space
@@ -184,13 +183,13 @@ public class SpaceServiceTests extends OpenSearchTestCase {
             // Act: Initialize non-draft space
             this.policyHashService.initializeSpace(spaceName, "test-doc-id");
 
-            // Verify the IndexRequest contains enabled=false for non-draft spaces
+            // Verify the IndexRequest contains enabled=true for non-draft spaces too
             verify(this.client).index(captor.capture());
             IndexRequest request = captor.getValue();
             String sourceJson = request.source().utf8ToString();
             assertTrue(
-                    "Policy for space '" + spaceName + "' should contain enabled: false",
-                    sourceJson.contains("\"enabled\":false"));
+                    "Policy for space '" + spaceName + "' should contain enabled: true",
+                    sourceJson.contains("\"enabled\":true"));
         }
     }
 }


### PR DESCRIPTION
### Description

Fixes an inconsistency where policies were created with `enabled: true` for the **draft** space but `enabled: false` for every other space (test, custom, standard). Because the promote preview compares the draft and test policies, this mismatch alone was reported as an "unpromoted change", so the dashboard showed up even on a fresh installation where the user hadn't made any changes.

- `SpaceService.initializeSpace()` now sets `enabled: true` for all spaces by default, so draft and test start out identical.
- Updated `SpaceServiceTests` accordingly: the test that asserted `enabled:false` for non-draft spaces now asserts `enabled:true`.


### Issues Resolved
Closes #1373

