### PR TITLE
Add missing permissions to read the settings index to the wazuh_manager role

### DIFF
--- a/docs/ref/security/access-control.md
+++ b/docs/ref/security/access-control.md
@@ -41,6 +41,7 @@ Service account used by the Wazuh Manager for data ingestion and content reads.
 
 - **Cluster permissions:** `cluster_composite_ops`, `cluster_monitor`.
 - **Index permissions:**
+  - `read` on `.wazuh-settings`.
   - `read` on `.wazuh-cti-consumers`, `wazuh-active-responses*`, `wazuh-threatintel-*`.
   - `read`, `index` on `wazuh-events-v5-*`, `wazuh-metrics-*`.
   - `read`, `index`, `delete` on `wazuh-states-*`.


### PR DESCRIPTION
### Description
Add missing permissions to read the settings index to the wazuh_manager role

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1541
