### PR TITLE
Adopt the new PR template and no-changelog label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,75 @@
-<!--  Thanks for sending a pull request, here are some tips:
+## Description
 
-1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
-2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
-3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
+<!--
+Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
+
+If this pull request resolves an existing issue, reference it here. For example:
+Closes #<issue_number>
 -->
 
-### Description
-[Describe what this change achieves]
+## Proposed Changes
 
-### Related Issues
-Resolves #[Issue number to be closed when this PR is merged]
-<!-- List any other related issues here -->
+<!--
+Summarize the changes made in this pull request. Include:
+- Features added
+- Bugs fixed
+- Any relevant technical details
+-->
 
-### Check List
-- [ ] Functionality includes testing.
-- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
-- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
+### Results and Evidence
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+<!--
+Provide evidence of the changes made, such as:
+- Logs
+- Screenshots
+- Before/after comparisons
+-->
+
+### Artifacts Affected
+
+<!--
+List the artifacts impacted by this pull request, such as:
+- Executables (specify platforms if applicable)
+- Default configuration files
+- Packages
+-->
+
+### Configuration Changes
+
+<!--
+If applicable, list any configuration changes introduced by this pull request, including:
+- New configuration parameters
+- Changes to default values
+- Backward compatibility notes
+-->
+
+### Documentation Updates
+
+<!--
+If applicable, list the sections of documentation that have been updated as part of this pull request.
+-->
+
+### Tests Introduced
+
+<!--
+If applicable, describe any new unit or integration tests added as part of this pull request. Include:
+- Scope of the tests
+- Any relevant details about test coverage
+-->
+
+## Review Checklist
+
+<!--
+List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
+-->
+
+- [ ] Code changes reviewed
+- [ ] Relevant evidence provided
+- [ ] Tests cover the new functionality
+- [ ] Configuration changes documented
+- [ ] Developer documentation reflects the changes
+- [ ] Meets requirements and/or definition of done
+- [ ] No unresolved dependencies with other issues
+- [ ] PR is linked to the relevant issue(s)
+- [ ] Correct labels applied (e.g., `no-changelog`)
+- [ ] ...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,21 @@
+<!--  Thanks for sending a pull request, here are some tips:
+
+1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
+2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
+3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
+-->
+
 ### Description
 [Describe what this change achieves]
 
-### Issues Resolved
-[List any issues this PR will resolve]
+### Related Issues
+Resolves #[Issue number to be closed when this PR is merged]
+<!-- List any other related issues here -->
+
+### Check List
+- [ ] Functionality includes testing.
+- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
+- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v3
         id: verify-changelog
         with:
-          skipLabels: "autocut, skip-changelog"
+          skipLabels: "no-changelog"
           changeLogPath: "CHANGELOG.md"

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -27,18 +27,20 @@ To address review feedback, push new commits on top of the branch and re-request
 
 ### Body template
 
-Use the following template when creating a Pull Request:
+Every repository provides the template below as its default `.github/pull_request_template.md`; it is pre-filled automatically when you open a PR. Every PR **must** be linked to an existing issue, and PRs should not be linked directly to GitHub Projects — track project status at the issue level instead.
 
 ```markdown
-## Description
+### Description
+[Describe what this change achieves]
 
-<!-- Brief description of the changes and the reasoning behind them. -->
+### Related Issues
+Resolves #[Issue number to be closed when this PR is merged]
+<!-- List any other related issues here -->
 
-Resolves #<issue_number>
-
-## Checklist
-
-- [ ] ...
+### Check List
+- [ ] Functionality includes testing.
+- [ ] API changes companion pull request created, if applicable.
+- [ ] Public documentation issue/PR created, if applicable.
 ```
 
 Always link the related issue with `Resolves #<number>` so it auto-closes on merge, and describe **why** rather than just **what** — the diff already shows what changed, so the description should explain the motivation.
@@ -49,7 +51,9 @@ Start from the linked issue to understand the context and acceptance criteria, t
 
 ### Changelog
 
-Every PR is expected to include a changelog entry. The `5_codequality_changelog.yml` workflow enforces this. Apply the **`skip-changelog`** label to bypass the check when the linked issue belongs to a **private repository**, or when the PR is linked to a public issue but genuinely does not require a changelog update.
+Every PR is expected to include a changelog entry, classified as **Added**, **Changed**, **Removed**, or **Fixed**. The `5_codequality_changelog.yml` workflow enforces this. Apply the **`no-changelog`** label to bypass the check when the linked issue belongs to a **private repository**, or when the PR genuinely does not require a changelog update.
+
+Changelog entries must always reference the **issue**, not the pull request, so the entry stays meaningful independently of how the change was implemented. An issue only belongs in the changelog if it affects the product and represents a change from a previously released version — internal/CI changes are never included, and neither are fixes for problems introduced in an unpublished version.
 
 ### Best practices
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -30,17 +30,81 @@ To address review feedback, push new commits on top of the branch and re-request
 Every repository provides the template below as its default `.github/pull_request_template.md`; it is pre-filled automatically when you open a PR. Every PR **must** be linked to an existing issue, and PRs should not be linked directly to GitHub Projects — track project status at the issue level instead.
 
 ```markdown
-### Description
-[Describe what this change achieves]
+## Description
 
-### Related Issues
-Resolves #[Issue number to be closed when this PR is merged]
-<!-- List any other related issues here -->
+<!--
+Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
 
-### Check List
-- [ ] Functionality includes testing.
-- [ ] API changes companion pull request created, if applicable.
-- [ ] Public documentation issue/PR created, if applicable.
+If this pull request resolves an existing issue, reference it here. For example:
+Closes #<issue_number>
+-->
+
+## Proposed Changes
+
+<!--
+Summarize the changes made in this pull request. Include:
+- Features added
+- Bugs fixed
+- Any relevant technical details
+-->
+
+### Results and Evidence
+
+<!--
+Provide evidence of the changes made, such as:
+- Logs
+- Screenshots
+- Before/after comparisons
+-->
+
+### Artifacts Affected
+
+<!--
+List the artifacts impacted by this pull request, such as:
+- Executables (specify platforms if applicable)
+- Default configuration files
+- Packages
+-->
+
+### Configuration Changes
+
+<!--
+If applicable, list any configuration changes introduced by this pull request, including:
+- New configuration parameters
+- Changes to default values
+- Backward compatibility notes
+-->
+
+### Documentation Updates
+
+<!--
+If applicable, list the sections of documentation that have been updated as part of this pull request.
+-->
+
+### Tests Introduced
+
+<!--
+If applicable, describe any new unit or integration tests added as part of this pull request. Include:
+- Scope of the tests
+- Any relevant details about test coverage
+-->
+
+## Review Checklist
+
+<!--
+List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
+-->
+
+- [ ] Code changes reviewed
+- [ ] Relevant evidence provided
+- [ ] Tests cover the new functionality
+- [ ] Configuration changes documented
+- [ ] Developer documentation reflects the changes
+- [ ] Meets requirements and/or definition of done
+- [ ] No unresolved dependencies with other issues
+- [ ] PR is linked to the relevant issue(s)
+- [ ] Correct labels applied (e.g., `no-changelog`)
+- [ ] ...
 ```
 
 Always link the related issue with `Resolves #<number>` so it auto-closes on merge, and describe **why** rather than just **what** — the diff already shows what changed, so the description should explain the motivation.


### PR DESCRIPTION
### Description
Updates the pull request template to the org-wide standard and switches the changelog enforcer workflow to accept only the new `no-changelog` skip label, retiring `autocut`/`skip-changelog`. 

### Issues Resolved
https://github.com/wazuh/internal-devel-requests/issues/5504
