### PR TITLE
Load standard and promoted test/custom content into all cluster nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Safeguard sensitive configurations [(#1277)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1277)
 - Reduce TTL for historical information about deletes in-memory [(#1328)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1328)
 - Integration's mode [(#1356)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1356)
+- Load standard space into all cluster nodes [(#1376)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1376)
 
 ### Changed
 - Add dependabot scan to the content-manager plugin [(#442)](https://github.com/wazuh/wazuh-indexer-plugins/issues/442)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -217,10 +217,22 @@ public class ContentManagerPlugin extends Plugin
         this.engineContentLoader =
                 new EngineContentLoader(this.engine, this.spaceService, this.threadPool);
 
+        if (PluginSettings.getInstance().isEngineMockEnabled()) {
+            this.securityAnalyticsService = new MockSecurityAnalyticsService();
+        } else {
+            this.securityAnalyticsService = new SecurityAnalyticsServiceImpl(client);
+        }
+
         // Initialize CatalogSyncJob
         this.catalogSyncJob =
                 new CatalogSyncJob(
-                        this.client, this.consumersIndex, environment, this.threadPool, this.engine);
+                        this.client,
+                        this.consumersIndex,
+                        environment,
+                        this.threadPool,
+                        this.engine,
+                        this.spaceService,
+                        this.securityAnalyticsService);
 
         // Initialize TelemetryPingJob
         this.telemetryPingJob =
@@ -229,13 +241,6 @@ public class ContentManagerPlugin extends Plugin
         // Register Executors
         runner.registerExecutor(CatalogSyncJob.JOB_TYPE, this.catalogSyncJob);
         runner.registerExecutor(TelemetryPingJob.JOB_TYPE, this.telemetryPingJob);
-
-        // Initialize services
-        if (PluginSettings.getInstance().isEngineMockEnabled()) {
-            this.securityAnalyticsService = new MockSecurityAnalyticsService();
-        } else {
-            this.securityAnalyticsService = new SecurityAnalyticsServiceImpl(client);
-        }
 
         this.logtestService =
                 new LogtestService(this.engine, this.securityAnalyticsService, this.client);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -28,6 +28,7 @@ import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.cluster.LocalNodeClusterManagerListener;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -86,6 +87,7 @@ import com.wazuh.contentmanager.action.*;
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsServiceImpl;
@@ -128,6 +130,8 @@ public class ContentManagerPlugin extends Plugin
     private CatalogSyncJob catalogSyncJob;
     private TelemetryPingJob telemetryPingJob;
     private EngineService engine;
+    private EngineContentLoader engineContentLoader;
+    private ClusterStateListener engineContentListener;
     private SpaceService spaceService;
     private SecurityAnalyticsService securityAnalyticsService;
     private Environment environment;
@@ -207,10 +211,20 @@ public class ContentManagerPlugin extends Plugin
             this.engine = new EngineServiceImpl();
         }
 
+        // Initialize services shared by the sync path and the per-node engine loader
+        this.spaceService = new SpaceService(this.client);
+        this.engineContentLoader =
+                new EngineContentLoader(this.engine, this.spaceService, this.threadPool);
+
         // Initialize CatalogSyncJob
         this.catalogSyncJob =
                 new CatalogSyncJob(
-                        this.client, this.consumersIndex, environment, this.threadPool, this.engine);
+                        this.client,
+                        this.consumersIndex,
+                        environment,
+                        this.threadPool,
+                        this.engine,
+                        this.engineContentLoader);
 
         // Initialize TelemetryPingJob
         this.telemetryPingJob =
@@ -221,7 +235,6 @@ public class ContentManagerPlugin extends Plugin
         runner.registerExecutor(TelemetryPingJob.JOB_TYPE, this.telemetryPingJob);
 
         // Initialize services
-        this.spaceService = new SpaceService(this.client);
         if (PluginSettings.getInstance().isEngineMockEnabled()) {
             this.securityAnalyticsService = new MockSecurityAnalyticsService();
         } else {
@@ -289,6 +302,17 @@ public class ContentManagerPlugin extends Plugin
         }
         this.threadPool.generic().execute(this::tryLoadAccessToken);
 
+        // Load the STANDARD space into this node's local Engine on every node, not just the elected
+        // cluster manager. Engine communication is node-local (a Unix socket), so each node must
+        // load the content itself; the content data lives in cluster-wide indices. The listener
+        // fires on every cluster-state update, so a load that failed because the Engine was not yet
+        // ready is retried on a subsequent event, and late/rejoining nodes converge on join — with
+        // no dedicated timer or poll. Once loaded, each call is a cheap in-memory hash comparison.
+        this.engineContentListener = event -> this.engineContentLoader.reloadIfChanged();
+        this.clusterService.addListener(this.engineContentListener);
+        // Attempt an initial load immediately; if the Engine is not ready yet the listener retries.
+        this.engineContentLoader.reloadIfChanged();
+
         AtomicBoolean started = new AtomicBoolean(false);
         LocalNodeClusterManagerListener listener =
                 new LocalNodeClusterManagerListener() {
@@ -348,6 +372,17 @@ public class ContentManagerPlugin extends Plugin
         // runs), trigger the callback explicitly.
         if (this.clusterService.state().nodes().isLocalNodeElectedClusterManager()) {
             listener.onClusterManager();
+        }
+    }
+
+    /**
+     * Deregisters the cluster-state listener that drives the per-node Engine content load. Invoked by
+     * OpenSearch when the plugin is closed (node shutdown).
+     */
+    @Override
+    public void close() {
+        if (this.engineContentListener != null && this.clusterService != null) {
+            this.clusterService.removeListener(this.engineContentListener);
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -219,12 +219,7 @@ public class ContentManagerPlugin extends Plugin
         // Initialize CatalogSyncJob
         this.catalogSyncJob =
                 new CatalogSyncJob(
-                        this.client,
-                        this.consumersIndex,
-                        environment,
-                        this.threadPool,
-                        this.engine,
-                        this.engineContentLoader);
+                        this.client, this.consumersIndex, environment, this.threadPool, this.engine);
 
         // Initialize TelemetryPingJob
         this.telemetryPingJob =
@@ -279,6 +274,7 @@ public class ContentManagerPlugin extends Plugin
                 this.subscriptionService,
                 this.catalogSyncJob,
                 this.engine,
+                this.engineContentLoader,
                 this.logtestService,
                 this.spaceService,
                 this.securityAnalyticsService);
@@ -927,6 +923,8 @@ public class ContentManagerPlugin extends Plugin
                 new ActionHandler<>(
                         IndexSubscriptionAction.INSTANCE, TransportIndexSubscriptionAction.class),
                 new ActionHandler<>(TriggerUpdateAction.INSTANCE, TransportTriggerUpdateAction.class),
+                new ActionHandler<>(
+                        ReloadEngineContentAction.INSTANCE, TransportReloadEngineContentAction.class),
                 // Group 2: Subscription GET/DELETE + Space DELETE
                 new ActionHandler<>(GetSubscriptionAction.INSTANCE, TransportGetSubscriptionAction.class),
                 new ActionHandler<>(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.action;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Nodes-level action that tells every node to reload the STANDARD space into its own local Engine.
+ *
+ * <p>Fired by the cluster manager after a content-changing sync so that all nodes converge
+ * promptly, not only when they next happen to receive an unrelated cluster-state event. Each node's
+ * handler delegates to the same hash-gated loader used by the per-node cluster-state listener, so a
+ * redundant broadcast is a cheap no-op.
+ */
+public class ReloadEngineContentAction extends ActionType<ReloadEngineContentResponse> {
+    public static final String NAME = "cluster:admin/content_manager/engine/reload";
+    public static final ReloadEngineContentAction INSTANCE = new ReloadEngineContentAction();
+
+    public ReloadEngineContentAction() {
+        super(NAME, ReloadEngineContentResponse::new);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentNodeResponse.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentNodeResponse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.action;
+
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Per-node response for {@link ReloadEngineContentAction}. Its presence in the aggregate response
+ * confirms the node accepted (scheduled) the reload; the actual load result is reported through the
+ * node's own Engine load logs. Carries no payload beyond the node identity.
+ */
+public class ReloadEngineContentNodeResponse extends BaseNodeResponse {
+
+    public ReloadEngineContentNodeResponse(DiscoveryNode node) {
+        super(node);
+    }
+
+    public ReloadEngineContentNodeResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentRequest.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.action;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Request for {@link ReloadEngineContentAction}. Carries no payload: it targets all nodes (a {@code
+ * null} node filter resolves to every node in the cluster) and each node reads the current content
+ * hash itself from the cluster-wide policies index.
+ */
+public class ReloadEngineContentRequest extends BaseNodesRequest<ReloadEngineContentRequest> {
+
+    /** Creates a request targeting all nodes in the cluster. */
+    public ReloadEngineContentRequest() {
+        super((String[]) null);
+    }
+
+    public ReloadEngineContentRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentResponse.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/ReloadEngineContentResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.action;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Aggregate response for {@link ReloadEngineContentAction}: one entry per responding node. */
+public class ReloadEngineContentResponse
+        extends BaseNodesResponse<ReloadEngineContentNodeResponse> {
+
+    public ReloadEngineContentResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public ReloadEngineContentResponse(
+            ClusterName clusterName,
+            List<ReloadEngineContentNodeResponse> nodes,
+            List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<ReloadEngineContentNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(ReloadEngineContentNodeResponse::new);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<ReloadEngineContentNodeResponse> nodes)
+            throws IOException {
+        out.writeList(nodes);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
@@ -38,6 +38,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import com.wazuh.contentmanager.action.ReloadEngineContentAction;
+import com.wazuh.contentmanager.action.ReloadEngineContentRequest;
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Policy;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
@@ -56,7 +58,6 @@ public class ConsumerRulesetService extends AbstractConsumerService {
 
     private final SecurityAnalyticsServiceImpl securityAnalyticsService;
     private final SpaceService spaceService;
-    private final EngineContentLoader engineContentLoader;
 
     private Set<String> preSwapIntegrationIds = Collections.emptySet();
     private Set<String> preSwapRuleIds = Collections.emptySet();
@@ -67,17 +68,12 @@ public class ConsumerRulesetService extends AbstractConsumerService {
      * @param client The OpenSearch client.
      * @param consumersIndex The consumers index wrapper.
      * @param environment The OpenSearch environment settings.
-     * @param engineContentLoader The loader that reloads the standard space into the local Engine.
      */
     public ConsumerRulesetService(
-            Client client,
-            ConsumersIndex consumersIndex,
-            Environment environment,
-            EngineContentLoader engineContentLoader) {
+            Client client, ConsumersIndex consumersIndex, Environment environment) {
         super(client, consumersIndex, environment);
         this.securityAnalyticsService = new SecurityAnalyticsServiceImpl(client);
         this.spaceService = new SpaceService(client);
-        this.engineContentLoader = engineContentLoader;
 
         this.mapper = new ObjectMapper();
         this.mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
@@ -200,9 +196,18 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             } catch (IOException e) {
                 log.error(Constants.E_LOG_CALCULATE_HASHES_FAILED, e.getMessage(), e);
             }
-            // Prompt nudge on the node that ran the sync (the cluster manager). Every node also
-            // converges independently via the cluster-state listener that drives this same loader.
-            this.engineContentLoader.reloadIfChanged();
+            // Broadcast a reload trigger to every node so each one loads the updated STANDARD space
+            // into its own local Engine. A routine incremental update changes only index documents
+            // (no cluster-state event), so peer nodes would otherwise not react until some unrelated
+            // cluster-state event happened to fire their listener. The broadcast targets all nodes
+            // including this one, and the per-node loader is hash-gated, so the call is idempotent
+            // and a node that is down simply converges later via the cluster-state listener.
+            this.client.execute(
+                    ReloadEngineContentAction.INSTANCE,
+                    new ReloadEngineContentRequest(),
+                    ActionListener.wrap(
+                            r -> log.debug(Constants.D_LOG_ENGINE_RELOAD_BROADCAST_SENT),
+                            e -> log.warn(Constants.W_LOG_ENGINE_RELOAD_BROADCAST_FAILED, e.getMessage())));
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.env.Environment;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.transport.client.Client;
@@ -42,8 +41,6 @@ import java.util.function.Consumer;
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Policy;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
-import com.wazuh.contentmanager.engine.service.EngineService;
-import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -59,7 +56,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
 
     private final SecurityAnalyticsServiceImpl securityAnalyticsService;
     private final SpaceService spaceService;
-    private final EngineService engineService;
+    private final EngineContentLoader engineContentLoader;
 
     private Set<String> preSwapIntegrationIds = Collections.emptySet();
     private Set<String> preSwapRuleIds = Collections.emptySet();
@@ -70,17 +67,17 @@ public class ConsumerRulesetService extends AbstractConsumerService {
      * @param client The OpenSearch client.
      * @param consumersIndex The consumers index wrapper.
      * @param environment The OpenSearch environment settings.
-     * @param engineService The engine service for loading content into the Engine.
+     * @param engineContentLoader The loader that reloads the standard space into the local Engine.
      */
     public ConsumerRulesetService(
             Client client,
             ConsumersIndex consumersIndex,
             Environment environment,
-            EngineService engineService) {
+            EngineContentLoader engineContentLoader) {
         super(client, consumersIndex, environment);
         this.securityAnalyticsService = new SecurityAnalyticsServiceImpl(client);
         this.spaceService = new SpaceService(client);
-        this.engineService = engineService;
+        this.engineContentLoader = engineContentLoader;
 
         this.mapper = new ObjectMapper();
         this.mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
@@ -203,7 +200,9 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             } catch (IOException e) {
                 log.error(Constants.E_LOG_CALCULATE_HASHES_FAILED, e.getMessage(), e);
             }
-            this.loadStandardSpaceIntoEngine();
+            // Prompt nudge on the node that ran the sync (the cluster manager). Every node also
+            // converges independently via the cluster-state listener that drives this same loader.
+            this.engineContentLoader.reloadIfChanged();
         }
     }
 
@@ -232,29 +231,6 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             throw new IOException(e);
         } catch (TimeoutException e) {
             throw new IOException(e);
-        }
-    }
-
-    /** Builds the engine payload for the standard space and loads it into the Engine. */
-    private void loadStandardSpaceIntoEngine() {
-        if (this.engineService == null) {
-            log.warn(Constants.E_LOG_ENGINE_IS_NULL);
-            return;
-        }
-        try {
-            JsonNode payload =
-                    this.awaitResult(l -> this.spaceService.buildEnginePayload(Space.STANDARD.toString(), l));
-            RestResponse response = this.engineService.promote(payload);
-            if (response.getStatus() == RestStatus.OK.getStatus()) {
-                log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
-            } else {
-                log.warn(
-                        Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
-                        response.getStatus(),
-                        response.getMessage());
-            }
-        } catch (Exception e) {
-            log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage());
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
@@ -57,7 +57,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
     private static final String[] DOCUMENT_ONLY_SOURCE = new String[] {Constants.KEY_DOCUMENT};
     private final ObjectMapper mapper;
 
-    private final SecurityAnalyticsServiceImpl securityAnalyticsService;
+    private final SecurityAnalyticsService securityAnalyticsService;
     private final SpaceService spaceService;
 
     private Set<String> preSwapIntegrationIds = Collections.emptySet();
@@ -69,12 +69,18 @@ public class ConsumerRulesetService extends AbstractConsumerService {
      * @param client The OpenSearch client.
      * @param consumersIndex The consumers index wrapper.
      * @param environment The OpenSearch environment settings.
+     * @param spaceService The shared space service.
+     * @param securityAnalyticsService The shared SAP service.
      */
     public ConsumerRulesetService(
-            Client client, ConsumersIndex consumersIndex, Environment environment) {
+            Client client,
+            ConsumersIndex consumersIndex,
+            Environment environment,
+            SpaceService spaceService,
+            SecurityAnalyticsService securityAnalyticsService) {
         super(client, consumersIndex, environment);
-        this.securityAnalyticsService = new SecurityAnalyticsServiceImpl(client);
-        this.spaceService = new SpaceService(client);
+        this.securityAnalyticsService = securityAnalyticsService;
+        this.spaceService = spaceService;
 
         this.mapper = new ObjectMapper();
         this.mapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
@@ -407,10 +413,13 @@ public class ConsumerRulesetService extends AbstractConsumerService {
      *     #syncIntegrations()}, keyed by document ID.
      */
     private void syncDetectors(Map<String, JsonNode> integrationDocs) throws IOException {
+        if (!(this.securityAnalyticsService instanceof SecurityAnalyticsServiceImpl sapService)) {
+            return;
+        }
         List<JsonNode> docs = new ArrayList<>();
         integrationDocs.forEach(
                 (id, doc) -> {
-                    if (this.securityAnalyticsService.buildDetectorRequest(doc, true) != null) {
+                    if (sapService.buildDetectorRequest(doc, true) != null) {
                         docs.add(doc);
                     }
                 });
@@ -526,17 +535,20 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             Set<String> staleIntegrationIds = new HashSet<>(this.preSwapIntegrationIds);
             staleIntegrationIds.removeAll(currentIntegrationIds);
 
-            for (String id : staleIntegrationIds) {
-                try {
-                    CompletableFuture<Void> future = new CompletableFuture<>();
+            if (!staleIntegrationIds.isEmpty()) {
+                CountDownLatch integrationLatch = new CountDownLatch(staleIntegrationIds.size());
+                for (String id : staleIntegrationIds) {
                     this.securityAnalyticsService.deleteIntegration(
                             id,
                             Space.STANDARD,
-                            ActionListener.wrap(r -> future.complete(null), future::completeExceptionally));
-                    future.get(60, TimeUnit.SECONDS);
-                } catch (Exception e) {
-                    log.warn("Failed to delete stale integration [{}]: {}", id, e.getMessage());
+                            ActionListener.wrap(
+                                    r -> integrationLatch.countDown(),
+                                    e -> {
+                                        log.warn("Failed to delete stale integration [{}]: {}", id, e.getMessage());
+                                        integrationLatch.countDown();
+                                    }));
                 }
+                integrationLatch.await(120, TimeUnit.SECONDS);
             }
 
             Set<String> currentRuleIds =
@@ -544,17 +556,20 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             Set<String> staleRuleIds = new HashSet<>(this.preSwapRuleIds);
             staleRuleIds.removeAll(currentRuleIds);
 
-            for (String id : staleRuleIds) {
-                try {
-                    CompletableFuture<Void> future = new CompletableFuture<>();
+            if (!staleRuleIds.isEmpty()) {
+                CountDownLatch ruleLatch = new CountDownLatch(staleRuleIds.size());
+                for (String id : staleRuleIds) {
                     this.securityAnalyticsService.deleteRule(
                             id,
                             Space.STANDARD,
-                            ActionListener.wrap(r -> future.complete(null), future::completeExceptionally));
-                    future.get(60, TimeUnit.SECONDS);
-                } catch (Exception e) {
-                    log.warn("Failed to delete stale rule [{}]: {}", id, e.getMessage());
+                            ActionListener.wrap(
+                                    r -> ruleLatch.countDown(),
+                                    e -> {
+                                        log.warn("Failed to delete stale rule [{}]: {}", id, e.getMessage());
+                                        ruleLatch.countDown();
+                                    }));
                 }
+                ruleLatch.await(120, TimeUnit.SECONDS);
             }
 
             if (!staleIntegrationIds.isEmpty() || !staleRuleIds.isEmpty()) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
@@ -24,8 +24,10 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -39,21 +41,26 @@ import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.utils.Constants;
 
 /**
- * Loads the STANDARD space content into the <em>local</em> node's Engine, keyed off the
- * cluster-wide aggregate content hash.
+ * Loads the shared, cluster-persisted content spaces into the <em>local</em> node's Engine, keyed
+ * off each space's cluster-wide aggregate content hash.
  *
  * <p>Engine communication is inherently node-local (a Unix domain socket), so every node must load
  * the content into its own Engine. The content itself lives in the cluster-wide {@code
  * wazuh-threatintel-*} indices; only the Engine load is a node-local side effect. This loader is
  * the per-node piece that performs that side effect.
  *
+ * <p>It tracks the {@link #TRACKED_SPACES shared singleton spaces} — {@code STANDARD} (changed by
+ * catalog sync) and {@code TEST}/{@code CUSTOM} (changed only by the promote flow). Per-user {@code
+ * DRAFT} content is not an Engine space and is not tracked.
+ *
  * <p>{@link #reloadIfChanged()} is driven from a cluster-state listener registered on every node
- * (so it reaches all nodes, not just the elected cluster manager) and from the post-sync path on
- * the manager as a prompt nudge. It compares the aggregate {@code space.hash.sha256} stored in
- * {@link Constants#INDEX_POLICIES} against the hash last loaded into this node's Engine and reloads
- * only when they differ. Because the cluster-state listener fires on every cluster-state update, a
- * load that failed because the Engine was not yet ready is retried on a subsequent event without
- * any dedicated timer or poll; once loaded, every later call is a cheap in-memory comparison.
+ * (so it reaches all nodes, not just the elected cluster manager) and from the post-sync and
+ * post-promote broadcasts as a prompt nudge. For each tracked space it compares the aggregate
+ * {@code space.hash.sha256} stored in {@link Constants#INDEX_POLICIES} against the hash last loaded
+ * into this node's Engine and reloads only that space when they differ. Because the cluster-state
+ * listener fires on every cluster-state update, a load that failed because the Engine was not yet
+ * ready is retried on a subsequent event without any dedicated timer or poll; once loaded, every
+ * later call is a cheap in-memory comparison.
  */
 public class EngineContentLoader {
 
@@ -62,16 +69,24 @@ public class EngineContentLoader {
     /** Blocking-call timeout for the async index reads, in seconds. */
     private static final long AWAIT_TIMEOUT_SECONDS = 60;
 
+    /**
+     * The shared, cluster-persisted spaces whose Engine representation must be consistent across the
+     * cluster. Each node loads all of them into its own Engine.
+     */
+    private static final List<String> TRACKED_SPACES =
+            List.of(Space.STANDARD.toString(), Space.TEST.toString(), Space.CUSTOM.toString());
+
     private final EngineService engine;
     private final SpaceService spaceService;
     private final ThreadPool threadPool;
 
     /**
-     * Hash of the content currently loaded into this node's Engine. In-memory only: a node restart
-     * (fresh Engine) starts from {@code null} and reloads. Advanced only after a successful (200 OK)
-     * load, so a failed load is retried on the next trigger.
+     * Per-space hash of the content currently loaded into this node's Engine (space name → hash).
+     * In-memory only: a node restart (fresh Engine) starts empty and reloads every space. A space's
+     * entry is advanced only after a successful (200 OK) load, so a failed load is retried on the
+     * next trigger.
      */
-    private volatile String loadedHash;
+    private final Map<String, String> loadedHashes = new ConcurrentHashMap<>();
 
     /** Collapses concurrent triggers so at most one reload is scheduled/running at a time. */
     private final AtomicBoolean inFlight = new AtomicBoolean(false);
@@ -91,7 +106,7 @@ public class EngineContentLoader {
     }
 
     /**
-     * Reloads the STANDARD space into the local Engine if the cluster-wide content hash differs from
+     * Reloads each tracked space into the local Engine if its cluster-wide content hash differs from
      * the last successfully loaded hash. Non-blocking and safe to call from a cluster-applier thread:
      * the actual work is offloaded to the generic thread pool and single-flighted, so a burst of
      * cluster-state events collapses into a single reload.
@@ -116,56 +131,69 @@ public class EngineContentLoader {
             // Could not schedule (e.g. pool shutting down); release the guard so a later trigger can
             // retry.
             this.inFlight.set(false);
-            log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage());
+            log.error(Constants.E_LOG_ENGINE_RELOAD_SCHEDULE_FAILED, e.getMessage());
         }
     }
 
     /**
      * Performs the actual reload on the calling thread (the generic pool thread, where blocking is
-     * permitted). Package-private so tests can drive it directly without the thread-pool hop.
-     *
-     * <p>Reads the aggregate STANDARD hash from {@link Constants#INDEX_POLICIES}; if there is no
-     * STANDARD policy yet, no usable hash, or the hash matches what is already loaded, it does
-     * nothing. Otherwise it builds the STANDARD engine payload and promotes it, recording the new
-     * hash only on a 200 OK so a non-OK response is retried on the next trigger.
+     * permitted). Package-private so tests can drive it directly without the thread-pool hop. Reloads
+     * each {@link #TRACKED_SPACES tracked space} independently; a failure loading one space is logged
+     * and does not prevent the others from loading.
      */
     void doReload() {
         if (this.engine == null) {
             log.warn(Constants.E_LOG_ENGINE_IS_NULL);
             return;
         }
-        try {
-            Map<String, Object> policy =
-                    this.awaitResult(l -> this.spaceService.getPolicy(Space.STANDARD.toString(), l));
-            if (policy == null) {
-                log.debug(Constants.D_LOG_ENGINE_STANDARD_NO_POLICY);
-                return;
+        for (String space : TRACKED_SPACES) {
+            try {
+                this.reloadSpace(space);
+            } catch (Exception e) {
+                log.error(Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED, space, e.getMessage());
             }
+        }
+    }
 
-            String desiredHash = extractSpaceHash(policy);
-            if (desiredHash == null || desiredHash.isBlank()) {
-                log.debug(Constants.D_LOG_ENGINE_STANDARD_NO_HASH);
-                return;
-            }
-            if (desiredHash.equals(this.loadedHash)) {
-                log.debug(Constants.D_LOG_ENGINE_STANDARD_UNCHANGED);
-                return;
-            }
+    /**
+     * Reloads a single space into the local Engine. Package-private for tests.
+     *
+     * <p>Reads the space's aggregate hash from {@link Constants#INDEX_POLICIES}; if there is no
+     * policy yet, no usable hash, or the hash matches what is already loaded for this space, it does
+     * nothing. Otherwise it builds the space's engine payload and promotes it, recording the new hash
+     * only on a 200 OK so a non-OK response is retried on the next trigger.
+     *
+     * @param space the space name (e.g. {@code standard}, {@code test}, {@code custom}).
+     * @throws Exception if an index read or the Engine call fails.
+     */
+    void reloadSpace(String space) throws Exception {
+        Map<String, Object> policy = this.awaitResult(l -> this.spaceService.getPolicy(space, l));
+        if (policy == null) {
+            log.debug(Constants.D_LOG_ENGINE_SPACE_NO_POLICY, space);
+            return;
+        }
 
-            JsonNode payload =
-                    this.awaitResult(l -> this.spaceService.buildEnginePayload(Space.STANDARD.toString(), l));
-            RestResponse response = this.engine.promote(payload);
-            if (response.getStatus() == RestStatus.OK.getStatus()) {
-                this.loadedHash = desiredHash;
-                log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
-            } else {
-                log.warn(
-                        Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
-                        response.getStatus(),
-                        response.getMessage());
-            }
-        } catch (Exception e) {
-            log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage());
+        String desiredHash = extractSpaceHash(policy);
+        if (desiredHash == null || desiredHash.isBlank()) {
+            log.debug(Constants.D_LOG_ENGINE_SPACE_NO_HASH, space);
+            return;
+        }
+        if (desiredHash.equals(this.loadedHashes.get(space))) {
+            log.debug(Constants.D_LOG_ENGINE_SPACE_UNCHANGED, space);
+            return;
+        }
+
+        JsonNode payload = this.awaitResult(l -> this.spaceService.buildEnginePayload(space, l));
+        RestResponse response = this.engine.promote(payload);
+        if (response.getStatus() == RestStatus.OK.getStatus()) {
+            this.loadedHashes.put(space, desiredHash);
+            log.info(Constants.I_LOG_ENGINE_SPACE_LOADED, space);
+        } else {
+            log.warn(
+                    Constants.W_LOG_ENGINE_SPACE_LOAD_STATUS,
+                    space,
+                    response.getStatus(),
+                    response.getMessage());
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
@@ -20,19 +20,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchTimeoutException;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
@@ -61,13 +62,23 @@ import com.wazuh.contentmanager.utils.Constants;
  * listener fires on every cluster-state update, a load that failed because the Engine was not yet
  * ready is retried on a subsequent event without any dedicated timer or poll; once loaded, every
  * later call is a cheap in-memory comparison.
+ *
+ * <p>The reload is fully asynchronous: the index reads are chained through {@link ActionListener}
+ * callbacks instead of being awaited on a pool thread, and the tracked spaces are walked one at a
+ * time so at most one Engine load is in progress. Only the blocking Engine call itself is
+ * dispatched to the generic pool, which keeps this frequently-triggered path from holding generic
+ * threads — a scarce, cluster-wide shared resource — while it waits on the content indices.
  */
 public class EngineContentLoader {
 
     private static final Logger log = LogManager.getLogger(EngineContentLoader.class);
 
-    /** Blocking-call timeout for the async index reads, in seconds. */
-    private static final long AWAIT_TIMEOUT_SECONDS = 60;
+    /**
+     * Upper bound on how long a single reload run may stay in flight. It only guards against a lost
+     * callback wedging the single-flight guard forever: when it fires, the run is completed
+     * exceptionally so a later trigger can start a fresh one.
+     */
+    private static final TimeValue RELOAD_TIMEOUT = TimeValue.timeValueMinutes(10);
 
     /**
      * The shared, cluster-persisted spaces whose Engine representation must be consistent across the
@@ -88,15 +99,32 @@ public class EngineContentLoader {
      */
     private final Map<String, String> loadedHashes = new ConcurrentHashMap<>();
 
-    /** Collapses concurrent triggers so at most one reload is scheduled/running at a time. */
-    private final AtomicBoolean inFlight = new AtomicBoolean(false);
+    /** Guards {@link #current} and each run's waiter list and completion flag. */
+    private final Object mutex = new Object();
+
+    /**
+     * The reload currently in flight, or {@code null} when idle. Acts as the single-flight guard: a
+     * trigger arriving while a run is in flight is folded into it instead of starting another.
+     */
+    private Run current;
+
+    /** One reload run: the listeners waiting on it, its watchdog and its completion flag. */
+    private static final class Run {
+        private final List<ActionListener<Void>> waiters = new ArrayList<>();
+
+        /** Assigned before the chain starts, read by whichever thread completes the run. */
+        private volatile Scheduler.ScheduledCancellable watchdog;
+
+        private boolean finished;
+    }
 
     /**
      * Constructs a new EngineContentLoader.
      *
      * @param engine the node-local Engine service.
      * @param spaceService the space service used to read the content hash and build the payload.
-     * @param threadPool the thread pool used to offload the blocking reload off the caller thread.
+     * @param threadPool the thread pool used to offload the blocking Engine call off the caller
+     *     thread and to arm the in-flight watchdog.
      */
     public EngineContentLoader(
             EngineService engine, SpaceService spaceService, ThreadPool threadPool) {
@@ -107,51 +135,143 @@ public class EngineContentLoader {
 
     /**
      * Reloads each tracked space into the local Engine if its cluster-wide content hash differs from
-     * the last successfully loaded hash. Non-blocking and safe to call from a cluster-applier thread:
-     * the actual work is offloaded to the generic thread pool and single-flighted, so a burst of
-     * cluster-state events collapses into a single reload.
+     * the last successfully loaded hash, ignoring the outcome. Every outcome — a per-space failure,
+     * an unavailable Engine, a timed-out run — is already logged, so the fire-and-forget triggers
+     * (the cluster-state listener, the post-sync and post-promote broadcasts) need no listener.
+     *
+     * @see #reloadIfChanged(ActionListener)
      */
     public void reloadIfChanged() {
-        if (!this.inFlight.compareAndSet(false, true)) {
-            // A reload is already scheduled or running; this trigger is folded into it.
+        this.reloadIfChanged(ActionListener.wrap(v -> {}, e -> {}));
+    }
+
+    /**
+     * Reloads each tracked space into the local Engine if its cluster-wide content hash differs from
+     * the last successfully loaded hash, notifying {@code listener} when the reload finishes.
+     * Non-blocking and safe to call from a cluster-applier thread: the work is driven entirely by
+     * {@link ActionListener} callbacks and single-flighted, so a burst of triggers collapses into a
+     * single reload.
+     *
+     * <p>No thread is parked waiting for the index reads — each step continues on the thread that
+     * completes the previous one. The generic pool is borrowed only for the blocking Engine socket
+     * call, and only for a space whose hash actually changed; the steady-state case (nothing changed)
+     * costs no pool thread at all.
+     *
+     * <p>Because triggers are collapsed, a call made while a reload is already running is notified
+     * when <em>that</em> run finishes, not by a run of its own. Such a run may have read the content
+     * hashes before this caller's change landed, so completion means "the in-flight reload finished",
+     * not "every change visible at call time is loaded". The cluster-state listener keeps converging
+     * the node either way.
+     *
+     * @param listener notified once: {@code onResponse} when the run completed (individual space
+     *     failures are logged, not surfaced), {@code onFailure} if the Engine is unavailable or the
+     *     run did not complete within {@link #RELOAD_TIMEOUT}.
+     */
+    public void reloadIfChanged(ActionListener<Void> listener) {
+        Run run;
+        synchronized (this.mutex) {
+            if (this.current != null) {
+                // A reload is already running; this trigger is folded into it and so is its listener.
+                this.current.waiters.add(listener);
+                return;
+            }
+            run = new Run();
+            run.waiters.add(listener);
+            this.current = run;
+        }
+        if (this.engine == null) {
+            log.warn(Constants.E_LOG_ENGINE_IS_NULL);
+            this.complete(run, new IllegalStateException(Constants.E_LOG_ENGINE_IS_NULL));
             return;
         }
+        run.watchdog = this.armWatchdog(run);
         try {
-            this.threadPool
-                    .generic()
-                    .execute(
-                            () -> {
-                                try {
-                                    this.doReload();
-                                } finally {
-                                    this.inFlight.set(false);
-                                }
-                            });
+            this.reloadFrom(0, () -> this.complete(run, null));
         } catch (Exception e) {
-            // Could not schedule (e.g. pool shutting down); release the guard so a later trigger can
-            // retry.
-            this.inFlight.set(false);
             log.error(Constants.E_LOG_ENGINE_RELOAD_SCHEDULE_FAILED, e.getMessage());
+            this.complete(run, e);
         }
     }
 
     /**
-     * Performs the actual reload on the calling thread (the generic pool thread, where blocking is
-     * permitted). Package-private so tests can drive it directly without the thread-pool hop. Reloads
-     * each {@link #TRACKED_SPACES tracked space} independently; a failure loading one space is logged
-     * and does not prevent the others from loading.
+     * Ends a reload run: cancels its watchdog, clears the single-flight guard and notifies everyone
+     * that joined the run. Idempotent — the first caller wins, so the watchdog and the normal
+     * completion path cannot both notify, and a chain that completes after its watchdog already fired
+     * does not disturb the run that replaced it.
+     *
+     * @param run the run to complete.
+     * @param failure {@code null} when the run completed, otherwise the failure to report.
+     * @return {@code true} if this call ended the run, {@code false} if it had already ended.
      */
-    void doReload() {
-        if (this.engine == null) {
-            log.warn(Constants.E_LOG_ENGINE_IS_NULL);
+    private boolean complete(Run run, Exception failure) {
+        List<ActionListener<Void>> waiters;
+        synchronized (this.mutex) {
+            if (run.finished) {
+                return false;
+            }
+            run.finished = true;
+            if (this.current == run) {
+                this.current = null;
+            }
+            waiters = List.copyOf(run.waiters);
+            run.waiters.clear();
+        }
+        if (run.watchdog != null) {
+            run.watchdog.cancel();
+        }
+        for (ActionListener<Void> waiter : waiters) {
+            if (failure == null) {
+                waiter.onResponse(null);
+            } else {
+                waiter.onFailure(failure);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Reloads the {@link #TRACKED_SPACES tracked spaces} one at a time, each step chained off the
+     * previous space's completion. A failure loading one space is logged and does not prevent the
+     * others from loading. Package-private so tests can drive the chain directly.
+     *
+     * <p>A node that cannot read the content yet is the one exception: every space reads its hash
+     * from the same {@link Constants#INDEX_POLICIES} index, so a missing index or a cluster block
+     * (usually {@code state not recovered / initialized}) is a precondition of the whole run rather
+     * than a per-space failure. Both are normal while a node starts up and both clear on their own,
+     * so the run ends after a single debug line instead of logging the same error once per tracked
+     * space on every cluster-state update. The next cluster-state event retries.
+     *
+     * @param index index into {@link #TRACKED_SPACES} of the space to reload next.
+     * @param onComplete invoked once, after the last space finishes (successfully or not).
+     */
+    void reloadFrom(int index, Runnable onComplete) {
+        if (index >= TRACKED_SPACES.size()) {
+            onComplete.run();
             return;
         }
-        for (String space : TRACKED_SPACES) {
-            try {
-                this.reloadSpace(space);
-            } catch (Exception e) {
-                log.error(Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED, space, e.getMessage());
-            }
+        String space = TRACKED_SPACES.get(index);
+        ActionListener<Void> next =
+                ActionListener.wrap(
+                        v -> this.reloadFrom(index + 1, onComplete),
+                        e -> {
+                            if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
+                                log.debug(
+                                        Constants.D_LOG_ENGINE_POLICIES_INDEX_NOT_READY, Constants.INDEX_POLICIES);
+                                onComplete.run();
+                                return;
+                            }
+                            if (ExceptionsHelper.unwrap(e, ClusterBlockException.class) != null) {
+                                log.debug(Constants.D_LOG_ENGINE_CLUSTER_NOT_READY, e.getMessage());
+                                onComplete.run();
+                                return;
+                            }
+                            log.error(Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED, space, e.getMessage());
+                            this.reloadFrom(index + 1, onComplete);
+                        });
+        try {
+            this.reloadSpace(space, next);
+        } catch (Exception e) {
+            next.onFailure(e);
         }
     }
 
@@ -164,36 +284,101 @@ public class EngineContentLoader {
      * only on a 200 OK so a non-OK response is retried on the next trigger.
      *
      * @param space the space name (e.g. {@code standard}, {@code test}, {@code custom}).
-     * @throws Exception if an index read or the Engine call fails.
+     * @param listener notified when this space is done: {@code onResponse} whether it was skipped or
+     *     loaded, {@code onFailure} if an index read or the Engine call failed.
      */
-    void reloadSpace(String space) throws Exception {
-        Map<String, Object> policy = this.awaitResult(l -> this.spaceService.getPolicy(space, l));
-        if (policy == null) {
-            log.debug(Constants.D_LOG_ENGINE_SPACE_NO_POLICY, space);
-            return;
-        }
+    void reloadSpace(String space, ActionListener<Void> listener) {
+        this.spaceService.getPolicy(
+                space,
+                ActionListener.wrap(
+                        policy -> {
+                            if (policy == null) {
+                                log.debug(Constants.D_LOG_ENGINE_SPACE_NO_POLICY, space);
+                                listener.onResponse(null);
+                                return;
+                            }
 
-        String desiredHash = extractSpaceHash(policy);
-        if (desiredHash == null || desiredHash.isBlank()) {
-            log.debug(Constants.D_LOG_ENGINE_SPACE_NO_HASH, space);
-            return;
-        }
-        if (desiredHash.equals(this.loadedHashes.get(space))) {
-            log.debug(Constants.D_LOG_ENGINE_SPACE_UNCHANGED, space);
-            return;
-        }
+                            String desiredHash = extractSpaceHash(policy);
+                            if (desiredHash == null || desiredHash.isBlank()) {
+                                log.debug(Constants.D_LOG_ENGINE_SPACE_NO_HASH, space);
+                                listener.onResponse(null);
+                                return;
+                            }
+                            if (desiredHash.equals(this.loadedHashes.get(space))) {
+                                log.debug(Constants.D_LOG_ENGINE_SPACE_UNCHANGED, space);
+                                listener.onResponse(null);
+                                return;
+                            }
 
-        JsonNode payload = this.awaitResult(l -> this.spaceService.buildEnginePayload(space, l));
-        RestResponse response = this.engine.promote(payload);
-        if (response.getStatus() == RestStatus.OK.getStatus()) {
-            this.loadedHashes.put(space, desiredHash);
-            log.info(Constants.I_LOG_ENGINE_SPACE_LOADED, space);
-        } else {
-            log.warn(
-                    Constants.W_LOG_ENGINE_SPACE_LOAD_STATUS,
-                    space,
-                    response.getStatus(),
-                    response.getMessage());
+                            this.spaceService.buildEnginePayload(
+                                    space,
+                                    ActionListener.wrap(
+                                            payload -> this.promote(space, desiredHash, payload, listener),
+                                            listener::onFailure));
+                        },
+                        listener::onFailure));
+    }
+
+    /**
+     * Promotes a space's payload into the local Engine on a generic pool thread. This is the only
+     * blocking step of a reload (a Unix-domain-socket round trip), so it is the only one that
+     * occupies a pool thread — and only for a space whose content actually changed.
+     *
+     * @param space the space name.
+     * @param desiredHash the hash to record once the Engine accepts the payload.
+     * @param payload the space's engine payload.
+     * @param listener notified when the Engine call completes.
+     */
+    private void promote(
+            String space, String desiredHash, JsonNode payload, ActionListener<Void> listener) {
+        this.threadPool
+                .generic()
+                .execute(
+                        () -> {
+                            try {
+                                RestResponse response = this.engine.promote(payload);
+                                if (response.getStatus() == RestStatus.OK.getStatus()) {
+                                    this.loadedHashes.put(space, desiredHash);
+                                    log.info(Constants.I_LOG_ENGINE_SPACE_LOADED, space);
+                                } else {
+                                    log.warn(
+                                            Constants.W_LOG_ENGINE_SPACE_LOAD_STATUS,
+                                            space,
+                                            response.getStatus(),
+                                            response.getMessage());
+                                }
+                                listener.onResponse(null);
+                            } catch (Exception e) {
+                                listener.onFailure(e);
+                            }
+                        });
+    }
+
+    /**
+     * Arms the in-flight watchdog for a reload run. It exists only so a callback that never fires
+     * cannot wedge the single-flight guard for the lifetime of the node: when it fires, the run is
+     * completed exceptionally, its waiters are released and the next trigger starts a fresh run.
+     *
+     * @param run the run to time out.
+     * @return the scheduled task so {@link #complete} can cancel it, or {@code null} if it could not
+     *     be scheduled (e.g. the pool is shutting down).
+     */
+    private Scheduler.ScheduledCancellable armWatchdog(Run run) {
+        try {
+            return this.threadPool.schedule(
+                    () -> {
+                        if (this.complete(
+                                run,
+                                new OpenSearchTimeoutException(
+                                        Constants.W_LOG_ENGINE_RELOAD_TIMED_OUT, RELOAD_TIMEOUT))) {
+                            log.warn(Constants.W_LOG_ENGINE_RELOAD_TIMED_OUT, RELOAD_TIMEOUT);
+                        }
+                    },
+                    RELOAD_TIMEOUT,
+                    ThreadPool.Names.GENERIC);
+        } catch (Exception e) {
+            log.debug(Constants.E_LOG_ENGINE_RELOAD_SCHEDULE_FAILED, e.getMessage());
+            return null;
         }
     }
 
@@ -212,27 +397,5 @@ public class EngineContentLoader {
             return null;
         }
         return Resource.extractHash((Map<String, Object>) space);
-    }
-
-    /**
-     * Bridges an asynchronous {@link ActionListener}-based operation into a blocking call. Only
-     * invoked from the generic pool thread, where blocking is permitted.
-     *
-     * @param <T> the result type.
-     * @param op consumer that starts the async operation with the supplied listener.
-     * @return the operation result.
-     * @throws Exception if the operation fails or times out.
-     */
-    private <T> T awaitResult(Consumer<ActionListener<T>> op) throws Exception {
-        CompletableFuture<T> future = new CompletableFuture<>();
-        op.accept(ActionListener.wrap(future::complete, future::completeExceptionally));
-        try {
-            return future.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            throw (cause instanceof Exception ex) ? ex : e;
-        } catch (TimeoutException e) {
-            throw new Exception(e);
-        }
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import com.wazuh.contentmanager.cti.catalog.model.Resource;
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.engine.service.EngineService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import com.wazuh.contentmanager.utils.Constants;
+
+/**
+ * Loads the STANDARD space content into the <em>local</em> node's Engine, keyed off the
+ * cluster-wide aggregate content hash.
+ *
+ * <p>Engine communication is inherently node-local (a Unix domain socket), so every node must load
+ * the content into its own Engine. The content itself lives in the cluster-wide {@code
+ * wazuh-threatintel-*} indices; only the Engine load is a node-local side effect. This loader is
+ * the per-node piece that performs that side effect.
+ *
+ * <p>{@link #reloadIfChanged()} is driven from a cluster-state listener registered on every node
+ * (so it reaches all nodes, not just the elected cluster manager) and from the post-sync path on
+ * the manager as a prompt nudge. It compares the aggregate {@code space.hash.sha256} stored in
+ * {@link Constants#INDEX_POLICIES} against the hash last loaded into this node's Engine and reloads
+ * only when they differ. Because the cluster-state listener fires on every cluster-state update, a
+ * load that failed because the Engine was not yet ready is retried on a subsequent event without
+ * any dedicated timer or poll; once loaded, every later call is a cheap in-memory comparison.
+ */
+public class EngineContentLoader {
+
+    private static final Logger log = LogManager.getLogger(EngineContentLoader.class);
+
+    /** Blocking-call timeout for the async index reads, in seconds. */
+    private static final long AWAIT_TIMEOUT_SECONDS = 60;
+
+    private final EngineService engine;
+    private final SpaceService spaceService;
+    private final ThreadPool threadPool;
+
+    /**
+     * Hash of the content currently loaded into this node's Engine. In-memory only: a node restart
+     * (fresh Engine) starts from {@code null} and reloads. Advanced only after a successful (200 OK)
+     * load, so a failed load is retried on the next trigger.
+     */
+    private volatile String loadedHash;
+
+    /** Collapses concurrent triggers so at most one reload is scheduled/running at a time. */
+    private final AtomicBoolean inFlight = new AtomicBoolean(false);
+
+    /**
+     * Constructs a new EngineContentLoader.
+     *
+     * @param engine the node-local Engine service.
+     * @param spaceService the space service used to read the content hash and build the payload.
+     * @param threadPool the thread pool used to offload the blocking reload off the caller thread.
+     */
+    public EngineContentLoader(
+            EngineService engine, SpaceService spaceService, ThreadPool threadPool) {
+        this.engine = engine;
+        this.spaceService = spaceService;
+        this.threadPool = threadPool;
+    }
+
+    /**
+     * Reloads the STANDARD space into the local Engine if the cluster-wide content hash differs from
+     * the last successfully loaded hash. Non-blocking and safe to call from a cluster-applier thread:
+     * the actual work is offloaded to the generic thread pool and single-flighted, so a burst of
+     * cluster-state events collapses into a single reload.
+     */
+    public void reloadIfChanged() {
+        if (!this.inFlight.compareAndSet(false, true)) {
+            // A reload is already scheduled or running; this trigger is folded into it.
+            return;
+        }
+        try {
+            this.threadPool
+                    .generic()
+                    .execute(
+                            () -> {
+                                try {
+                                    this.doReload();
+                                } finally {
+                                    this.inFlight.set(false);
+                                }
+                            });
+        } catch (Exception e) {
+            // Could not schedule (e.g. pool shutting down); release the guard so a later trigger can
+            // retry.
+            this.inFlight.set(false);
+            log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * Performs the actual reload on the calling thread (the generic pool thread, where blocking is
+     * permitted). Package-private so tests can drive it directly without the thread-pool hop.
+     *
+     * <p>Reads the aggregate STANDARD hash from {@link Constants#INDEX_POLICIES}; if there is no
+     * STANDARD policy yet, no usable hash, or the hash matches what is already loaded, it does
+     * nothing. Otherwise it builds the STANDARD engine payload and promotes it, recording the new
+     * hash only on a 200 OK so a non-OK response is retried on the next trigger.
+     */
+    void doReload() {
+        if (this.engine == null) {
+            log.warn(Constants.E_LOG_ENGINE_IS_NULL);
+            return;
+        }
+        try {
+            Map<String, Object> policy =
+                    this.awaitResult(l -> this.spaceService.getPolicy(Space.STANDARD.toString(), l));
+            if (policy == null) {
+                log.debug(Constants.D_LOG_ENGINE_STANDARD_NO_POLICY);
+                return;
+            }
+
+            String desiredHash = extractSpaceHash(policy);
+            if (desiredHash == null || desiredHash.isBlank()) {
+                log.debug(Constants.D_LOG_ENGINE_STANDARD_NO_HASH);
+                return;
+            }
+            if (desiredHash.equals(this.loadedHash)) {
+                log.debug(Constants.D_LOG_ENGINE_STANDARD_UNCHANGED);
+                return;
+            }
+
+            JsonNode payload =
+                    this.awaitResult(l -> this.spaceService.buildEnginePayload(Space.STANDARD.toString(), l));
+            RestResponse response = this.engine.promote(payload);
+            if (response.getStatus() == RestStatus.OK.getStatus()) {
+                this.loadedHash = desiredHash;
+                log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
+            } else {
+                log.warn(
+                        Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
+                        response.getStatus(),
+                        response.getMessage());
+            }
+        } catch (Exception e) {
+            log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * Extracts the aggregate space hash ({@code space.hash.sha256}) from a policy document source.
+     * This is the hash maintained by {@link SpaceService#calculateAndUpdate}, which changes whenever
+     * any resource in the space changes — distinct from the policy document's own top-level hash.
+     *
+     * @param policy the policy document source map.
+     * @return the aggregate space hash, or {@code null} if the space sub-object is absent.
+     */
+    @SuppressWarnings("unchecked")
+    private static String extractSpaceHash(Map<String, Object> policy) {
+        Object space = policy.get(Constants.KEY_SPACE);
+        if (!(space instanceof Map)) {
+            return null;
+        }
+        return Resource.extractHash((Map<String, Object>) space);
+    }
+
+    /**
+     * Bridges an asynchronous {@link ActionListener}-based operation into a blocking call. Only
+     * invoked from the generic pool thread, where blocking is permitted.
+     *
+     * @param <T> the result type.
+     * @param op consumer that starts the async operation with the supplied listener.
+     * @return the operation result.
+     * @throws Exception if the operation fails or times out.
+     */
+    private <T> T awaitResult(Consumer<ActionListener<T>> op) throws Exception {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        op.accept(ActionListener.wrap(future::complete, future::completeExceptionally));
+        try {
+            return future.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            throw (cause instanceof Exception ex) ? ex : e;
+        } catch (TimeoutException e) {
+            throw new Exception(e);
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.engine.service.EngineService;
-import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.utils.Constants;
 
 /**
@@ -131,6 +130,19 @@ public class EngineContentLoader {
         this.engine = engine;
         this.spaceService = spaceService;
         this.threadPool = threadPool;
+    }
+
+    /**
+     * Records a hash as already loaded for the given space, so that a subsequent {@link
+     * #reloadIfChanged} skips it when the index hash matches. Use this when an external path (e.g.
+     * {@link com.wazuh.contentmanager.transport.TransportActionHelper#reloadStandardSpaceIntoEngine})
+     * has already promoted the space's content into the Engine.
+     *
+     * @param space the space name (e.g. {@code standard}).
+     * @param hash the hash that was successfully loaded.
+     */
+    public void updateLoadedHash(String space, String hash) {
+        this.loadedHashes.put(space, hash);
     }
 
     /**
@@ -331,27 +343,23 @@ public class EngineContentLoader {
      */
     private void promote(
             String space, String desiredHash, JsonNode payload, ActionListener<Void> listener) {
-        this.threadPool
-                .generic()
-                .execute(
-                        () -> {
-                            try {
-                                RestResponse response = this.engine.promote(payload);
-                                if (response.getStatus() == RestStatus.OK.getStatus()) {
-                                    this.loadedHashes.put(space, desiredHash);
-                                    log.info(Constants.I_LOG_ENGINE_SPACE_LOADED, space);
-                                } else {
-                                    log.warn(
-                                            Constants.W_LOG_ENGINE_SPACE_LOAD_STATUS,
-                                            space,
-                                            response.getStatus(),
-                                            response.getMessage());
-                                }
-                                listener.onResponse(null);
-                            } catch (Exception e) {
-                                listener.onFailure(e);
+        this.engine.promoteAsync(
+                payload,
+                ActionListener.wrap(
+                        response -> {
+                            if (response.getStatus() == RestStatus.OK.getStatus()) {
+                                this.loadedHashes.put(space, desiredHash);
+                                log.info(Constants.I_LOG_ENGINE_SPACE_LOADED, space);
+                            } else {
+                                log.warn(
+                                        Constants.W_LOG_ENGINE_SPACE_LOAD_STATUS,
+                                        space,
+                                        response.getStatus(),
+                                        response.getMessage());
                             }
-                        });
+                            listener.onResponse(null);
+                        },
+                        listener::onFailure));
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.opensearch.action.bulk.BulkRequest;
@@ -35,8 +36,10 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
@@ -967,7 +970,16 @@ public class SpaceService {
                             }
                         },
                         e -> {
-                            log.error(Constants.E_LOG_GET_POLICY_FAILED, space, e.getMessage());
+                            // A missing policies index or a cluster block (typically "state not
+                            // recovered / initialized") is an expected pre-initialization state, not an
+                            // operational error: every node reads policies from startup onwards.
+                            // Callers still get the failure and decide.
+                            if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null
+                                    || ExceptionsHelper.unwrap(e, ClusterBlockException.class) != null) {
+                                log.debug(Constants.D_LOG_POLICY_INDEX_NOT_READY, space, e.getMessage());
+                            } else {
+                                log.error(Constants.E_LOG_GET_POLICY_FAILED, space, e.getMessage());
+                            }
                             listener.onFailure(
                                     new IOException("Failed to retrieve policy: " + e.getMessage(), e));
                         }));

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -253,20 +253,19 @@ public class SpaceService {
 
             ObjectNode docNode = this.objectMapper.valueToTree(policy);
             Resource.nestMetadataFields(docNode);
-            @SuppressWarnings("unchecked")
-            Map<String, Object> docMap = this.objectMapper.convertValue(docNode, Map.class);
 
-            String docJson = this.objectMapper.writeValueAsString(docMap);
+            String docJson = this.objectMapper.writeValueAsString(docNode);
             String docHash = Resource.computeSha256(docJson);
 
-            Map<String, Object> space = new HashMap<>();
-            space.put(Constants.KEY_NAME, spaceName);
-            space.put(Constants.KEY_HASH, Map.of(Constants.KEY_SHA256, docHash));
+            ObjectNode hashNode = this.objectMapper.createObjectNode().put(Constants.KEY_SHA256, docHash);
+            ObjectNode spaceNode = this.objectMapper.createObjectNode();
+            spaceNode.put(Constants.KEY_NAME, spaceName);
+            spaceNode.set(Constants.KEY_HASH, hashNode.deepCopy());
 
-            Map<String, Object> source = new HashMap<>();
-            source.put(Constants.KEY_DOCUMENT, docMap);
-            source.put(Constants.KEY_SPACE, space);
-            source.put(Constants.KEY_HASH, Map.of(Constants.KEY_SHA256, docHash));
+            ObjectNode source = this.objectMapper.createObjectNode();
+            source.set(Constants.KEY_DOCUMENT, docNode);
+            source.set(Constants.KEY_SPACE, spaceNode);
+            source.set(Constants.KEY_HASH, hashNode);
 
             IndexRequest request =
                     new IndexRequest(Constants.INDEX_POLICIES)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
@@ -36,6 +36,8 @@ import com.wazuh.contentmanager.cti.catalog.service.AbstractConsumerService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerCveService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerIocService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerRulesetService;
+import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
+import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.JobExecutor;
 import com.wazuh.contentmanager.utils.Constants;
@@ -81,12 +83,15 @@ public class CatalogSyncJob implements JobExecutor {
             ConsumersIndex consumersIndex,
             Environment environment,
             ThreadPool threadPool,
-            EngineService engineService) {
+            EngineService engineService,
+            SpaceService spaceService,
+            SecurityAnalyticsService securityAnalyticsService) {
         this.client = client;
         this.threadPool = threadPool;
         this.synchronizers =
                 List.of(
-                        new ConsumerRulesetService(client, consumersIndex, environment),
+                        new ConsumerRulesetService(
+                                client, consumersIndex, environment, spaceService, securityAnalyticsService),
                         new ConsumerIocService(client, consumersIndex, environment, engineService),
                         new ConsumerCveService(client, consumersIndex, environment));
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
@@ -35,6 +35,7 @@ import com.wazuh.contentmanager.cti.catalog.service.AbstractConsumerService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerCveService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerIocService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerRulesetService;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.JobExecutor;
 import com.wazuh.contentmanager.utils.Constants;
@@ -74,18 +75,20 @@ public class CatalogSyncJob implements JobExecutor {
      * @param threadPool The thread pool manager, used to offload blocking tasks to the generic
      *     executor.
      * @param engineService The engine service for notifying the Engine about IOC updates.
+     * @param engineContentLoader The loader that reloads the standard space into the local Engine.
      */
     public CatalogSyncJob(
             Client client,
             ConsumersIndex consumersIndex,
             Environment environment,
             ThreadPool threadPool,
-            EngineService engineService) {
+            EngineService engineService,
+            EngineContentLoader engineContentLoader) {
         this.client = client;
         this.threadPool = threadPool;
         this.synchronizers =
                 List.of(
-                        new ConsumerRulesetService(client, consumersIndex, environment, engineService),
+                        new ConsumerRulesetService(client, consumersIndex, environment, engineContentLoader),
                         new ConsumerIocService(client, consumersIndex, environment, engineService),
                         new ConsumerCveService(client, consumersIndex, environment));
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
@@ -35,7 +35,6 @@ import com.wazuh.contentmanager.cti.catalog.service.AbstractConsumerService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerCveService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerIocService;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerRulesetService;
-import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.JobExecutor;
 import com.wazuh.contentmanager.utils.Constants;
@@ -75,20 +74,18 @@ public class CatalogSyncJob implements JobExecutor {
      * @param threadPool The thread pool manager, used to offload blocking tasks to the generic
      *     executor.
      * @param engineService The engine service for notifying the Engine about IOC updates.
-     * @param engineContentLoader The loader that reloads the standard space into the local Engine.
      */
     public CatalogSyncJob(
             Client client,
             ConsumersIndex consumersIndex,
             Environment environment,
             ThreadPool threadPool,
-            EngineService engineService,
-            EngineContentLoader engineContentLoader) {
+            EngineService engineService) {
         this.client = client;
         this.threadPool = threadPool;
         this.synchronizers =
                 List.of(
-                        new ConsumerRulesetService(client, consumersIndex, environment, engineContentLoader),
+                        new ConsumerRulesetService(client, consumersIndex, environment),
                         new ConsumerIocService(client, consumersIndex, environment, engineService),
                         new ConsumerCveService(client, consumersIndex, environment));
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
@@ -47,6 +47,7 @@ import com.wazuh.contentmanager.action.ContentCreateRequest;
 import com.wazuh.contentmanager.action.ContentResponse;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.ResourceLockService;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
@@ -69,6 +70,7 @@ public abstract class AbstractTransportCreateActionSpaces
     protected final PayloadValidations documentValidations = new PayloadValidations();
     protected final Client client;
     protected final EngineService engine;
+    protected final EngineContentLoader engineContentLoader;
     protected final ResourceLockService resourceLockService;
 
     protected AbstractTransportCreateActionSpaces(
@@ -76,10 +78,12 @@ public abstract class AbstractTransportCreateActionSpaces
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
+            EngineService engine,
+            EngineContentLoader engineContentLoader) {
         super(actionName, transportService, actionFilters, ContentCreateRequest::new);
         this.client = client;
         this.engine = engine;
+        this.engineContentLoader = engineContentLoader;
         this.resourceLockService = new ResourceLockService(client, transportService.getThreadPool());
     }
 
@@ -404,7 +408,10 @@ public abstract class AbstractTransportCreateActionSpaces
                                                                 ActionListener.wrap(
                                                                         changed -> {
                                                                             TransportActionHelper.reloadStandardSpaceIntoEngine(
-                                                                                    this.engine, spaceService, changed);
+                                                                                    this.engine,
+                                                                                    spaceService,
+                                                                                    changed,
+                                                                                    this.engineContentLoader);
                                                                             log.info(
                                                                                     Constants.I_LOG_SUCCESS,
                                                                                     "Created",

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
@@ -411,7 +411,8 @@ public abstract class AbstractTransportCreateActionSpaces
                                                                                     this.engine,
                                                                                     spaceService,
                                                                                     changed,
-                                                                                    this.engineContentLoader);
+                                                                                    this.engineContentLoader,
+                                                                                    this.client);
                                                                             log.info(
                                                                                     Constants.I_LOG_SUCCESS,
                                                                                     "Created",

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
@@ -246,7 +246,11 @@ public abstract class AbstractTransportDeleteActionSpaces
                                     ActionListener.wrap(
                                             changed -> {
                                                 TransportActionHelper.reloadStandardSpaceIntoEngine(
-                                                        this.engine, spaceService, changed, this.engineContentLoader);
+                                                        this.engine,
+                                                        spaceService,
+                                                        changed,
+                                                        this.engineContentLoader,
+                                                        this.client);
                                                 log.info(Constants.I_LOG_SUCCESS, "Deleted", this.getResourceType(), id);
                                                 respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
                                             },

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
@@ -41,6 +41,7 @@ import com.wazuh.contentmanager.action.ContentDeleteRequest;
 import com.wazuh.contentmanager.action.ContentResponse;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsServiceImpl;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
@@ -63,16 +64,19 @@ public abstract class AbstractTransportDeleteActionSpaces
     protected final PayloadValidations documentValidations = new PayloadValidations();
     protected final Client client;
     protected final EngineService engine;
+    protected final EngineContentLoader engineContentLoader;
 
     protected AbstractTransportDeleteActionSpaces(
             String actionName,
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
+            EngineService engine,
+            EngineContentLoader engineContentLoader) {
         super(actionName, transportService, actionFilters, ContentDeleteRequest::new);
         this.client = client;
         this.engine = engine;
+        this.engineContentLoader = engineContentLoader;
     }
 
     @Override
@@ -242,7 +246,7 @@ public abstract class AbstractTransportDeleteActionSpaces
                                     ActionListener.wrap(
                                             changed -> {
                                                 TransportActionHelper.reloadStandardSpaceIntoEngine(
-                                                        this.engine, spaceService, changed);
+                                                        this.engine, spaceService, changed, this.engineContentLoader);
                                                 log.info(Constants.I_LOG_SUCCESS, "Deleted", this.getResourceType(), id);
                                                 respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
                                             },

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
@@ -50,6 +50,7 @@ import com.wazuh.contentmanager.action.ContentUpdateRequest;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -70,16 +71,19 @@ public abstract class AbstractTransportUpdateActionSpaces
     protected final PayloadValidations documentValidations = new PayloadValidations();
     protected final Client client;
     protected final EngineService engine;
+    protected final EngineContentLoader engineContentLoader;
 
     protected AbstractTransportUpdateActionSpaces(
             String actionName,
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
+            EngineService engine,
+            EngineContentLoader engineContentLoader) {
         super(actionName, transportService, actionFilters, ContentUpdateRequest::new);
         this.client = client;
         this.engine = engine;
+        this.engineContentLoader = engineContentLoader;
     }
 
     @Override
@@ -334,7 +338,7 @@ public abstract class AbstractTransportUpdateActionSpaces
                                         ActionListener.wrap(
                                                 changed -> {
                                                     TransportActionHelper.reloadStandardSpaceIntoEngine(
-                                                            this.engine, spaceService, changed);
+                                                            this.engine, spaceService, changed, this.engineContentLoader);
                                                     log.info(Constants.I_LOG_SUCCESS, "Updated", this.getResourceType(), id);
                                                     respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
                                                 },

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
@@ -338,7 +338,11 @@ public abstract class AbstractTransportUpdateActionSpaces
                                         ActionListener.wrap(
                                                 changed -> {
                                                     TransportActionHelper.reloadStandardSpaceIntoEngine(
-                                                            this.engine, spaceService, changed, this.engineContentLoader);
+                                                            this.engine,
+                                                            spaceService,
+                                                            changed,
+                                                            this.engineContentLoader,
+                                                            this.client);
                                                     log.info(Constants.I_LOG_SUCCESS, "Updated", this.getResourceType(), id);
                                                     respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
                                                 },

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import com.wazuh.contentmanager.action.ReloadEngineContentAction;
+import com.wazuh.contentmanager.action.ReloadEngineContentRequest;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
@@ -110,7 +112,8 @@ public final class TransportActionHelper {
             EngineService engine,
             SpaceService spaceService,
             Set<String> changedSpaces,
-            EngineContentLoader engineContentLoader) {
+            EngineContentLoader engineContentLoader,
+            Client client) {
         if (changedSpaces == null || !changedSpaces.contains(Space.STANDARD.toString())) {
             return;
         }
@@ -118,6 +121,13 @@ public final class TransportActionHelper {
             log.warn(Constants.E_LOG_ENGINE_IS_NULL);
             return;
         }
+
+        client.execute(
+                ReloadEngineContentAction.INSTANCE,
+                new ReloadEngineContentRequest(),
+                ActionListener.wrap(
+                        r -> log.debug(Constants.D_LOG_ENGINE_RELOAD_BROADCAST_SENT),
+                        e -> log.warn(Constants.W_LOG_ENGINE_RELOAD_BROADCAST_FAILED, e.getMessage())));
 
         spaceService.buildEnginePayload(
                 Space.STANDARD.toString(),

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
@@ -122,18 +122,23 @@ public final class TransportActionHelper {
                                         ActionListener.wrap(
                                                 response -> {
                                                     if (response.getStatus() == RestStatus.OK.getStatus()) {
-                                                        log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
+                                                        log.info(Constants.I_LOG_ENGINE_SPACE_LOADED, Space.STANDARD);
                                                     } else {
                                                         log.warn(
-                                                                Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
+                                                                Constants.W_LOG_ENGINE_SPACE_LOAD_STATUS,
+                                                                Space.STANDARD,
                                                                 response.getStatus(),
                                                                 response.getMessage());
                                                     }
                                                 },
                                                 e ->
                                                         log.error(
-                                                                Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage()))),
-                        e -> log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage())));
+                                                                Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED,
+                                                                Space.STANDARD,
+                                                                e.getMessage()))),
+                        e ->
+                                log.error(
+                                        Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED, Space.STANDARD, e.getMessage())));
     }
 
     /** Walks the exception cause chain looking for an OpenSearchSecurityException. */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
@@ -122,23 +122,18 @@ public final class TransportActionHelper {
                                         ActionListener.wrap(
                                                 response -> {
                                                     if (response.getStatus() == RestStatus.OK.getStatus()) {
-                                                        log.info(Constants.I_LOG_ENGINE_SPACE_LOADED, Space.STANDARD);
+                                                        log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
                                                     } else {
                                                         log.warn(
-                                                                Constants.W_LOG_ENGINE_SPACE_LOAD_STATUS,
-                                                                Space.STANDARD,
+                                                                Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
                                                                 response.getStatus(),
                                                                 response.getMessage());
                                                     }
                                                 },
                                                 e ->
                                                         log.error(
-                                                                Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED,
-                                                                Space.STANDARD,
-                                                                e.getMessage()))),
-                        e ->
-                                log.error(
-                                        Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED, Space.STANDARD, e.getMessage())));
+                                                                Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage()))),
+                        e -> log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage())));
     }
 
     /** Walks the exception cause chain looking for an OpenSearchSecurityException. */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
@@ -27,10 +27,13 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.transport.client.Client;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -104,7 +107,10 @@ public final class TransportActionHelper {
      *     space.
      */
     public static void reloadStandardSpaceIntoEngine(
-            EngineService engine, SpaceService spaceService, Set<String> changedSpaces) {
+            EngineService engine,
+            SpaceService spaceService,
+            Set<String> changedSpaces,
+            EngineContentLoader engineContentLoader) {
         if (changedSpaces == null || !changedSpaces.contains(Space.STANDARD.toString())) {
             return;
         }
@@ -123,6 +129,7 @@ public final class TransportActionHelper {
                                                 response -> {
                                                     if (response.getStatus() == RestStatus.OK.getStatus()) {
                                                         log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
+                                                        updateLoaderHash(spaceService, engineContentLoader);
                                                     } else {
                                                         log.warn(
                                                                 Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
@@ -134,6 +141,30 @@ public final class TransportActionHelper {
                                                         log.error(
                                                                 Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage()))),
                         e -> log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage())));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void updateLoaderHash(
+            SpaceService spaceService, EngineContentLoader engineContentLoader) {
+        if (engineContentLoader == null) {
+            return;
+        }
+        spaceService.getPolicy(
+                Space.STANDARD.toString(),
+                ActionListener.wrap(
+                        policy -> {
+                            if (policy == null) {
+                                return;
+                            }
+                            Object space = policy.get(Constants.KEY_SPACE);
+                            if (space instanceof Map) {
+                                String hash = Resource.extractHash((Map<String, Object>) space);
+                                if (hash != null) {
+                                    engineContentLoader.updateLoadedHash(Space.STANDARD.toString(), hash);
+                                }
+                            }
+                        },
+                        e -> log.debug("Failed to read hash for loader update: {}", e.getMessage())));
     }
 
     /** Walks the exception cause chain looking for an OpenSearchSecurityException. */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateFilterAction.java
@@ -36,6 +36,7 @@ import com.wazuh.contentmanager.action.CreateFilterAction;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -52,8 +53,15 @@ public class TransportCreateFilterAction extends AbstractTransportCreateActionSp
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
-        super(CreateFilterAction.NAME, transportService, actionFilters, client, engine);
+            EngineService engine,
+            EngineContentLoader engineContentLoader) {
+        super(
+                CreateFilterAction.NAME,
+                transportService,
+                actionFilters,
+                client,
+                engine,
+                engineContentLoader);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportDeleteFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportDeleteFilterAction.java
@@ -34,6 +34,7 @@ import com.wazuh.contentmanager.action.DeleteFilterAction;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -48,8 +49,15 @@ public class TransportDeleteFilterAction extends AbstractTransportDeleteActionSp
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
-        super(DeleteFilterAction.NAME, transportService, actionFilters, client, engine);
+            EngineService engine,
+            EngineContentLoader engineContentLoader) {
+        super(
+                DeleteFilterAction.NAME,
+                transportService,
+                actionFilters,
+                client,
+                engine,
+                engineContentLoader);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
@@ -55,7 +55,6 @@ import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
-import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.rest.model.SpaceDiff;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -67,6 +66,7 @@ public class TransportPostPromoteAction
         extends HandledTransportAction<PostPromoteRequest, MessageStatusResponse> {
 
     private static final Logger log = LogManager.getLogger(TransportPostPromoteAction.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /** All resource types in the order they should be processed during consolidation. */
     private static final List<String> APPLY_RESOURCE_TYPES =
@@ -128,8 +128,7 @@ public class TransportPostPromoteAction
         }
 
         try {
-            ObjectMapper mapper = new ObjectMapper();
-            SpaceDiff spaceDiff = mapper.readValue(body, SpaceDiff.class);
+            SpaceDiff spaceDiff = MAPPER.readValue(body, SpaceDiff.class);
             this.validatePromoteRequest(spaceDiff);
 
             this.gatherPromotionDataAsync(spaceDiff, listener);
@@ -680,24 +679,29 @@ public class TransportPostPromoteAction
 
     private void invokeEngineAndConsolidate(
             PromotionContext context, Space targetSpace, ActionListener<MessageStatusResponse> listener) {
-        RestResponse engineResponse = this.engine.promote(context.enginePayload);
-
-        if (engineResponse.getStatus() != RestStatus.OK.getStatus()
-                && engineResponse.getStatus() != RestStatus.ACCEPTED.getStatus()) {
-            log.warn(Constants.W_LOG_VALIDATION_FAILED, engineResponse.getMessage());
-            try {
-                log.debug(
-                        Constants.D_LOG_ENGINE_REJECTED_PAYLOAD,
-                        new ObjectMapper().writeValueAsString(context.enginePayload));
-            } catch (IOException ignored) {
-            }
-            listener.onResponse(
-                    new MessageStatusResponse(
-                            engineResponse.getMessage(), RestStatus.fromCode(engineResponse.getStatus())));
-            return;
-        }
-        log.debug(Constants.D_LOG_ENGINE_VALIDATION_COMPLETE, targetSpace);
-        consolidateChangesAsync(context, listener);
+        this.engine.promoteAsync(
+                context.enginePayload,
+                ActionListener.wrap(
+                        engineResponse -> {
+                            if (engineResponse.getStatus() != RestStatus.OK.getStatus()
+                                    && engineResponse.getStatus() != RestStatus.ACCEPTED.getStatus()) {
+                                log.warn(Constants.W_LOG_VALIDATION_FAILED, engineResponse.getMessage());
+                                try {
+                                    log.debug(
+                                            Constants.D_LOG_ENGINE_REJECTED_PAYLOAD,
+                                            MAPPER.writeValueAsString(context.enginePayload));
+                                } catch (IOException ignored) {
+                                }
+                                listener.onResponse(
+                                        new MessageStatusResponse(
+                                                engineResponse.getMessage(),
+                                                RestStatus.fromCode(engineResponse.getStatus())));
+                                return;
+                            }
+                            log.debug(Constants.D_LOG_ENGINE_VALIDATION_COMPLETE, targetSpace);
+                            consolidateChangesAsync(context, listener);
+                        },
+                        listener::onFailure));
     }
 
     // ── Consolidation phase ──────────────────────────────────────────────────
@@ -782,7 +786,6 @@ public class TransportPostPromoteAction
 
     private void sapSyncAsync(PromotionContext context, ActionListener<Void> listener) {
         Space targetSpaceEnum = Space.fromValue(context.targetSpace);
-        ObjectMapper mapper = new ObjectMapper();
 
         List<String> rulesToDelete = new ArrayList<>(context.rulesToDelete);
         List<String> integrationsToDelete = new ArrayList<>(context.integrationsToDelete);
@@ -809,7 +812,6 @@ public class TransportPostPromoteAction
                                                                         Constants.KEY_INTEGRATIONS, Collections.emptyMap()),
                                                                 Constants.KEY_INTEGRATIONS,
                                                                 targetSpaceEnum,
-                                                                mapper,
                                                                 context.targetSpace,
                                                                 ActionListener.wrap(
                                                                         v3 ->
@@ -819,7 +821,6 @@ public class TransportPostPromoteAction
                                                                                                 Constants.KEY_RULES, Collections.emptyMap()),
                                                                                         Constants.KEY_RULES,
                                                                                         targetSpaceEnum,
-                                                                                        mapper,
                                                                                         context.targetSpace,
                                                                                         listener),
                                                                         listener::onFailure)),
@@ -864,19 +865,11 @@ public class TransportPostPromoteAction
             Map<String, Map<String, Object>> oldVersionsForType,
             String resourceType,
             Space targetSpaceEnum,
-            ObjectMapper mapper,
             String targetSpace,
             ActionListener<Void> listener) {
         List<Map.Entry<String, Map<String, Object>>> entries = new ArrayList<>(resources.entrySet());
         upsertSapEntryAsync(
-                entries,
-                0,
-                oldVersionsForType,
-                resourceType,
-                targetSpaceEnum,
-                mapper,
-                targetSpace,
-                listener);
+                entries, 0, oldVersionsForType, resourceType, targetSpaceEnum, targetSpace, listener);
     }
 
     private void upsertSapEntryAsync(
@@ -885,7 +878,6 @@ public class TransportPostPromoteAction
             Map<String, Map<String, Object>> oldVersionsForType,
             String resourceType,
             Space targetSpaceEnum,
-            ObjectMapper mapper,
             String targetSpace,
             ActionListener<Void> listener) {
         if (idx >= entries.size()) {
@@ -902,7 +894,6 @@ public class TransportPostPromoteAction
                     oldVersionsForType,
                     resourceType,
                     targetSpaceEnum,
-                    mapper,
                     targetSpace,
                     listener);
             return;
@@ -924,7 +915,6 @@ public class TransportPostPromoteAction
                                         oldVersionsForType,
                                         resourceType,
                                         targetSpaceEnum,
-                                        mapper,
                                         targetSpace,
                                         listener),
                         e -> {
@@ -940,17 +930,16 @@ public class TransportPostPromoteAction
                                     oldVersionsForType,
                                     resourceType,
                                     targetSpaceEnum,
-                                    mapper,
                                     targetSpace,
                                     listener);
                         });
 
         if (Constants.KEY_INTEGRATIONS.equals(resourceType)) {
             this.securityAnalyticsService.upsertIntegration(
-                    mapper.valueToTree(document), targetSpaceEnum, method, itemListener);
+                    MAPPER.valueToTree(document), targetSpaceEnum, method, itemListener);
         } else {
             this.securityAnalyticsService.upsertRule(
-                    mapper.valueToTree(document), targetSpaceEnum, method, itemListener);
+                    MAPPER.valueToTree(document), targetSpaceEnum, method, itemListener);
         }
     }
 
@@ -1105,14 +1094,12 @@ public class TransportPostPromoteAction
     private void reconcileSapAfterRollbackAsync(
             PromotionContext context, ActionListener<Void> listener) {
         Space targetSpaceEnum = Space.fromValue(context.targetSpace);
-        ObjectMapper mapper = new ObjectMapper();
 
         revertSapAppliedAsync(
                 context.rulesToApply,
                 context.oldVersions.getOrDefault(Constants.KEY_RULES, Collections.emptyMap()),
                 Constants.KEY_RULES,
                 targetSpaceEnum,
-                mapper,
                 ActionListener.wrap(
                         v ->
                                 revertSapAppliedAsync(
@@ -1121,7 +1108,6 @@ public class TransportPostPromoteAction
                                                 Constants.KEY_INTEGRATIONS, Collections.emptyMap()),
                                         Constants.KEY_INTEGRATIONS,
                                         targetSpaceEnum,
-                                        mapper,
                                         ActionListener.wrap(
                                                 v2 ->
                                                         restoreSapDeletedAsync(
@@ -1129,7 +1115,6 @@ public class TransportPostPromoteAction
                                                                         Constants.KEY_INTEGRATIONS, Collections.emptyMap()),
                                                                 Constants.KEY_INTEGRATIONS,
                                                                 targetSpaceEnum,
-                                                                mapper,
                                                                 ActionListener.wrap(
                                                                         v3 ->
                                                                                 restoreSapDeletedAsync(
@@ -1137,7 +1122,6 @@ public class TransportPostPromoteAction
                                                                                                 Constants.KEY_RULES, Collections.emptyMap()),
                                                                                         Constants.KEY_RULES,
                                                                                         targetSpaceEnum,
-                                                                                        mapper,
                                                                                         listener),
                                                                         e -> listener.onResponse(null))),
                                                 e -> listener.onResponse(null))),
@@ -1149,11 +1133,10 @@ public class TransportPostPromoteAction
             Map<String, Map<String, Object>> oldVersionsForType,
             String resourceType,
             Space targetSpaceEnum,
-            ObjectMapper mapper,
             ActionListener<Void> listener) {
         List<Map.Entry<String, Map<String, Object>>> entries = new ArrayList<>(resources.entrySet());
         revertSapAppliedEntryAsync(
-                entries, 0, oldVersionsForType, resourceType, targetSpaceEnum, mapper, listener);
+                entries, 0, oldVersionsForType, resourceType, targetSpaceEnum, listener);
     }
 
     private void revertSapAppliedEntryAsync(
@@ -1162,7 +1145,6 @@ public class TransportPostPromoteAction
             Map<String, Map<String, Object>> oldVersionsForType,
             String resourceType,
             Space targetSpaceEnum,
-            ObjectMapper mapper,
             ActionListener<Void> listener) {
         if (idx >= entries.size()) {
             listener.onResponse(null);
@@ -1175,23 +1157,11 @@ public class TransportPostPromoteAction
                 ActionListener.wrap(
                         v ->
                                 revertSapAppliedEntryAsync(
-                                        entries,
-                                        idx + 1,
-                                        oldVersionsForType,
-                                        resourceType,
-                                        targetSpaceEnum,
-                                        mapper,
-                                        listener),
+                                        entries, idx + 1, oldVersionsForType, resourceType, targetSpaceEnum, listener),
                         e -> {
                             log.warn(Constants.W_LOG_SAP_ROLLBACK_FAILED, resourceType, id, e.getMessage());
                             revertSapAppliedEntryAsync(
-                                    entries,
-                                    idx + 1,
-                                    oldVersionsForType,
-                                    resourceType,
-                                    targetSpaceEnum,
-                                    mapper,
-                                    listener);
+                                    entries, idx + 1, oldVersionsForType, resourceType, targetSpaceEnum, listener);
                         });
 
         ActionListener<ActionResponse> sapListener =
@@ -1207,7 +1177,7 @@ public class TransportPostPromoteAction
         } else if (oldVersion.containsKey(Constants.KEY_DOCUMENT)) {
             @SuppressWarnings("unchecked")
             Map<String, Object> document = (Map<String, Object>) oldVersion.get(Constants.KEY_DOCUMENT);
-            JsonNode docNode = mapper.valueToTree(document);
+            JsonNode docNode = MAPPER.valueToTree(document);
             if (Constants.KEY_INTEGRATIONS.equals(resourceType)) {
                 this.securityAnalyticsService.upsertIntegration(
                         docNode, targetSpaceEnum, RestRequest.Method.PUT, sapListener);
@@ -1225,10 +1195,9 @@ public class TransportPostPromoteAction
             Map<String, Map<String, Object>> snapshots,
             String resourceType,
             Space targetSpaceEnum,
-            ObjectMapper mapper,
             ActionListener<Void> listener) {
         List<Map.Entry<String, Map<String, Object>>> entries = new ArrayList<>(snapshots.entrySet());
-        restoreSapDeletedEntryAsync(entries, 0, resourceType, targetSpaceEnum, mapper, listener);
+        restoreSapDeletedEntryAsync(entries, 0, resourceType, targetSpaceEnum, listener);
     }
 
     private void restoreSapDeletedEntryAsync(
@@ -1236,7 +1205,6 @@ public class TransportPostPromoteAction
             int idx,
             String resourceType,
             Space targetSpaceEnum,
-            ObjectMapper mapper,
             ActionListener<Void> listener) {
         if (idx >= entries.size()) {
             listener.onResponse(null);
@@ -1249,7 +1217,7 @@ public class TransportPostPromoteAction
                 ActionListener.wrap(
                         v ->
                                 restoreSapDeletedEntryAsync(
-                                        entries, idx + 1, resourceType, targetSpaceEnum, mapper, listener),
+                                        entries, idx + 1, resourceType, targetSpaceEnum, listener),
                         e -> {
                             log.warn(
                                     Constants.W_LOG_SAP_ROLLBACK_RESTORE_DELETED_FAILED,
@@ -1257,13 +1225,13 @@ public class TransportPostPromoteAction
                                     id,
                                     e.getMessage());
                             restoreSapDeletedEntryAsync(
-                                    entries, idx + 1, resourceType, targetSpaceEnum, mapper, listener);
+                                    entries, idx + 1, resourceType, targetSpaceEnum, listener);
                         });
 
         if (snapshot != null && snapshot.containsKey(Constants.KEY_DOCUMENT)) {
             @SuppressWarnings("unchecked")
             Map<String, Object> document = (Map<String, Object>) snapshot.get(Constants.KEY_DOCUMENT);
-            JsonNode docNode = mapper.valueToTree(document);
+            JsonNode docNode = MAPPER.valueToTree(document);
 
             ActionListener<ActionResponse> sapListener =
                     ActionListener.wrap(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
@@ -33,6 +33,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,6 +49,8 @@ import java.util.Set;
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.action.PostPromoteAction;
 import com.wazuh.contentmanager.action.PostPromoteRequest;
+import com.wazuh.contentmanager.action.ReloadEngineContentAction;
+import com.wazuh.contentmanager.action.ReloadEngineContentRequest;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
@@ -87,6 +90,7 @@ public class TransportPostPromoteAction
     private final SpaceService spaceService;
     private final EngineService engine;
     private final SecurityAnalyticsService securityAnalyticsService;
+    private final Client client;
 
     @Inject
     public TransportPostPromoteAction(
@@ -94,11 +98,13 @@ public class TransportPostPromoteAction
             ActionFilters actionFilters,
             SpaceService spaceService,
             EngineService engine,
-            SecurityAnalyticsService securityAnalyticsService) {
+            SecurityAnalyticsService securityAnalyticsService,
+            Client client) {
         super(PostPromoteAction.NAME, transportService, actionFilters, PostPromoteRequest::new);
         this.spaceService = spaceService;
         this.engine = engine;
         this.securityAnalyticsService = securityAnalyticsService;
+        this.client = client;
     }
 
     // ── Entry point ──────────────────────────────────────────────────────────
@@ -955,10 +961,30 @@ public class TransportPostPromoteAction
         this.spaceService.calculateAndUpdate(
                 List.of(context.targetSpace),
                 ActionListener.wrap(
-                        changedSpaces ->
-                                listener.onResponse(
-                                        new MessageStatusResponse(Constants.S_200_PROMOTION_COMPLETED, RestStatus.OK)),
+                        changedSpaces -> {
+                            // Promote loaded the content into this (coordinating) node's Engine only; the
+                            // Engine socket is node-local. Broadcast a reload so every node loads the
+                            // now-consolidated content into its own Engine, keyed off the target space's
+                            // freshly recomputed hash. Reuses the same node-local, hash-gated loader as the
+                            // STANDARD path; nodes that are down converge later via the cluster-state listener.
+                            broadcastEngineReload();
+                            listener.onResponse(
+                                    new MessageStatusResponse(Constants.S_200_PROMOTION_COMPLETED, RestStatus.OK));
+                        },
                         e -> respondWithError(listener, e)));
+    }
+
+    /**
+     * Fires the cluster-wide Engine reload broadcast (fire-and-forget). Each node reloads any tracked
+     * space whose hash changed; failures are logged and never affect the promote response.
+     */
+    private void broadcastEngineReload() {
+        this.client.execute(
+                ReloadEngineContentAction.INSTANCE,
+                new ReloadEngineContentRequest(),
+                ActionListener.wrap(
+                        r -> log.debug(Constants.D_LOG_ENGINE_RELOAD_BROADCAST_SENT),
+                        e -> log.warn(Constants.W_LOG_ENGINE_RELOAD_BROADCAST_FAILED, e.getMessage())));
     }
 
     // ── Rollback ─────────────────────────────────────────────────────────────

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportReloadEngineContentAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportReloadEngineContentAction.java
@@ -90,6 +90,14 @@ public class TransportReloadEngineContentAction
         return new ReloadEngineContentNodeResponse(in);
     }
 
+    /**
+     * Triggers the node-local reload and responds immediately: the response acknowledges that the
+     * reload was started, not that the Engine finished loading. {@link TransportNodesAction} sends
+     * the response from this method's return value, so waiting for {@link
+     * EngineContentLoader#reloadIfChanged(org.opensearch.core.action.ActionListener)} to complete
+     * would mean parking this generic-pool thread for the whole reload — exactly what the loader's
+     * async design avoids. Nodes converge via the per-node cluster-state listener regardless.
+     */
     @Override
     protected ReloadEngineContentNodeResponse nodeOperation(NodeRequest request) {
         this.engineContentLoader.reloadIfChanged();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportReloadEngineContentAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportReloadEngineContentAction.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportRequest;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.wazuh.contentmanager.action.ReloadEngineContentAction;
+import com.wazuh.contentmanager.action.ReloadEngineContentNodeResponse;
+import com.wazuh.contentmanager.action.ReloadEngineContentRequest;
+import com.wazuh.contentmanager.action.ReloadEngineContentResponse;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
+
+/**
+ * Handles {@link ReloadEngineContentAction} on every targeted node: it asks the node-local {@link
+ * EngineContentLoader} to reload the STANDARD space if the cluster-wide content hash changed.
+ *
+ * <p>The call is hash-gated and single-flighted inside the loader, so this handler is a cheap no-op
+ * when the node's Engine is already up to date, and the broadcast composes safely with the per-node
+ * cluster-state listener that drives the same loader.
+ */
+public class TransportReloadEngineContentAction
+        extends TransportNodesAction<
+                ReloadEngineContentRequest,
+                ReloadEngineContentResponse,
+                TransportReloadEngineContentAction.NodeRequest,
+                ReloadEngineContentNodeResponse> {
+
+    private final EngineContentLoader engineContentLoader;
+
+    @Inject
+    public TransportReloadEngineContentAction(
+            ThreadPool threadPool,
+            ClusterService clusterService,
+            TransportService transportService,
+            ActionFilters actionFilters,
+            EngineContentLoader engineContentLoader) {
+        super(
+                ReloadEngineContentAction.NAME,
+                threadPool,
+                clusterService,
+                transportService,
+                actionFilters,
+                ReloadEngineContentRequest::new,
+                NodeRequest::new,
+                ThreadPool.Names.GENERIC,
+                ReloadEngineContentNodeResponse.class);
+        this.engineContentLoader = engineContentLoader;
+    }
+
+    @Override
+    protected ReloadEngineContentResponse newResponse(
+            ReloadEngineContentRequest request,
+            List<ReloadEngineContentNodeResponse> responses,
+            List<FailedNodeException> failures) {
+        return new ReloadEngineContentResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected NodeRequest newNodeRequest(ReloadEngineContentRequest request) {
+        return new NodeRequest();
+    }
+
+    @Override
+    protected ReloadEngineContentNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new ReloadEngineContentNodeResponse(in);
+    }
+
+    @Override
+    protected ReloadEngineContentNodeResponse nodeOperation(NodeRequest request) {
+        this.engineContentLoader.reloadIfChanged();
+        return new ReloadEngineContentNodeResponse(clusterService.localNode());
+    }
+
+    /** Per-node request. Empty: the node reads the content hash itself from the policies index. */
+    public static class NodeRequest extends TransportRequest {
+        public NodeRequest() {}
+
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateFilterAction.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import com.wazuh.contentmanager.action.UpdateFilterAction;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.utils.Constants;
@@ -44,8 +45,15 @@ public class TransportUpdateFilterAction extends AbstractTransportUpdateActionSp
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
-        super(UpdateFilterAction.NAME, transportService, actionFilters, client, engine);
+            EngineService engine,
+            EngineContentLoader engineContentLoader) {
+        super(
+                UpdateFilterAction.NAME,
+                transportService,
+                actionFilters,
+                client,
+                engine,
+                engineContentLoader);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
@@ -37,6 +37,7 @@ import com.wazuh.contentmanager.action.UpdateIntegrationAction;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsServiceImpl;
 import com.wazuh.contentmanager.engine.service.EngineService;
@@ -71,8 +72,15 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
-        super(UpdateIntegrationAction.NAME, transportService, actionFilters, client, engine);
+            EngineService engine,
+            EngineContentLoader engineContentLoader) {
+        super(
+                UpdateIntegrationAction.NAME,
+                transportService,
+                actionFilters,
+                client,
+                engine,
+                engineContentLoader);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
@@ -48,6 +48,7 @@ import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Policy;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -66,6 +67,7 @@ public class TransportUpdatePolicyAction
 
     private final SpaceService spaceService;
     private final EngineService engineService;
+    private final EngineContentLoader engineContentLoader;
     private final Client client;
     private final PayloadValidations payloadValidations;
 
@@ -75,10 +77,12 @@ public class TransportUpdatePolicyAction
             ActionFilters actionFilters,
             SpaceService spaceService,
             EngineService engineService,
+            EngineContentLoader engineContentLoader,
             Client client) {
         super(UpdatePolicyAction.NAME, transportService, actionFilters, UpdatePolicyRequest::new);
         this.spaceService = spaceService;
         this.engineService = engineService;
+        this.engineContentLoader = engineContentLoader;
         this.client = client;
         this.payloadValidations = new PayloadValidations();
     }
@@ -350,7 +354,7 @@ public class TransportUpdatePolicyAction
                 ActionListener.wrap(
                         changedSpaces -> {
                             TransportActionHelper.reloadStandardSpaceIntoEngine(
-                                    this.engineService, this.spaceService, changedSpaces);
+                                    this.engineService, this.spaceService, changedSpaces, this.engineContentLoader);
                             listener.onResponse(new MessageStatusResponse(policyId, RestStatus.OK));
                         },
                         e -> respondWithError(listener, e)));

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
@@ -354,7 +354,11 @@ public class TransportUpdatePolicyAction
                 ActionListener.wrap(
                         changedSpaces -> {
                             TransportActionHelper.reloadStandardSpaceIntoEngine(
-                                    this.engineService, this.spaceService, changedSpaces, this.engineContentLoader);
+                                    this.engineService,
+                                    this.spaceService,
+                                    changedSpaces,
+                                    this.engineContentLoader,
+                                    this.client);
                             listener.onResponse(new MessageStatusResponse(policyId, RestStatus.OK));
                         },
                         e -> respondWithError(listener, e)));

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -257,6 +257,12 @@ public class Constants {
             "Engine load for standard space returned status [{}]: {}";
     public static final String E_LOG_ENGINE_STANDARD_LOAD_FAILED =
             "Failed to load standard space into Engine: {}";
+    public static final String D_LOG_ENGINE_STANDARD_NO_POLICY =
+            "No standard policy found; skipping Engine load.";
+    public static final String D_LOG_ENGINE_STANDARD_NO_HASH =
+            "Standard policy has no aggregate hash yet; skipping Engine load.";
+    public static final String D_LOG_ENGINE_STANDARD_UNCHANGED =
+            "Standard content hash unchanged; Engine already up to date.";
     public static final String E_LOG_SAP_INDEX_MISSING =
             "{} index is missing. Cannot sync {} to Security Analytics Plugin.";
     public static final String D_LOG_SAP_NOTHING_TO_SYNC =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -274,6 +274,12 @@ public class Constants {
             "No aggregate hash for {} space yet; skipping Engine load.";
     public static final String D_LOG_ENGINE_SPACE_UNCHANGED =
             "Content hash unchanged for {} space; Engine already up to date.";
+    public static final String I_LOG_ENGINE_STANDARD_LOADED =
+            "Standard space reloaded into Engine after content mutation.";
+    public static final String W_LOG_ENGINE_STANDARD_LOAD_STATUS =
+            "Engine returned status [{}] when reloading standard space: {}";
+    public static final String E_LOG_ENGINE_STANDARD_LOAD_FAILED =
+            "Failed to reload standard space into Engine: {}";
     public static final String D_LOG_ENGINE_RELOAD_BROADCAST_SENT =
             "Broadcast engine content reload to all nodes after content update.";
     public static final String W_LOG_ENGINE_RELOAD_BROADCAST_FAILED =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -251,18 +251,23 @@ public class Constants {
             "Partial failures deleting Security Analytics resources for space [{}]: {}";
     public static final String I_LOG_SAP_SPACE_DELETED =
             "Deleted [{}] integrations and [{}] rules from Security Analytics for space [{}]";
-    public static final String I_LOG_ENGINE_STANDARD_LOADED =
-            "Engine load for standard space completed successfully.";
-    public static final String W_LOG_ENGINE_STANDARD_LOAD_STATUS =
-            "Engine load for standard space returned status [{}]: {}";
-    public static final String E_LOG_ENGINE_STANDARD_LOAD_FAILED =
-            "Failed to load standard space into Engine: {}";
-    public static final String D_LOG_ENGINE_STANDARD_NO_POLICY =
-            "No standard policy found; skipping Engine load.";
-    public static final String D_LOG_ENGINE_STANDARD_NO_HASH =
-            "Standard policy has no aggregate hash yet; skipping Engine load.";
-    public static final String D_LOG_ENGINE_STANDARD_UNCHANGED =
-            "Standard content hash unchanged; Engine already up to date.";
+    // Space-parameterized Engine load logs (space name is the first {}). The "standard" rendering of
+    // I_LOG_ENGINE_SPACE_LOADED is intentionally byte-identical to the original standard-only message
+    // so existing log-based validation keeps matching.
+    public static final String I_LOG_ENGINE_SPACE_LOADED =
+            "Engine load for {} space completed successfully.";
+    public static final String W_LOG_ENGINE_SPACE_LOAD_STATUS =
+            "Engine load for {} space returned status [{}]: {}";
+    public static final String E_LOG_ENGINE_SPACE_LOAD_FAILED =
+            "Failed to load {} space into Engine: {}";
+    public static final String E_LOG_ENGINE_RELOAD_SCHEDULE_FAILED =
+            "Failed to schedule Engine content reload: {}";
+    public static final String D_LOG_ENGINE_SPACE_NO_POLICY =
+            "No policy found for {} space; skipping Engine load.";
+    public static final String D_LOG_ENGINE_SPACE_NO_HASH =
+            "No aggregate hash for {} space yet; skipping Engine load.";
+    public static final String D_LOG_ENGINE_SPACE_UNCHANGED =
+            "Content hash unchanged for {} space; Engine already up to date.";
     public static final String D_LOG_ENGINE_RELOAD_BROADCAST_SENT =
             "Broadcast engine content reload to all nodes after content update.";
     public static final String W_LOG_ENGINE_RELOAD_BROADCAST_FAILED =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -263,6 +263,10 @@ public class Constants {
             "Standard policy has no aggregate hash yet; skipping Engine load.";
     public static final String D_LOG_ENGINE_STANDARD_UNCHANGED =
             "Standard content hash unchanged; Engine already up to date.";
+    public static final String D_LOG_ENGINE_RELOAD_BROADCAST_SENT =
+            "Broadcast engine content reload to all nodes after content update.";
+    public static final String W_LOG_ENGINE_RELOAD_BROADCAST_FAILED =
+            "Failed to broadcast engine content reload to cluster nodes: {}";
     public static final String E_LOG_SAP_INDEX_MISSING =
             "{} index is missing. Cannot sync {} to Security Analytics Plugin.";
     public static final String D_LOG_SAP_NOTHING_TO_SYNC =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -262,6 +262,12 @@ public class Constants {
             "Failed to load {} space into Engine: {}";
     public static final String E_LOG_ENGINE_RELOAD_SCHEDULE_FAILED =
             "Failed to schedule Engine content reload: {}";
+    public static final String D_LOG_ENGINE_POLICIES_INDEX_NOT_READY =
+            "Index [{}] does not exist yet; deferring Engine content load until it is created.";
+    public static final String D_LOG_ENGINE_CLUSTER_NOT_READY =
+            "Cluster cannot serve content reads yet ({}); deferring Engine content load.";
+    public static final String W_LOG_ENGINE_RELOAD_TIMED_OUT =
+            "Engine content reload did not complete within [{}]; releasing the in-flight guard.";
     public static final String D_LOG_ENGINE_SPACE_NO_POLICY =
             "No policy found for {} space; skipping Engine load.";
     public static final String D_LOG_ENGINE_SPACE_NO_HASH =
@@ -378,6 +384,8 @@ public class Constants {
     public static final String E_LOG_GET_DOCUMENT_FAILED =
             "Failed to get document [{}] from index [{}]: {}";
     public static final String E_LOG_GET_POLICY_FAILED = "Failed to get policy for space [{}]: {}";
+    public static final String D_LOG_POLICY_INDEX_NOT_READY =
+            "Policies are not readable yet; cannot read the policy for space [{}]: {}";
     public static final String W_LOG_DOCUMENT_NOT_FOUND_FOR_DELETION =
             "Document with document.id [{}] not found in space [{}] for deletion";
     public static final String E_LOG_DELETE_RESOURCES_FAILED = "Failed to delete resources: {}";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.jobscheduler.jobs.TelemetryPingJob;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -75,6 +76,7 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
     @Mock private DiscoveryNode discoveryNode;
     @Mock private CatalogSyncJob catalogSyncJob;
     @Mock private TelemetryPingJob telemetryPingJob;
+    @Mock private EngineContentLoader engineContentLoader;
     @Mock private ConsumersIndex consumersIndex;
     @Mock private ClusterState clusterState;
     @Mock private DiscoveryNodes discoveryNodes;
@@ -109,6 +111,7 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
         this.injectField(this.plugin, "threadPool", this.threadPool);
         this.injectField(this.plugin, "catalogSyncJob", this.catalogSyncJob);
         this.injectField(this.plugin, "telemetryPingJob", this.telemetryPingJob);
+        this.injectField(this.plugin, "engineContentLoader", this.engineContentLoader);
         this.injectField(this.plugin, "consumersIndex", this.consumersIndex);
 
         ContentManagerPluginTests.clearInstance();

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
@@ -37,7 +37,10 @@ import java.util.Objects;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerRulesetService;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.settings.PluginSettings;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Integration test that verifies space initialization does not create duplicate policy documents
@@ -100,7 +103,7 @@ public class SpaceInitializationIT extends OpenSearchIntegTestCase {
                         OpenSearchIntegTestCase.client(),
                         new ConsumersIndex(OpenSearchIntegTestCase.client()),
                         null,
-                        null);
+                        mock(EngineContentLoader.class));
 
         // First call — simulates the cluster manager node completing a sync
         synchronizer.onSyncComplete(true);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerRulesetService;
+import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
 /**
@@ -99,6 +100,8 @@ public class SpaceInitializationIT extends OpenSearchIntegTestCase {
                 new ConsumerRulesetService(
                         OpenSearchIntegTestCase.client(),
                         new ConsumersIndex(OpenSearchIntegTestCase.client()),
+                        null,
+                        new SpaceService(OpenSearchIntegTestCase.client()),
                         null);
 
         // First call — simulates the cluster manager node completing a sync

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
@@ -37,10 +37,7 @@ import java.util.Objects;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerRulesetService;
-import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.settings.PluginSettings;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * Integration test that verifies space initialization does not create duplicate policy documents
@@ -102,8 +99,7 @@ public class SpaceInitializationIT extends OpenSearchIntegTestCase {
                 new ConsumerRulesetService(
                         OpenSearchIntegTestCase.client(),
                         new ConsumersIndex(OpenSearchIntegTestCase.client()),
-                        null,
-                        mock(EngineContentLoader.class));
+                        null);
 
         // First call — simulates the cluster manager node completing a sync
         synchronizer.onSyncComplete(true);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
@@ -40,7 +40,6 @@ import java.util.Map;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.model.LocalConsumer;
-import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -61,7 +60,7 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     @Mock private Client client;
     @Mock private ConsumersIndex consumersIndex;
     @Mock private Environment environment;
-    @Mock private EngineService engineService;
+    @Mock private EngineContentLoader engineContentLoader;
 
     @Before
     @Override
@@ -71,7 +70,7 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         PluginSettings.getInstance(Settings.EMPTY);
         this.synchronizer =
                 new ConsumerRulesetService(
-                        this.client, this.consumersIndex, this.environment, this.engineService);
+                        this.client, this.consumersIndex, this.environment, this.engineContentLoader);
     }
 
     @After

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
@@ -60,6 +60,8 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     @Mock private Client client;
     @Mock private ConsumersIndex consumersIndex;
     @Mock private Environment environment;
+    @Mock private SpaceService spaceService;
+    @Mock private SecurityAnalyticsService securityAnalyticsService;
 
     @Before
     @Override
@@ -68,7 +70,12 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         this.closeable = MockitoAnnotations.openMocks(this);
         PluginSettings.getInstance(Settings.EMPTY);
         this.synchronizer =
-                new ConsumerRulesetService(this.client, this.consumersIndex, this.environment);
+                new ConsumerRulesetService(
+                        this.client,
+                        this.consumersIndex,
+                        this.environment,
+                        this.spaceService,
+                        this.securityAnalyticsService);
     }
 
     @After

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
@@ -60,7 +60,6 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     @Mock private Client client;
     @Mock private ConsumersIndex consumersIndex;
     @Mock private Environment environment;
-    @Mock private EngineContentLoader engineContentLoader;
 
     @Before
     @Override
@@ -69,8 +68,7 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         this.closeable = MockitoAnnotations.openMocks(this);
         PluginSettings.getInstance(Settings.EMPTY);
         this.synchronizer =
-                new ConsumerRulesetService(
-                        this.client, this.consumersIndex, this.environment, this.engineContentLoader);
+                new ConsumerRulesetService(this.client, this.consumersIndex, this.environment);
     }
 
     @After

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
@@ -32,6 +32,7 @@ import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.utils.Constants;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -44,10 +45,16 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link EngineContentLoader}. The tests drive {@link
  * EngineContentLoader#doReload()} directly to bypass the thread-pool hop, and stub the async {@link
  * SpaceService} reads to respond synchronously.
+ *
+ * <p>The loader tracks the shared spaces {@code standard}, {@code test} and {@code custom}. By
+ * default {@link #setUp()} stubs every space to have no policy (so it is skipped), and each test
+ * opts specific spaces in via {@link #stubPolicy}.
  */
 public class EngineContentLoaderTests extends OpenSearchTestCase {
 
     private static final String STANDARD = "standard";
+    private static final String TEST = "test";
+    private static final String CUSTOM = "custom";
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private EngineService engine;
@@ -61,22 +68,44 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.spaceService = mock(SpaceService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
         this.loader = new EngineContentLoader(this.engine, this.spaceService, threadPool);
+
+        // Default: every space has no policy (skipped). Individual tests override per space so an
+        // untouched tracked space is a fast no-op rather than an unstubbed 60s await.
+        doAnswer(
+                        inv -> {
+                            ActionListener<Map<String, Object>> l = inv.getArgument(1);
+                            l.onResponse(null);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(anyString(), any());
+        // Default payload for any space (only reached when a space's hash actually changed).
+        doAnswer(
+                        inv -> {
+                            ActionListener<JsonNode> l = inv.getArgument(1);
+                            l.onResponse(MAPPER.createObjectNode());
+                            return null;
+                        })
+                .when(this.spaceService)
+                .buildEnginePayload(anyString(), any());
     }
 
     /** Builds a policy source map carrying the aggregate space hash at {@code space.hash.sha256}. */
-    private static Map<String, Object> policyWithHash(String sha256) {
+    private static Map<String, Object> policyWithHash(String spaceName, String sha256) {
         Map<String, Object> hash = new HashMap<>();
         hash.put(Constants.KEY_SHA256, sha256);
         Map<String, Object> space = new HashMap<>();
-        space.put(Constants.KEY_NAME, STANDARD);
+        space.put(Constants.KEY_NAME, spaceName);
         space.put(Constants.KEY_HASH, hash);
         Map<String, Object> policy = new HashMap<>();
         policy.put(Constants.KEY_SPACE, space);
         return policy;
     }
 
-    /** Stubs {@link SpaceService#getPolicy} to synchronously return the given policy source. */
-    private void stubPolicy(Map<String, Object> policy) {
+    /**
+     * Stubs {@link SpaceService#getPolicy} for one space to synchronously return the given source.
+     */
+    private void stubPolicy(String spaceName, Map<String, Object> policy) {
         doAnswer(
                         inv -> {
                             ActionListener<Map<String, Object>> l = inv.getArgument(1);
@@ -84,27 +113,17 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
                             return null;
                         })
                 .when(this.spaceService)
-                .getPolicy(eq(STANDARD), any());
+                .getPolicy(eq(spaceName), any());
     }
 
-    /** Stubs {@link SpaceService#buildEnginePayload} to synchronously return an empty payload. */
-    private void stubPayload() {
-        JsonNode payload = MAPPER.createObjectNode();
-        doAnswer(
-                        inv -> {
-                            ActionListener<JsonNode> l = inv.getArgument(1);
-                            l.onResponse(payload);
-                            return null;
-                        })
-                .when(this.spaceService)
-                .buildEnginePayload(eq(STANDARD), any());
+    private void okPromote() {
+        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
     }
 
     /** A changed (first-seen) hash triggers a promote and the hash is recorded. */
     public void testChangedHashPromotes() {
-        this.stubPolicy(policyWithHash("hash-1"));
-        this.stubPayload();
-        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
+        this.okPromote();
 
         this.loader.doReload();
 
@@ -113,9 +132,8 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
     /** A second reload with the same hash after a successful load is a no-op. */
     public void testUnchangedHashSkips() {
-        this.stubPolicy(policyWithHash("hash-1"));
-        this.stubPayload();
-        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
+        this.okPromote();
 
         this.loader.doReload();
         this.loader.doReload();
@@ -125,13 +143,12 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
     /** A different hash after a successful load triggers another promote. */
     public void testNewHashReloads() {
-        this.stubPayload();
-        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
+        this.okPromote();
 
-        this.stubPolicy(policyWithHash("hash-1"));
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
         this.loader.doReload();
 
-        this.stubPolicy(policyWithHash("hash-2"));
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-2"));
         this.loader.doReload();
 
         verify(this.engine, times(2)).promote(any());
@@ -139,8 +156,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
     /** A non-OK Engine response does not record the hash, so the next reload retries. */
     public void testNonOkResponseIsRetried() {
-        this.stubPolicy(policyWithHash("hash-1"));
-        this.stubPayload();
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
         when(this.engine.promote(any()))
                 .thenReturn(new RestResponse("busy", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
 
@@ -150,9 +166,9 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         verify(this.engine, times(2)).promote(any());
     }
 
-    /** No STANDARD policy yet: nothing is loaded. */
+    /** No policy yet: nothing is loaded. */
     public void testNullPolicySkips() {
-        this.stubPolicy(null);
+        this.stubPolicy(STANDARD, null);
 
         this.loader.doReload();
 
@@ -163,10 +179,47 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
     public void testMissingHashSkips() {
         Map<String, Object> policy = new HashMap<>();
         policy.put(Constants.KEY_SPACE, new HashMap<>()); // space present but no hash
-        this.stubPolicy(policy);
+        this.stubPolicy(STANDARD, policy);
 
         this.loader.doReload();
 
         verify(this.engine, never()).promote(any());
+    }
+
+    /** All three tracked spaces (standard, test, custom) with changed hashes each load once. */
+    public void testAllTrackedSpacesLoad() {
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
+        this.stubPolicy(TEST, policyWithHash(TEST, "test-1"));
+        this.stubPolicy(CUSTOM, policyWithHash(CUSTOM, "cust-1"));
+        this.okPromote();
+
+        this.loader.doReload();
+
+        verify(this.engine, times(3)).promote(any());
+    }
+
+    /** Only the space whose hash changed reloads; the unchanged ones are skipped. */
+    public void testOnlyChangedSpaceReloads() {
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
+        this.stubPolicy(TEST, policyWithHash(TEST, "test-1"));
+        this.stubPolicy(CUSTOM, policyWithHash(CUSTOM, "cust-1"));
+        this.okPromote();
+
+        this.loader.doReload(); // loads all three (3 promotes)
+
+        this.stubPolicy(TEST, policyWithHash(TEST, "test-2")); // only TEST changes
+        this.loader.doReload(); // one more promote (TEST)
+
+        verify(this.engine, times(4)).promote(any());
+    }
+
+    /** A promoted TEST space alone loads even when standard/custom are unchanged/absent. */
+    public void testTestSpaceLoadsIndependently() {
+        this.stubPolicy(TEST, policyWithHash(TEST, "test-1"));
+        this.okPromote();
+
+        this.loader.doReload();
+
+        verify(this.engine, times(1)).promote(any());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.wazuh.contentmanager.engine.service.EngineService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+import com.wazuh.contentmanager.utils.Constants;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link EngineContentLoader}. The tests drive {@link
+ * EngineContentLoader#doReload()} directly to bypass the thread-pool hop, and stub the async {@link
+ * SpaceService} reads to respond synchronously.
+ */
+public class EngineContentLoaderTests extends OpenSearchTestCase {
+
+    private static final String STANDARD = "standard";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private EngineService engine;
+    private SpaceService spaceService;
+    private EngineContentLoader loader;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.engine = mock(EngineService.class);
+        this.spaceService = mock(SpaceService.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        this.loader = new EngineContentLoader(this.engine, this.spaceService, threadPool);
+    }
+
+    /** Builds a policy source map carrying the aggregate space hash at {@code space.hash.sha256}. */
+    private static Map<String, Object> policyWithHash(String sha256) {
+        Map<String, Object> hash = new HashMap<>();
+        hash.put(Constants.KEY_SHA256, sha256);
+        Map<String, Object> space = new HashMap<>();
+        space.put(Constants.KEY_NAME, STANDARD);
+        space.put(Constants.KEY_HASH, hash);
+        Map<String, Object> policy = new HashMap<>();
+        policy.put(Constants.KEY_SPACE, space);
+        return policy;
+    }
+
+    /** Stubs {@link SpaceService#getPolicy} to synchronously return the given policy source. */
+    private void stubPolicy(Map<String, Object> policy) {
+        doAnswer(
+                        inv -> {
+                            ActionListener<Map<String, Object>> l = inv.getArgument(1);
+                            l.onResponse(policy);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(eq(STANDARD), any());
+    }
+
+    /** Stubs {@link SpaceService#buildEnginePayload} to synchronously return an empty payload. */
+    private void stubPayload() {
+        JsonNode payload = MAPPER.createObjectNode();
+        doAnswer(
+                        inv -> {
+                            ActionListener<JsonNode> l = inv.getArgument(1);
+                            l.onResponse(payload);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .buildEnginePayload(eq(STANDARD), any());
+    }
+
+    /** A changed (first-seen) hash triggers a promote and the hash is recorded. */
+    public void testChangedHashPromotes() {
+        this.stubPolicy(policyWithHash("hash-1"));
+        this.stubPayload();
+        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
+
+        this.loader.doReload();
+
+        verify(this.engine, times(1)).promote(any());
+    }
+
+    /** A second reload with the same hash after a successful load is a no-op. */
+    public void testUnchangedHashSkips() {
+        this.stubPolicy(policyWithHash("hash-1"));
+        this.stubPayload();
+        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
+
+        this.loader.doReload();
+        this.loader.doReload();
+
+        verify(this.engine, times(1)).promote(any());
+    }
+
+    /** A different hash after a successful load triggers another promote. */
+    public void testNewHashReloads() {
+        this.stubPayload();
+        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
+
+        this.stubPolicy(policyWithHash("hash-1"));
+        this.loader.doReload();
+
+        this.stubPolicy(policyWithHash("hash-2"));
+        this.loader.doReload();
+
+        verify(this.engine, times(2)).promote(any());
+    }
+
+    /** A non-OK Engine response does not record the hash, so the next reload retries. */
+    public void testNonOkResponseIsRetried() {
+        this.stubPolicy(policyWithHash("hash-1"));
+        this.stubPayload();
+        when(this.engine.promote(any()))
+                .thenReturn(new RestResponse("busy", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+
+        this.loader.doReload();
+        this.loader.doReload();
+
+        verify(this.engine, times(2)).promote(any());
+    }
+
+    /** No STANDARD policy yet: nothing is loaded. */
+    public void testNullPolicySkips() {
+        this.stubPolicy(null);
+
+        this.loader.doReload();
+
+        verify(this.engine, never()).promote(any());
+    }
+
+    /** A policy without an aggregate hash is skipped. */
+    public void testMissingHashSkips() {
+        Map<String, Object> policy = new HashMap<>();
+        policy.put(Constants.KEY_SPACE, new HashMap<>()); // space present but no hash
+        this.stubPolicy(policy);
+
+        this.loader.doReload();
+
+        verify(this.engine, never()).promote(any());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
@@ -19,13 +19,20 @@ package com.wazuh.contentmanager.cti.catalog.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.gateway.GatewayService;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -42,9 +49,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link EngineContentLoader}. The tests drive {@link
- * EngineContentLoader#doReload()} directly to bypass the thread-pool hop, and stub the async {@link
- * SpaceService} reads to respond synchronously.
+ * Unit tests for {@link EngineContentLoader}. The reload is fully asynchronous, so the tests stub
+ * the {@link SpaceService} reads to respond synchronously and back the generic pool with a
+ * same-thread executor: {@link EngineContentLoader#reloadIfChanged()} then completes before it
+ * returns, and the assertions need no waiting.
  *
  * <p>The loader tracks the shared spaces {@code standard}, {@code test} and {@code custom}. By
  * default {@link #setUp()} stubs every space to have no policy (so it is skipped), and each test
@@ -59,6 +67,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
     private EngineService engine;
     private SpaceService spaceService;
+    private ThreadPool threadPool;
     private EngineContentLoader loader;
 
     @Override
@@ -66,11 +75,15 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         super.setUp();
         this.engine = mock(EngineService.class);
         this.spaceService = mock(SpaceService.class);
-        ThreadPool threadPool = mock(ThreadPool.class);
-        this.loader = new EngineContentLoader(this.engine, this.spaceService, threadPool);
+        this.threadPool = mock(ThreadPool.class);
+        // Run the (normally forked) blocking Engine call on the calling thread so each
+        // reloadIfChanged() finishes synchronously; schedule() is left returning null, which the
+        // loader treats as "watchdog could not be armed".
+        when(this.threadPool.generic()).thenReturn(OpenSearchExecutors.newDirectExecutorService());
+        this.loader = new EngineContentLoader(this.engine, this.spaceService, this.threadPool);
 
         // Default: every space has no policy (skipped). Individual tests override per space so an
-        // untouched tracked space is a fast no-op rather than an unstubbed 60s await.
+        // untouched tracked space is a fast no-op.
         doAnswer(
                         inv -> {
                             ActionListener<Map<String, Object>> l = inv.getArgument(1);
@@ -125,7 +138,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
         this.okPromote();
 
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, times(1)).promote(any());
     }
@@ -135,8 +148,8 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
         this.okPromote();
 
-        this.loader.doReload();
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, times(1)).promote(any());
     }
@@ -146,10 +159,10 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.okPromote();
 
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
 
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-2"));
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, times(2)).promote(any());
     }
@@ -160,8 +173,8 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         when(this.engine.promote(any()))
                 .thenReturn(new RestResponse("busy", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
 
-        this.loader.doReload();
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, times(2)).promote(any());
     }
@@ -170,7 +183,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
     public void testNullPolicySkips() {
         this.stubPolicy(STANDARD, null);
 
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, never()).promote(any());
     }
@@ -181,7 +194,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         policy.put(Constants.KEY_SPACE, new HashMap<>()); // space present but no hash
         this.stubPolicy(STANDARD, policy);
 
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, never()).promote(any());
     }
@@ -193,7 +206,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.stubPolicy(CUSTOM, policyWithHash(CUSTOM, "cust-1"));
         this.okPromote();
 
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, times(3)).promote(any());
     }
@@ -205,10 +218,10 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.stubPolicy(CUSTOM, policyWithHash(CUSTOM, "cust-1"));
         this.okPromote();
 
-        this.loader.doReload(); // loads all three (3 promotes)
+        this.loader.reloadIfChanged(); // loads all three (3 promotes)
 
         this.stubPolicy(TEST, policyWithHash(TEST, "test-2")); // only TEST changes
-        this.loader.doReload(); // one more promote (TEST)
+        this.loader.reloadIfChanged(); // one more promote (TEST)
 
         verify(this.engine, times(4)).promote(any());
     }
@@ -218,8 +231,192 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.stubPolicy(TEST, policyWithHash(TEST, "test-1"));
         this.okPromote();
 
-        this.loader.doReload();
+        this.loader.reloadIfChanged();
 
         verify(this.engine, times(1)).promote(any());
+    }
+
+    /**
+     * Nothing to load means no pool thread is borrowed at all: the hash reads run on the caller's
+     * callbacks and the generic pool is only reached for an actual Engine call.
+     */
+    public void testNoThreadIsBorrowedWhenNothingChanged() {
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
+        this.okPromote();
+
+        this.loader.reloadIfChanged(); // loads STANDARD (one generic dispatch)
+        verify(this.threadPool, times(1)).generic();
+
+        this.loader.reloadIfChanged(); // everything up to date now
+        verify(this.threadPool, times(1)).generic();
+    }
+
+    /** A read failure is logged per space and still lets the remaining spaces load. */
+    public void testFailedSpaceDoesNotBlockOthers() {
+        doAnswer(
+                        inv -> {
+                            ActionListener<Map<String, Object>> l = inv.getArgument(1);
+                            l.onFailure(new IllegalStateException("index read failed"));
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(eq(STANDARD), any());
+        this.stubPolicy(TEST, policyWithHash(TEST, "test-1"));
+        this.stubPolicy(CUSTOM, policyWithHash(CUSTOM, "cust-1"));
+        this.okPromote();
+
+        this.loader.reloadIfChanged();
+
+        verify(this.engine, times(2)).promote(any());
+    }
+
+    /** The single-flight guard is released once the async chain finishes, so later triggers run. */
+    public void testGuardIsReleasedAfterFailure() {
+        doAnswer(
+                        inv -> {
+                            ActionListener<JsonNode> l = inv.getArgument(1);
+                            l.onFailure(new IllegalStateException("payload build failed"));
+                            return null;
+                        })
+                .when(this.spaceService)
+                .buildEnginePayload(eq(STANDARD), any());
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
+        this.okPromote();
+
+        this.loader.reloadIfChanged(); // fails before promoting
+        verify(this.engine, never()).promote(any());
+
+        // Guard released: a later trigger retries and this time the payload builds.
+        doAnswer(
+                        inv -> {
+                            ActionListener<JsonNode> l = inv.getArgument(1);
+                            l.onResponse(MAPPER.createObjectNode());
+                            return null;
+                        })
+                .when(this.spaceService)
+                .buildEnginePayload(eq(STANDARD), any());
+
+        this.loader.reloadIfChanged();
+
+        verify(this.engine, times(1)).promote(any());
+    }
+
+    /** The listener overload is notified when the run finishes, after the spaces were loaded. */
+    public void testListenerIsNotifiedOnCompletion() {
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
+        this.okPromote();
+
+        AtomicReference<Boolean> completed = new AtomicReference<>();
+        this.loader.reloadIfChanged(
+                ActionListener.wrap(v -> completed.set(true), e -> completed.set(false)));
+
+        assertEquals(Boolean.TRUE, completed.get());
+        verify(this.engine, times(1)).promote(any());
+    }
+
+    /**
+     * A trigger arriving while a reload is in flight does not start a second run; its listener is
+     * notified when the run it was folded into finishes.
+     */
+    public void testFoldedTriggerIsNotifiedWithTheRunItJoined() {
+        // Hold the STANDARD policy read open so the run stays in flight across both triggers.
+        AtomicReference<ActionListener<Map<String, Object>>> pendingRead = new AtomicReference<>();
+        doAnswer(
+                        inv -> {
+                            pendingRead.set(inv.getArgument(1));
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(eq(STANDARD), any());
+        this.okPromote();
+
+        AtomicReference<Boolean> first = new AtomicReference<>();
+        AtomicReference<Boolean> second = new AtomicReference<>();
+        this.loader.reloadIfChanged(ActionListener.wrap(v -> first.set(true), e -> first.set(false)));
+        this.loader.reloadIfChanged(ActionListener.wrap(v -> second.set(true), e -> second.set(false)));
+
+        // Still in flight: neither listener has been notified, and only one run was started.
+        assertNull(first.get());
+        assertNull(second.get());
+        verify(this.spaceService, times(1)).getPolicy(eq(STANDARD), any());
+
+        pendingRead.get().onResponse(policyWithHash(STANDARD, "std-1"));
+
+        assertEquals(Boolean.TRUE, first.get());
+        assertEquals(Boolean.TRUE, second.get());
+        verify(this.engine, times(1)).promote(any());
+    }
+
+    /**
+     * A missing policies index ends the run after the first space: every space reads the same index,
+     * so the remaining ones are not attempted (and the caller is not told this is a failure).
+     */
+    public void testMissingPoliciesIndexEndsTheRunQuietly() {
+        this.stubPolicyFailure(new IndexNotFoundException(Constants.INDEX_POLICIES));
+        this.assertRunDeferredThenRecovers();
+    }
+
+    /**
+     * Same for a cluster block: before the cluster state is recovered every read is rejected with
+     * {@code state not recovered / initialized}, which is a startup condition, not a load failure.
+     */
+    public void testClusterBlockEndsTheRunQuietly() {
+        this.stubPolicyFailure(
+                new ClusterBlockException(Set.of(GatewayService.STATE_NOT_RECOVERED_BLOCK)));
+        this.assertRunDeferredThenRecovers();
+    }
+
+    /**
+     * Stubs every space's policy read to fail with {@code cause}, wrapped as {@code getPolicy} does.
+     */
+    private void stubPolicyFailure(Exception cause) {
+        doAnswer(
+                        inv -> {
+                            ActionListener<Map<String, Object>> l = inv.getArgument(1);
+                            l.onFailure(
+                                    new IOException("Failed to retrieve policy: " + cause.getMessage(), cause));
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(anyString(), any());
+    }
+
+    /**
+     * Asserts the run stopped after the first space without reporting a failure, and that a later
+     * trigger loads normally once the reads succeed.
+     */
+    private void assertRunDeferredThenRecovers() {
+        AtomicReference<Boolean> completed = new AtomicReference<>();
+        this.loader.reloadIfChanged(
+                ActionListener.wrap(v -> completed.set(true), e -> completed.set(false)));
+
+        assertEquals(Boolean.TRUE, completed.get());
+        verify(this.spaceService, times(1)).getPolicy(anyString(), any());
+        verify(this.engine, never()).promote(any());
+
+        // Once the reads succeed the next trigger loads normally.
+        this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
+        this.stubPolicy(TEST, null);
+        this.stubPolicy(CUSTOM, null);
+        this.okPromote();
+
+        this.loader.reloadIfChanged();
+
+        verify(this.engine, times(1)).promote(any());
+    }
+
+    /** An unavailable Engine is reported to the listener and does not wedge the guard. */
+    public void testListenerFailsWhenEngineUnavailable() {
+        EngineContentLoader nullEngineLoader =
+                new EngineContentLoader(null, this.spaceService, this.threadPool);
+
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        nullEngineLoader.reloadIfChanged(ActionListener.wrap(v -> {}, failure::set));
+
+        assertNotNull(failure.get());
+        // Guard released: a second call reaches the same check rather than being folded in.
+        AtomicReference<Exception> secondFailure = new AtomicReference<>();
+        nullEngineLoader.reloadIfChanged(ActionListener.wrap(v -> {}, secondFailure::set));
+        assertNotNull(secondFailure.get());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
@@ -129,8 +129,16 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
                 .getPolicy(eq(spaceName), any());
     }
 
+    @SuppressWarnings("unchecked")
     private void okPromote() {
-        when(this.engine.promote(any())).thenReturn(new RestResponse("ok", RestStatus.OK.getStatus()));
+        doAnswer(
+                        inv -> {
+                            ActionListener<RestResponse> l = inv.getArgument(1);
+                            l.onResponse(new RestResponse("ok", RestStatus.OK.getStatus()));
+                            return null;
+                        })
+                .when(this.engine)
+                .promoteAsync(any(), any());
     }
 
     /** A changed (first-seen) hash triggers a promote and the hash is recorded. */
@@ -140,7 +148,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(1)).promote(any());
+        verify(this.engine, times(1)).promoteAsync(any(), any());
     }
 
     /** A second reload with the same hash after a successful load is a no-op. */
@@ -151,7 +159,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.loader.reloadIfChanged();
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(1)).promote(any());
+        verify(this.engine, times(1)).promoteAsync(any(), any());
     }
 
     /** A different hash after a successful load triggers another promote. */
@@ -164,19 +172,26 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-2"));
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(2)).promote(any());
+        verify(this.engine, times(2)).promoteAsync(any(), any());
     }
 
     /** A non-OK Engine response does not record the hash, so the next reload retries. */
+    @SuppressWarnings("unchecked")
     public void testNonOkResponseIsRetried() {
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "hash-1"));
-        when(this.engine.promote(any()))
-                .thenReturn(new RestResponse("busy", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+        doAnswer(
+                        inv -> {
+                            ActionListener<RestResponse> l = inv.getArgument(1);
+                            l.onResponse(new RestResponse("busy", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+                            return null;
+                        })
+                .when(this.engine)
+                .promoteAsync(any(), any());
 
         this.loader.reloadIfChanged();
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(2)).promote(any());
+        verify(this.engine, times(2)).promoteAsync(any(), any());
     }
 
     /** No policy yet: nothing is loaded. */
@@ -185,7 +200,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, never()).promote(any());
+        verify(this.engine, never()).promoteAsync(any(), any());
     }
 
     /** A policy without an aggregate hash is skipped. */
@@ -196,7 +211,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, never()).promote(any());
+        verify(this.engine, never()).promoteAsync(any(), any());
     }
 
     /** All three tracked spaces (standard, test, custom) with changed hashes each load once. */
@@ -208,7 +223,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(3)).promote(any());
+        verify(this.engine, times(3)).promoteAsync(any(), any());
     }
 
     /** Only the space whose hash changed reloads; the unchanged ones are skipped. */
@@ -223,7 +238,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.stubPolicy(TEST, policyWithHash(TEST, "test-2")); // only TEST changes
         this.loader.reloadIfChanged(); // one more promote (TEST)
 
-        verify(this.engine, times(4)).promote(any());
+        verify(this.engine, times(4)).promoteAsync(any(), any());
     }
 
     /** A promoted TEST space alone loads even when standard/custom are unchanged/absent. */
@@ -233,22 +248,22 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(1)).promote(any());
+        verify(this.engine, times(1)).promoteAsync(any(), any());
     }
 
     /**
      * Nothing to load means no pool thread is borrowed at all: the hash reads run on the caller's
-     * callbacks and the generic pool is only reached for an actual Engine call.
+     * callbacks and the engine call is delegated to {@code promoteAsync}.
      */
     public void testNoThreadIsBorrowedWhenNothingChanged() {
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
         this.okPromote();
 
-        this.loader.reloadIfChanged(); // loads STANDARD (one generic dispatch)
-        verify(this.threadPool, times(1)).generic();
+        this.loader.reloadIfChanged(); // loads STANDARD via promoteAsync (no generic dispatch)
+        verify(this.threadPool, never()).generic();
 
         this.loader.reloadIfChanged(); // everything up to date now
-        verify(this.threadPool, times(1)).generic();
+        verify(this.threadPool, never()).generic();
     }
 
     /** A read failure is logged per space and still lets the remaining spaces load. */
@@ -267,7 +282,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(2)).promote(any());
+        verify(this.engine, times(2)).promoteAsync(any(), any());
     }
 
     /** The single-flight guard is released once the async chain finishes, so later triggers run. */
@@ -284,7 +299,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         this.okPromote();
 
         this.loader.reloadIfChanged(); // fails before promoting
-        verify(this.engine, never()).promote(any());
+        verify(this.engine, never()).promoteAsync(any(), any());
 
         // Guard released: a later trigger retries and this time the payload builds.
         doAnswer(
@@ -298,7 +313,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(1)).promote(any());
+        verify(this.engine, times(1)).promoteAsync(any(), any());
     }
 
     /** The listener overload is notified when the run finishes, after the spaces were loaded. */
@@ -311,7 +326,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
                 ActionListener.wrap(v -> completed.set(true), e -> completed.set(false)));
 
         assertEquals(Boolean.TRUE, completed.get());
-        verify(this.engine, times(1)).promote(any());
+        verify(this.engine, times(1)).promoteAsync(any(), any());
     }
 
     /**
@@ -344,7 +359,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         assertEquals(Boolean.TRUE, first.get());
         assertEquals(Boolean.TRUE, second.get());
-        verify(this.engine, times(1)).promote(any());
+        verify(this.engine, times(1)).promoteAsync(any(), any());
     }
 
     /**
@@ -392,7 +407,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         assertEquals(Boolean.TRUE, completed.get());
         verify(this.spaceService, times(1)).getPolicy(anyString(), any());
-        verify(this.engine, never()).promote(any());
+        verify(this.engine, never()).promoteAsync(any(), any());
 
         // Once the reads succeed the next trigger loads normally.
         this.stubPolicy(STANDARD, policyWithHash(STANDARD, "std-1"));
@@ -402,7 +417,7 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
 
         this.loader.reloadIfChanged();
 
-        verify(this.engine, times(1)).promote(any());
+        verify(this.engine, times(1)).promoteAsync(any(), any());
     }
 
     /** An unavailable Engine is reported to the listener and does not wedge the guard. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
-import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
@@ -67,7 +66,6 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
     @Mock private Environment environment;
     @Mock private ThreadPool threadPool;
     @Mock private EngineService engineService;
-    @Mock private EngineContentLoader engineContentLoader;
     @Mock private GetRequestBuilder getRequestBuilder;
     @Mock private GetResponse getResponse;
 
@@ -84,8 +82,7 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
                         this.consumersIndex,
                         this.environment,
                         this.threadPool,
-                        this.engineService,
-                        this.engineContentLoader);
+                        this.engineService);
 
         when(this.client.prepareGet(Constants.INDEX_SETUP_STATUS, Constants.SETUP_STATUS_DOC_ID))
                 .thenReturn(this.getRequestBuilder);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
+import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
+import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
@@ -67,6 +69,8 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
     @Mock private Environment environment;
     @Mock private ThreadPool threadPool;
     @Mock private EngineService engineService;
+    @Mock private SpaceService spaceService;
+    @Mock private SecurityAnalyticsService securityAnalyticsService;
     @Mock private GetRequestBuilder getRequestBuilder;
     @Mock private GetResponse getResponse;
 
@@ -86,7 +90,9 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
                         this.consumersIndex,
                         this.environment,
                         this.threadPool,
-                        this.engineService);
+                        this.engineService,
+                        this.spaceService,
+                        this.securityAnalyticsService);
 
         when(this.client.prepareGet(Constants.INDEX_SETUP_STATUS, Constants.SETUP_STATUS_DOC_ID))
                 .thenReturn(this.getRequestBuilder);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
@@ -66,6 +67,7 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
     @Mock private Environment environment;
     @Mock private ThreadPool threadPool;
     @Mock private EngineService engineService;
+    @Mock private EngineContentLoader engineContentLoader;
     @Mock private GetRequestBuilder getRequestBuilder;
     @Mock private GetResponse getResponse;
 
@@ -82,7 +84,8 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
                         this.consumersIndex,
                         this.environment,
                         this.threadPool,
-                        this.engineService);
+                        this.engineService,
+                        this.engineContentLoader);
 
         when(this.client.prepareGet(Constants.INDEX_SETUP_STATUS, Constants.SETUP_STATUS_DOC_ID))
                 .thenReturn(this.getRequestBuilder);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import java.util.Set;
 
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -52,6 +53,7 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
 
     private SpaceService spaceService;
     private EngineService engine;
+    private EngineContentLoader engineContentLoader;
     private ObjectNode payload;
 
     @Before
@@ -60,6 +62,7 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
         super.setUp();
         this.spaceService = mock(SpaceService.class);
         this.engine = mock(EngineService.class);
+        this.engineContentLoader = mock(EngineContentLoader.class);
         this.payload = MAPPER.createObjectNode();
         this.payload.put("space", Space.STANDARD.toString());
     }
@@ -111,28 +114,33 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
         stubPromoteAsync(new RestResponse("OK", RestStatus.OK.getStatus()));
 
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+                this.engine,
+                this.spaceService,
+                Set.of(Space.STANDARD.toString()),
+                this.engineContentLoader);
 
         verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
 
     public void testSkipsReloadWhenStandardSpaceUnchanged() {
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, Set.of(Space.DRAFT.toString()));
+                this.engine, this.spaceService, Set.of(Space.DRAFT.toString()), this.engineContentLoader);
 
         verifyNoInteractions(this.spaceService);
         verifyNoInteractions(this.engine);
     }
 
     public void testSkipsReloadWhenNoSpaceChanged() {
-        TransportActionHelper.reloadStandardSpaceIntoEngine(this.engine, this.spaceService, Set.of());
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                this.engine, this.spaceService, Set.of(), this.engineContentLoader);
 
         verifyNoInteractions(this.spaceService);
         verifyNoInteractions(this.engine);
     }
 
     public void testSkipsReloadWhenChangedSpacesIsNull() {
-        TransportActionHelper.reloadStandardSpaceIntoEngine(this.engine, this.spaceService, null);
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                this.engine, this.spaceService, null, this.engineContentLoader);
 
         verifyNoInteractions(this.spaceService);
         verifyNoInteractions(this.engine);
@@ -141,7 +149,7 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
     /** A missing Engine must not build a payload, and must not fail the completed mutation. */
     public void testToleratesMissingEngine() {
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                null, this.spaceService, Set.of(Space.STANDARD.toString()));
+                null, this.spaceService, Set.of(Space.STANDARD.toString()), this.engineContentLoader);
 
         verifyNoInteractions(this.spaceService);
     }
@@ -155,7 +163,10 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
         stubPromoteAsync(new RestResponse("rejected", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
 
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+                this.engine,
+                this.spaceService,
+                Set.of(Space.STANDARD.toString()),
+                this.engineContentLoader);
 
         verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
@@ -165,7 +176,10 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
         stubPromoteAsyncFailure(new RuntimeException("socket unavailable"));
 
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+                this.engine,
+                this.spaceService,
+                Set.of(Space.STANDARD.toString()),
+                this.engineContentLoader);
 
         verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
@@ -184,7 +198,10 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
                 .buildEnginePayload(eq(Space.STANDARD.toString()), any(ActionListener.class));
 
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+                this.engine,
+                this.spaceService,
+                Set.of(Space.STANDARD.toString()),
+                this.engineContentLoader);
 
         verify(this.engine, never()).promoteAsync(any(JsonNode.class), any(ActionListener.class));
     }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.Client;
 import org.junit.Before;
 
 import java.util.Set;
@@ -54,6 +55,7 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
     private SpaceService spaceService;
     private EngineService engine;
     private EngineContentLoader engineContentLoader;
+    private Client client;
     private ObjectNode payload;
 
     @Before
@@ -63,6 +65,7 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
         this.spaceService = mock(SpaceService.class);
         this.engine = mock(EngineService.class);
         this.engineContentLoader = mock(EngineContentLoader.class);
+        this.client = mock(Client.class);
         this.payload = MAPPER.createObjectNode();
         this.payload.put("space", Space.STANDARD.toString());
     }
@@ -117,14 +120,19 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
                 this.engine,
                 this.spaceService,
                 Set.of(Space.STANDARD.toString()),
-                this.engineContentLoader);
+                this.engineContentLoader,
+                this.client);
 
         verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
 
     public void testSkipsReloadWhenStandardSpaceUnchanged() {
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, Set.of(Space.DRAFT.toString()), this.engineContentLoader);
+                this.engine,
+                this.spaceService,
+                Set.of(Space.DRAFT.toString()),
+                this.engineContentLoader,
+                this.client);
 
         verifyNoInteractions(this.spaceService);
         verifyNoInteractions(this.engine);
@@ -132,7 +140,7 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
 
     public void testSkipsReloadWhenNoSpaceChanged() {
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, Set.of(), this.engineContentLoader);
+                this.engine, this.spaceService, Set.of(), this.engineContentLoader, this.client);
 
         verifyNoInteractions(this.spaceService);
         verifyNoInteractions(this.engine);
@@ -140,7 +148,7 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
 
     public void testSkipsReloadWhenChangedSpacesIsNull() {
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                this.engine, this.spaceService, null, this.engineContentLoader);
+                this.engine, this.spaceService, null, this.engineContentLoader, this.client);
 
         verifyNoInteractions(this.spaceService);
         verifyNoInteractions(this.engine);
@@ -149,7 +157,11 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
     /** A missing Engine must not build a payload, and must not fail the completed mutation. */
     public void testToleratesMissingEngine() {
         TransportActionHelper.reloadStandardSpaceIntoEngine(
-                null, this.spaceService, Set.of(Space.STANDARD.toString()), this.engineContentLoader);
+                null,
+                this.spaceService,
+                Set.of(Space.STANDARD.toString()),
+                this.engineContentLoader,
+                this.client);
 
         verifyNoInteractions(this.spaceService);
     }
@@ -166,7 +178,8 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
                 this.engine,
                 this.spaceService,
                 Set.of(Space.STANDARD.toString()),
-                this.engineContentLoader);
+                this.engineContentLoader,
+                this.client);
 
         verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
@@ -179,7 +192,8 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
                 this.engine,
                 this.spaceService,
                 Set.of(Space.STANDARD.toString()),
-                this.engineContentLoader);
+                this.engineContentLoader,
+                this.client);
 
         verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
@@ -201,7 +215,8 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
                 this.engine,
                 this.spaceService,
                 Set.of(Space.STANDARD.toString()),
-                this.engineContentLoader);
+                this.engineContentLoader,
+                this.client);
 
         verify(this.engine, never()).promoteAsync(any(JsonNode.class), any(ActionListener.class));
     }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateFilterActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateFilterActionTests.java
@@ -50,6 +50,7 @@ import java.nio.charset.StandardCharsets;
 
 import com.wazuh.contentmanager.action.ContentCreateRequest;
 import com.wazuh.contentmanager.action.ContentResponse;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
@@ -91,7 +92,11 @@ public class TransportCreateFilterActionTests extends OpenSearchTestCase {
         when(transportService.getThreadPool()).thenReturn(threadPool);
         this.action =
                 new TransportCreateFilterAction(
-                        transportService, mock(ActionFilters.class), this.client, mock(EngineService.class));
+                        transportService,
+                        mock(ActionFilters.class),
+                        this.client,
+                        mock(EngineService.class),
+                        mock(EngineContentLoader.class));
     }
 
     @After

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportReloadEngineContentActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportReloadEngineContentActionTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import org.opensearch.Version;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.wazuh.contentmanager.action.ReloadEngineContentNodeResponse;
+import com.wazuh.contentmanager.action.ReloadEngineContentRequest;
+import com.wazuh.contentmanager.action.ReloadEngineContentResponse;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportReloadEngineContentActionTests extends OpenSearchTestCase {
+
+    private EngineContentLoader loader;
+    private ClusterService clusterService;
+    private DiscoveryNode localNode;
+    private TransportReloadEngineContentAction action;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.loader = mock(EngineContentLoader.class);
+        this.localNode = new DiscoveryNode("node-1", buildNewFakeTransportAddress(), Version.CURRENT);
+        this.clusterService = mock(ClusterService.class);
+        when(this.clusterService.getClusterName()).thenReturn(new ClusterName("test-cluster"));
+        when(this.clusterService.localNode()).thenReturn(this.localNode);
+        this.action =
+                new TransportReloadEngineContentAction(
+                        mock(ThreadPool.class),
+                        this.clusterService,
+                        mock(TransportService.class),
+                        mock(ActionFilters.class),
+                        this.loader);
+    }
+
+    /** The node handler delegates to the hash-gated loader and reports the local node. */
+    public void testNodeOperationTriggersReload() {
+        ReloadEngineContentNodeResponse response =
+                this.action.nodeOperation(new TransportReloadEngineContentAction.NodeRequest());
+
+        verify(this.loader, times(1)).reloadIfChanged();
+        assertEquals(this.localNode, response.getNode());
+    }
+
+    /** newResponse aggregates node responses under the cluster name. */
+    public void testNewResponseAggregatesNodes() {
+        ReloadEngineContentNodeResponse nodeResponse =
+                new ReloadEngineContentNodeResponse(this.localNode);
+
+        ReloadEngineContentResponse response =
+                this.action.newResponse(
+                        new ReloadEngineContentRequest(), List.of(nodeResponse), Collections.emptyList());
+
+        assertEquals("test-cluster", response.getClusterName().value());
+        assertEquals(1, response.getNodes().size());
+        assertEquals(this.localNode, response.getNodes().get(0).getNode());
+    }
+
+    /** The per-node response round-trips over the wire. */
+    public void testNodeResponseSerialization() throws Exception {
+        ReloadEngineContentNodeResponse original = new ReloadEngineContentNodeResponse(this.localNode);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        ReloadEngineContentNodeResponse read =
+                new ReloadEngineContentNodeResponse(out.bytes().streamInput());
+
+        assertEquals(this.localNode, read.getNode());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportTriggerUpdateActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportTriggerUpdateActionTests.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutorService;
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.action.TriggerUpdateRequest;
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
-import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -149,8 +148,7 @@ public class TransportTriggerUpdateActionTests extends OpenSearchTestCase {
                         mock(ConsumersIndex.class),
                         mock(Environment.class),
                         threadPool,
-                        mock(EngineService.class),
-                        mock(EngineContentLoader.class));
+                        mock(EngineService.class));
         TransportTriggerUpdateAction realAction =
                 new TransportTriggerUpdateAction(
                         mock(TransportService.class), mock(ActionFilters.class), realCatalogSyncJob);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportTriggerUpdateActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportTriggerUpdateActionTests.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutorService;
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.action.TriggerUpdateRequest;
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -148,7 +149,8 @@ public class TransportTriggerUpdateActionTests extends OpenSearchTestCase {
                         mock(ConsumersIndex.class),
                         mock(Environment.class),
                         threadPool,
-                        mock(EngineService.class));
+                        mock(EngineService.class),
+                        mock(EngineContentLoader.class));
         TransportTriggerUpdateAction realAction =
                 new TransportTriggerUpdateAction(
                         mock(TransportService.class), mock(ActionFilters.class), realCatalogSyncJob);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportTriggerUpdateActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportTriggerUpdateActionTests.java
@@ -37,6 +37,8 @@ import java.util.concurrent.ExecutorService;
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.action.TriggerUpdateRequest;
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
+import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
+import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -148,7 +150,9 @@ public class TransportTriggerUpdateActionTests extends OpenSearchTestCase {
                         mock(ConsumersIndex.class),
                         mock(Environment.class),
                         threadPool,
-                        mock(EngineService.class));
+                        mock(EngineService.class),
+                        mock(SpaceService.class),
+                        mock(SecurityAnalyticsService.class));
         TransportTriggerUpdateAction realAction =
                 new TransportTriggerUpdateAction(
                         mock(TransportService.class), mock(ActionFilters.class), realCatalogSyncJob);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.action.UpdatePolicyRequest;
+import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -90,6 +91,7 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
                         mock(ActionFilters.class),
                         this.spaceService,
                         engineService,
+                        mock(EngineContentLoader.class),
                         this.client);
 
         when(this.spaceService.getKnownEnrichmentTypes()).thenReturn(Collections.emptySet());


### PR DESCRIPTION
## Description
In a Wazuh cluster, Engine content was loaded into the elected cluster-manager's Engine only. Because each node runs its own Engine over a node-local Unix domain socket, engine-backed operations 
(e.g. `POST /_plugins/_content_manager/logtest`) only returned correct results when the request happened to be served by the manager. 
  
This affects two independent content flows, and this PR distributes the per-node Engine load for **both** — while keeping the operations that must stay centralized on a single node. The content itself already lives in the cluster-wide `wazuh-threatintel-*` indices; only the node-local Engine *load* was missing on the other nodes.
  
### 1. STANDARD space (after a catalog sync)
STANDARD content is refreshed by the catalog sync, which runs manager-only. After a sync, every node's local Engine now converges to the new STANDARD content. The external catalog fetch stays manager-only (a single external pull); only the Engine load becomes distributed.
  
### 2. TEST / CUSTOM spaces (after a promotion)
Promoted TEST/CUSTOM content was deployed only to the node that served the `POST /_plugins/_content_manager/promote` request. TEST and CUSTOM are shared, cluster-persisted, singleton spaces, so their Engine representation should be consistent on every node. After a promote, every node's local Engine now loads the consolidated content. The promote's validation gate and consolidation stay on the coordinating node; the other nodes self-load from the replicated indices afterwards (no re-validation).
  
### Shared mechanism: node-local load, cluster-wide trigger 
`engine.promote` is a node-local Unix socket and cannot be made a cluster-wide call, so the load stays per-node and is driven by a cluster-wide signal:
- A shared **`EngineContentLoader`** tracks the aggregate `space.hash.sha256` of `{standard, test, custom}` and loads a space into the local Engine only when its hash differs from what this node last loaded (hash-gated, single-flighted, in-memory).
- A per-node **`ClusterStateListener`** (registered on every node, outside the manager-only gate) drives the loader on cluster-state updates — this gives **convergence** for late/rejoining/new nodes and **self-healing retry** (a load that failed because the Engine was not ready is retried on a later event, no polling).
- A **`ReloadEngineContentAction`** nodes-broadcast provides **prompt** propagation to already-running nodes: it is fired after a catalog sync (STANDARD) and after a promote (TEST/CUSTOM), and each node runs the same hash-gated loader.

Closes # https://github.com/wazuh/wazuh-indexer-plugins/issues/1376

## Proposed Changes

All changes within `plugins/content-manager/`.
  
**Shared loader + broadcast**
- **New `cti/catalog/service/EngineContentLoader.java`** — node-local, hash-gated loader over the shared spaces `{standard, test, custom}`; single-flighted, records a space's hash only on `200 OK` so failed loads retry.
- **New `action/ReloadEngineContentAction`** (+ `ReloadEngineContentRequest`, `ReloadEngineContentNodeResponse`, `ReloadEngineContentResponse`) and **`transport/TransportReloadEngineContentAction`** — a `TransportNodesAction` that runs `reloadIfChanged()` on every node.
- **`utils/Constants.java`** — space-parameterized Engine-load log messages.
  
**STANDARD path (catalog sync)**
- **`ContentManagerPlugin`** — instantiates the shared loader; registers the `ClusterStateListener` on all nodes; performs an immediate load attempt on startup; registers the broadcast action.
- **`ConsumerRulesetService`** — fires the `ReloadEngineContentAction` broadcast after a content-changing sync (replacing its former direct `EngineService` dependency).
- **`CatalogSyncJob`** — consequential one-line update to the `ConsumerRulesetService` construction (dropped argument).
  
**TEST / CUSTOM path (promotion)**
- **`transport/TransportPostPromoteAction`** — after consolidation recomputes the target space's hash, fires the same `ReloadEngineContentAction` broadcast so every node loads the promoted TEST/CUSTOM content.
  
**Tests**
- **New** `EngineContentLoaderTests` (per-space hash-gated load, single-flight, non-OK retry, multi-space coverage) and `TransportReloadEngineContentActionTests` (node delegation, response aggregation, wire round-trip).
- **Updated** `ConsumerRulesetServiceTests`, `ContentManagerPluginTests`, `SpaceInitializationIT`.

### Results and Evidence
See comments:
- https://github.com/wazuh/wazuh-indexer-plugins/pull/1399#issuecomment-5047589224
- https://github.com/wazuh/wazuh-indexer-plugins/pull/1399#issuecomment-5049920410

### Artifacts Affected
**`wazuh-indexer-content-manager` plugin** (JAR)

### Configuration Changes
N/A

### Documentation Updates
N/A

### Tests Introduced

**New unit tests**
- `EngineContentLoaderTests` — the node-local loader: hash-gated load per space, single-flight collapse, `loadedHash` advanced only on 200 (non-OK is retried), null-policy / missing-hash skips, and multi-space coverage over `{standard, test, custom}` (all three load, only a changed space reloads, a space loads independently).
- `TransportReloadEngineContentActionTests` — the broadcast nodes-action: `nodeOperation` delegates to the loader and reports the local node, `newResponse` aggregates under the cluster name, and per-node response wire  round-trip.                                                                                                                                                                                                                    
                                                                                                                                                                                                                                   **Existing tests updated**                                                                                                                                               
  - `ConsumerRulesetServiceTests`, `CatalogSyncJobTests`, `TransportTriggerUpdateActionTests`, `ContentManagerPluginTests` , `SpaceInitializationIT`.              

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
