### PR TITLE
Set tag input default to false and revert bogus v5.0.0-rc1 references

### DIFF
--- a/.github/workflows/5_builderpackage_plugins.yml
+++ b/.github/workflows/5_builderpackage_plugins.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Resolve branches
         id: branches
-        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@5.0.0
         with:
           branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
@@ -89,7 +89,7 @@ jobs:
     needs: [branches, get-version]
     steps:
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: ${{ inputs.revision }}
@@ -112,7 +112,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-common-utils
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: ${{ inputs.revision }}
@@ -135,7 +135,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-alerting
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-security-analytics/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-security-analytics/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: ${{ inputs.revision }}

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -16,7 +16,7 @@ on:
         type: string
       tag:
         description: 'Set to true when this bump is preparing a tag release'
-        default: true
+        default: false
         required: false
         type: boolean
       issue-link:

--- a/.github/workflows/5_codequality_email.yml
+++ b/.github/workflows/5_codequality_email.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@v5.0.0-rc1
+      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@5.0.0
         with:
             email_domain: 'wazuh.com, @users.noreply.github.com'
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Resolve branches
         id: branches
-        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@5.0.0
         with:
           branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
@@ -67,7 +67,7 @@ jobs:
     needs: [branches, get-version]
     steps:
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0
@@ -89,7 +89,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-common-utils
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0
@@ -111,7 +111,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ github.run_id }}-alerting
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-security-analytics/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-security-analytics/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v7
       - name: Resolve branches
         id: branches
-        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@5.0.0
         with:
           branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
       - name: Get common-utils latest commit
@@ -72,7 +72,7 @@ jobs:
             m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_plugin_ref }}-${{ needs.branches.outputs.common_utils_sha }}-
       - name: Publish to Maven Local
         if: steps.cache-common-utils.outputs.cache-hit != 'true'
-        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0
@@ -110,7 +110,7 @@ jobs:
             m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_plugin_ref }}-
       - name: Publish to Maven Local
         if: steps.cache-alerting.outputs.cache-hit != 'true'
-        uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: ${{ inputs.revision }}
@@ -145,7 +145,7 @@ jobs:
             m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_plugin_ref }}-${{ needs.branches.outputs.common_utils_sha }}-
       - name: Publish to Maven Local
         if: steps.cache-security-analytics.outputs.cache-hit != 'true'
-        uses: wazuh/wazuh-indexer-security-analytics/.github/actions/5_local_maven_publisher@v5.0.0-rc1
+        uses: wazuh/wazuh-indexer-security-analytics/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0


### PR DESCRIPTION
## Description

The `tag` input in the bumper workflow defaulted to `true`, causing stage-only bumps to wrongly pin workflow references to a tag (`v5.0.0-rc1`) that doesn't exist yet. This PR sets the default to `false` and reverts those references back to `5.0.0`.

## Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1765
