### PR TITLE
Fix file descriptor leak in Content Manager catalog sync

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -50,7 +50,7 @@ import com.wazuh.contentmanager.settings.PluginSettings;
  * <p>This client manages an asynchronous HTTP client to perform requests against the catalog
  * service, specifically handling consumer context retrieval.
  */
-public class ApiClient {
+public class ApiClient implements AutoCloseable {
 
     private final String baseUri;
     private final ResourceUrlResolver urlResolver;
@@ -111,6 +111,7 @@ public class ApiClient {
     }
 
     /** Closes the underlying HTTP asynchronous client gracefully. */
+    @Override
     public void close() {
         this.client.close(CloseMode.GRACEFUL);
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ResourceUrlResolver.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ResourceUrlResolver.java
@@ -30,4 +30,10 @@ public interface ResourceUrlResolver {
      * @return the resolved URL to use for the request.
      */
     String resolve(String originalUrl);
+
+    /**
+     * Releases any resources held by this resolver (e.g. an HTTP client used to obtain signed URLs).
+     * No-op by default; implementations that own closeable resources should override it.
+     */
+    default void close() {}
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SignedUrlResolver.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SignedUrlResolver.java
@@ -61,4 +61,13 @@ public class SignedUrlResolver implements ResourceUrlResolver {
         PluginSettings.getInstance().setAccessToken(null);
         return originalUrl;
     }
+
+    /**
+     * Closes the underlying token-exchange service, releasing its HTTP client. Without this, the
+     * client's I/O reactor selectors leak file descriptors on every catalog sync (issue #1763).
+     */
+    @Override
+    public void close() {
+        this.tokenExchangeService.close();
+    }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -517,192 +517,61 @@ public abstract class AbstractConsumerService {
                                 catalogUri,
                                 this.consumersIndex,
                                 new ApiClient(urlResolver));
-        LocalConsumer localConsumer = consumerService.getLocalConsumer();
-        boolean catalogConfigured = catalogUri != null && !catalogUri.isBlank();
-        RemoteConsumer remoteConsumer = catalogConfigured ? consumerService.getRemoteConsumer() : null;
+        // The consumerService and urlResolver each own an HTTP client whose I/O reactor starts
+        // selector threads holding epoll/eventfd descriptors. They must be closed on every exit
+        // path (including exceptions) or the process leaks FDs on each sync (issue #1763). The
+        // injected test override is owned by the caller, so it must not be closed here.
+        boolean ownsConsumerService = this.consumerServiceOverride == null;
+        try {
+            LocalConsumer localConsumer = consumerService.getLocalConsumer();
+            boolean catalogConfigured = catalogUri != null && !catalogUri.isBlank();
+            RemoteConsumer remoteConsumer =
+                    catalogConfigured ? consumerService.getRemoteConsumer() : null;
 
-        // A configured catalog whose remote consumer could not be fetched signals an unreachable
-        // feed. The pass still completes (falling back to the local snapshot / applying no remote
-        // changes), but the caller retries so a transiently-blocked feed recovers immediately.
-        // getRemoteConsumer() swallows the network failure and returns null, so this is the only
-        // place the unreachable-feed condition is observable.
-        boolean feedUnreachable = catalogConfigured && remoteConsumer == null;
+            // A configured catalog whose remote consumer could not be fetched signals an unreachable
+            // feed. The pass still completes (falling back to the local snapshot / applying no remote
+            // changes), but the caller retries so a transiently-blocked feed recovers immediately.
+            // getRemoteConsumer() swallows the network failure and returns null, so this is the only
+            // place the unreachable-feed condition is observable.
+            boolean feedUnreachable = catalogConfigured && remoteConsumer == null;
 
-        Map<String, ContentIndex> indicesMap = new HashMap<>();
+            Map<String, ContentIndex> indicesMap = new HashMap<>();
 
-        for (Map.Entry<String, String> entry : this.getMappings().entrySet()) {
-            String indexName = this.getIndexName(entry.getKey());
-            ContentIndex index = new ContentIndex(this.client, indexName, entry.getValue());
-            indicesMap.put(entry.getKey(), index);
+            for (Map.Entry<String, String> entry : this.getMappings().entrySet()) {
+                String indexName = this.getIndexName(entry.getKey());
+                ContentIndex index = new ContentIndex(this.client, indexName, entry.getValue());
+                indicesMap.put(entry.getKey(), index);
 
-            // Check if index exists to avoid creation exception
-            boolean indexExists = this.client.admin().indices().prepareExists(indexName).get().isExists();
+                // Check if index exists to avoid creation exception
+                boolean indexExists =
+                        this.client.admin().indices().prepareExists(indexName).get().isExists();
 
-            if (!indexExists) {
-                try {
-                    // ContentIndex.createIndex() already logs the creation; avoid a duplicate here.
-                    index.createIndex();
-                } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                    log.error(Constants.E_LOG_INDEX_CREATE_FAILED, indexName, e.getMessage());
+                if (!indexExists) {
+                    try {
+                        // ContentIndex.createIndex() already logs the creation; avoid a duplicate here.
+                        index.createIndex();
+                    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                        log.error(Constants.E_LOG_INDEX_CREATE_FAILED, indexName, e.getMessage());
+                    }
                 }
             }
-        }
 
-        // When a plan change is detected, download into hidden shadow indices and atomically
-        // swap aliases. This avoids any window where users see empty/partial data.
-        if (shadowSwapRequired) {
-            if (!this.performShadowSwap(
-                    consumerType, catalogUri, swapTargetResource, indicesMap, remoteConsumer, urlResolver)) {
-                return new SyncResult(false, feedUnreachable);
-            }
-            // The swapped snapshot only carries data up to its snapshot offset. Close the gap to
-            // the remote head in the same pass; otherwise the consumer would be reported as READY
-            // while trailing the remote offset (local_offset < remote_offset) until the next sync.
-            if (remoteConsumer.getSnapshotOffset() < remoteConsumer.getOffset()) {
-                this.performIncrementalUpdate(
-                        context,
-                        consumer,
+            // When a plan change is detected, download into hidden shadow indices and atomically
+            // swap aliases. This avoids any window where users see empty/partial data.
+            if (shadowSwapRequired) {
+                if (!this.performShadowSwap(
                         consumerType,
                         catalogUri,
-                        urlResolver,
+                        swapTargetResource,
                         indicesMap,
-                        remoteConsumer.getSnapshotOffset(),
-                        remoteConsumer.getOffset());
-            }
-            return new SyncResult(true, feedUnreachable);
-        }
-
-        boolean updated = false;
-        long currentOffset = localConsumer != null ? localConsumer.getLocalOffset() : 0;
-
-        // Offset mismatch resilience
-        if (localConsumer != null && remoteConsumer != null) {
-            if (currentOffset > remoteConsumer.getOffset()) {
-                log.warn(
-                        Constants.W_LOG_LOCAL_OFFSET_EXCEEDS_REMOTE,
-                        currentOffset,
-                        remoteConsumer.getOffset(),
-                        consumerType);
-                currentOffset = 0;
-            }
-        }
-
-        if (currentOffset == 0) {
-            final Path localSnapshotPath = localSnapshot;
-            boolean snapshotExists;
-            if (localSnapshotPath == null) {
-                snapshotExists = false;
-            } else {
-                try {
-                    snapshotExists =
-                            AccessController.doPrivilegedChecked(() -> Files.exists(localSnapshotPath));
-                } catch (Exception e) {
-                    log.warn(Constants.W_LOG_LOCAL_SNAPSHOT_CHECK_FAILED, localSnapshotPath, e.getMessage());
-                    snapshotExists = false;
+                        remoteConsumer,
+                        urlResolver)) {
+                    return new SyncResult(false, feedUnreachable);
                 }
-            }
-
-            boolean hasEffectiveCatalog = catalogUri != null && !catalogUri.isBlank();
-
-            // t0: persist the initial consumer state (status=running, local_offset=0,
-            // remote_offset=<latest known>) before snapshot loading begins, so external observers
-            // can see the in-progress state. Identity fields come from the remote response when a
-            // catalog URL is available (either setting or existing doc's resource), otherwise from
-            // the manifest entry.
-            this.writeInitialConsumer(remoteConsumer, manifestEntry, catalogUri, consumerType);
-
-            SnapshotServiceImpl snapshotService =
-                    this.snapshotServiceOverride != null
-                            ? this.snapshotServiceOverride
-                            : new SnapshotServiceImpl(
-                                    consumerType, indicesMap, this.consumersIndex, this.environment, urlResolver);
-
-            // When a catalog URL is available, prefer remote initialization and fall back to local
-            // snapshot on failure. The catalog URL comes from the configured setting, or from a
-            // previous run's persisted `resource` when the setting is empty.
-            if (hasEffectiveCatalog
-                    && remoteConsumer != null
-                    && remoteConsumer.getSnapshotLink() != null) {
-                // Ruleset snapshots also affect Security Analytics/Space resources; other catalogs only
-                // clear indices.
-                if (this.isRulesetConsumer()) {
-                    try {
-                        SecurityAnalyticsService securityAnalyticsService =
-                                new SecurityAnalyticsServiceImpl(this.client);
-                        CompletableFuture<Void> sapFuture = new CompletableFuture<>();
-                        securityAnalyticsService.deleteSpaceResources(
-                                Space.STANDARD,
-                                ActionListener.wrap(
-                                        r -> sapFuture.complete(null), sapFuture::completeExceptionally));
-                        sapFuture.get(60, TimeUnit.SECONDS);
-
-                        SpaceService spaceService = new SpaceService(this.client);
-                        CompletableFuture<Void> spaceFuture = new CompletableFuture<>();
-                        spaceService.deleteSpaceResources(
-                                Space.STANDARD,
-                                ActionListener.wrap(
-                                        r -> spaceFuture.complete(null), spaceFuture::completeExceptionally));
-                        spaceFuture.get(60, TimeUnit.SECONDS);
-                    } catch (Exception e) {
-                        log.error(Constants.E_LOG_CLEAR_RESOURCES_FAILED, consumerType, e.getMessage());
-                    }
-                } else {
-                    indicesMap.values().forEach(ContentIndex::clear);
-                }
-
-                log.debug(Constants.D_LOG_SNAPSHOT_INIT_CUSTOM_URL, catalogUri);
-                boolean remoteSuccess = snapshotService.initialize(remoteConsumer);
-                if (remoteSuccess) {
-                    currentOffset = remoteConsumer.getSnapshotOffset();
-                    updated = true;
-                    if (snapshotExists) {
-                        SnapshotServiceImpl.deleteSnapshot(localSnapshot);
-                    }
-                } else if (snapshotExists) {
-                    log.warn(Constants.W_LOG_REMOTE_SNAPSHOT_FAILED_FALLBACK, consumerType, localSnapshot);
-                    boolean localSuccess = snapshotService.initialize(localSnapshot, manifestEntry);
-                    if (localSuccess) {
-                        currentOffset = snapshotService.getMaxOffsetSeen();
-                        updated = true;
-                    } else {
-                        log.warn(Constants.W_LOG_LOCAL_SNAPSHOT_FALLBACK_FAILED, consumerType);
-                    }
-                } else {
-                    log.warn(Constants.W_LOG_REMOTE_SNAPSHOT_FAILED_NO_LOCAL, consumerType, localSnapshot);
-                }
-            } else if (snapshotExists) {
-                if (hasEffectiveCatalog) {
-                    // Catalog URL was set but the remote attempt did not yield a usable response
-                    // (invalid URL, network failure, missing snapshot link). Fall back to the
-                    // packaged local snapshot.
-                    log.warn(
-                            Constants.W_LOG_CATALOG_UNREACHABLE_FALLBACK,
-                            catalogUri,
-                            consumerType,
-                            localSnapshot.getFileName());
-                } else {
-                    log.debug(
-                            Constants.D_LOG_INIT_FROM_LOCAL_SNAPSHOT, consumerType, localSnapshot.getFileName());
-                }
-                boolean localSuccess = snapshotService.initialize(localSnapshot, manifestEntry);
-                if (localSuccess) {
-                    currentOffset = snapshotService.getMaxOffsetSeen();
-                    updated = true;
-                } else {
-                    log.error(Constants.E_LOG_LOCAL_SNAPSHOT_INIT_FAILED, consumerType);
-                }
-            } else if (hasEffectiveCatalog) {
-                log.error(
-                        Constants.E_LOG_INIT_FAILED_NO_LOCAL_NO_REMOTE_REACH, consumerType, localSnapshot);
-            } else {
-                log.error(
-                        Constants.E_LOG_INIT_FAILED_NO_LOCAL_NO_REMOTE_CONFIG, consumerType, localSnapshot);
-            }
-        }
-
-        // Incremental Update
-        if (remoteConsumer != null && currentOffset < remoteConsumer.getOffset()) {
-            updated =
+                // The swapped snapshot only carries data up to its snapshot offset. Close the gap to
+                // the remote head in the same pass; otherwise the consumer would be reported as READY
+                // while trailing the remote offset (local_offset < remote_offset) until the next sync.
+                if (remoteConsumer.getSnapshotOffset() < remoteConsumer.getOffset()) {
                     this.performIncrementalUpdate(
                             context,
                             consumer,
@@ -710,10 +579,164 @@ public abstract class AbstractConsumerService {
                             catalogUri,
                             urlResolver,
                             indicesMap,
-                            currentOffset,
+                            remoteConsumer.getSnapshotOffset(),
                             remoteConsumer.getOffset());
+                }
+                return new SyncResult(true, feedUnreachable);
+            }
+
+            boolean updated = false;
+            long currentOffset = localConsumer != null ? localConsumer.getLocalOffset() : 0;
+
+            // Offset mismatch resilience
+            if (localConsumer != null && remoteConsumer != null) {
+                if (currentOffset > remoteConsumer.getOffset()) {
+                    log.warn(
+                            Constants.W_LOG_LOCAL_OFFSET_EXCEEDS_REMOTE,
+                            currentOffset,
+                            remoteConsumer.getOffset(),
+                            consumerType);
+                    currentOffset = 0;
+                }
+            }
+
+            if (currentOffset == 0) {
+                final Path localSnapshotPath = localSnapshot;
+                boolean snapshotExists;
+                if (localSnapshotPath == null) {
+                    snapshotExists = false;
+                } else {
+                    try {
+                        snapshotExists =
+                                AccessController.doPrivilegedChecked(() -> Files.exists(localSnapshotPath));
+                    } catch (Exception e) {
+                        log.warn(
+                                Constants.W_LOG_LOCAL_SNAPSHOT_CHECK_FAILED, localSnapshotPath, e.getMessage());
+                        snapshotExists = false;
+                    }
+                }
+
+                boolean hasEffectiveCatalog = catalogUri != null && !catalogUri.isBlank();
+
+                // t0: persist the initial consumer state (status=running, local_offset=0,
+                // remote_offset=<latest known>) before snapshot loading begins, so external observers
+                // can see the in-progress state. Identity fields come from the remote response when a
+                // catalog URL is available (either setting or existing doc's resource), otherwise from
+                // the manifest entry.
+                this.writeInitialConsumer(remoteConsumer, manifestEntry, catalogUri, consumerType);
+
+                SnapshotServiceImpl snapshotService =
+                        this.snapshotServiceOverride != null
+                                ? this.snapshotServiceOverride
+                                : new SnapshotServiceImpl(
+                                        consumerType, indicesMap, this.consumersIndex, this.environment, urlResolver);
+
+                // When a catalog URL is available, prefer remote initialization and fall back to local
+                // snapshot on failure. The catalog URL comes from the configured setting, or from a
+                // previous run's persisted `resource` when the setting is empty.
+                if (hasEffectiveCatalog
+                        && remoteConsumer != null
+                        && remoteConsumer.getSnapshotLink() != null) {
+                    // Ruleset snapshots also affect Security Analytics/Space resources; other catalogs only
+                    // clear indices.
+                    if (this.isRulesetConsumer()) {
+                        try {
+                            SecurityAnalyticsService securityAnalyticsService =
+                                    new SecurityAnalyticsServiceImpl(this.client);
+                            CompletableFuture<Void> sapFuture = new CompletableFuture<>();
+                            securityAnalyticsService.deleteSpaceResources(
+                                    Space.STANDARD,
+                                    ActionListener.wrap(
+                                            r -> sapFuture.complete(null), sapFuture::completeExceptionally));
+                            sapFuture.get(60, TimeUnit.SECONDS);
+
+                            SpaceService spaceService = new SpaceService(this.client);
+                            CompletableFuture<Void> spaceFuture = new CompletableFuture<>();
+                            spaceService.deleteSpaceResources(
+                                    Space.STANDARD,
+                                    ActionListener.wrap(
+                                            r -> spaceFuture.complete(null), spaceFuture::completeExceptionally));
+                            spaceFuture.get(60, TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            log.error(Constants.E_LOG_CLEAR_RESOURCES_FAILED, consumerType, e.getMessage());
+                        }
+                    } else {
+                        indicesMap.values().forEach(ContentIndex::clear);
+                    }
+
+                    log.debug(Constants.D_LOG_SNAPSHOT_INIT_CUSTOM_URL, catalogUri);
+                    boolean remoteSuccess = snapshotService.initialize(remoteConsumer);
+                    if (remoteSuccess) {
+                        currentOffset = remoteConsumer.getSnapshotOffset();
+                        updated = true;
+                        if (snapshotExists) {
+                            SnapshotServiceImpl.deleteSnapshot(localSnapshot);
+                        }
+                    } else if (snapshotExists) {
+                        log.warn(Constants.W_LOG_REMOTE_SNAPSHOT_FAILED_FALLBACK, consumerType, localSnapshot);
+                        boolean localSuccess = snapshotService.initialize(localSnapshot, manifestEntry);
+                        if (localSuccess) {
+                            currentOffset = snapshotService.getMaxOffsetSeen();
+                            updated = true;
+                        } else {
+                            log.warn(Constants.W_LOG_LOCAL_SNAPSHOT_FALLBACK_FAILED, consumerType);
+                        }
+                    } else {
+                        log.warn(Constants.W_LOG_REMOTE_SNAPSHOT_FAILED_NO_LOCAL, consumerType, localSnapshot);
+                    }
+                } else if (snapshotExists) {
+                    if (hasEffectiveCatalog) {
+                        // Catalog URL was set but the remote attempt did not yield a usable response
+                        // (invalid URL, network failure, missing snapshot link). Fall back to the
+                        // packaged local snapshot.
+                        log.warn(
+                                Constants.W_LOG_CATALOG_UNREACHABLE_FALLBACK,
+                                catalogUri,
+                                consumerType,
+                                localSnapshot.getFileName());
+                    } else {
+                        log.debug(
+                                Constants.D_LOG_INIT_FROM_LOCAL_SNAPSHOT,
+                                consumerType,
+                                localSnapshot.getFileName());
+                    }
+                    boolean localSuccess = snapshotService.initialize(localSnapshot, manifestEntry);
+                    if (localSuccess) {
+                        currentOffset = snapshotService.getMaxOffsetSeen();
+                        updated = true;
+                    } else {
+                        log.error(Constants.E_LOG_LOCAL_SNAPSHOT_INIT_FAILED, consumerType);
+                    }
+                } else if (hasEffectiveCatalog) {
+                    log.error(
+                            Constants.E_LOG_INIT_FAILED_NO_LOCAL_NO_REMOTE_REACH, consumerType, localSnapshot);
+                } else {
+                    log.error(
+                            Constants.E_LOG_INIT_FAILED_NO_LOCAL_NO_REMOTE_CONFIG, consumerType, localSnapshot);
+                }
+            }
+
+            // Incremental Update
+            if (remoteConsumer != null && currentOffset < remoteConsumer.getOffset()) {
+                updated =
+                        this.performIncrementalUpdate(
+                                context,
+                                consumer,
+                                consumerType,
+                                catalogUri,
+                                urlResolver,
+                                indicesMap,
+                                currentOffset,
+                                remoteConsumer.getOffset());
+            }
+            return new SyncResult(updated, feedUnreachable);
+        } finally {
+            if (ownsConsumerService) {
+                consumerService.close();
+            }
+            // SignedUrlResolver closes its token-exchange client; RegularUrlResolver.close() is a no-op.
+            urlResolver.close();
         }
-        return new SyncResult(updated, feedUnreachable);
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, Wazuh Inc.
+ * Copyright (C) 2024-2026, Wazuh Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -35,4 +35,10 @@ public interface ConsumerService {
      * @return The {@link RemoteConsumer} object representing the remote state.
      */
     RemoteConsumer getRemoteConsumer();
+
+    /**
+     * Releases resources held by this service, in particular the underlying HTTP client whose I/O
+     * reactor otherwise leaks file descriptors. Must be called once the service is no longer needed.
+     */
+    void close();
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportVersionCheckAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportVersionCheckAction.java
@@ -86,8 +86,12 @@ public class TransportVersionCheckAction
             }
 
             String tag = "v" + version;
-            ApiClient apiClient = new ApiClient();
-            SimpleHttpResponse ctiResponse = apiClient.getReleaseUpdates(tag);
+            // The ApiClient starts an I/O reactor (selector threads holding epoll/eventfd FDs);
+            // close it on every path to avoid leaking descriptors per request (issue #1763).
+            SimpleHttpResponse ctiResponse;
+            try (ApiClient apiClient = new ApiClient()) {
+                ctiResponse = apiClient.getReleaseUpdates(tag);
+            }
 
             int ctiStatusCode = ctiResponse.getCode();
             if (ctiStatusCode < 200 || ctiStatusCode >= 300) {


### PR DESCRIPTION
## Description

Fixes the file-descriptor leak reported in wazuh/wazuh-indexer#1763, where the `wazuh-indexer` process FD count climbs linearly (~+25 FD/h, 128 → 1613 over a 24h performance test) and never recovers.

Root cause: the Content Manager creates HttpClient5 `CloseableHttpAsyncClient` instances that are never closed. Each client starts an I/O reactor whose selector threads hold one `epoll` FD plus one `eventfd` per CPU, and those threads live forever once started. The clients are created per catalog sync pass (`CatalogSyncJob`, 3 consumers) and per on-demand `POST /_plugins/_content_manager/update` or `GET /version/check`, so descriptors accumulate permanently.

> **Reviewer note — scope reduced by #1391.** PR #1391 ("Keep last working snapshot") merged into
> `5.0.0` while this PR was open and independently closed the same clients at the same call sites —
> in fact at two *more* sites than this branch originally covered (`UpdateServiceImpl` and `PlansServiceImpl`). 
> The merge commit in this branch therefore takes #1391's version of `AbstractConsumerService` wholesale, 
> preserving its new three-tier snapshot fallback. What remains here is the `AutoCloseable` plumbing plus close 
> hooks that #1391 does not use. See "Proposed Changes" for exactly what is still live. If the team prefers, this PR
> can be closed as superseded and reduced to the `AutoCloseable` change plus a CHANGELOG entry.

> Metrics can be obtained running:
> 
> ```console
> PID=$(pgrep -f org.opensearch.bootstrap.OpenSearch | head -1)
> 
> sudo ls -l /proc/$PID/fd | awk '/ -> /{t++} /eventpoll/{e++} /\[eventfd\]/{f++} \
>   END{printf "total=%d epoll=%d eventfd=%d\n", t, e, f}'
> ```




### Proposed Changes

Net diff against `5.0.0` is 27 insertions / 6 deletions across 5 files:

| File | Change | Status |
|---|---|---|
| `cti/catalog/client/ApiClient.java` | `implements AutoCloseable`, `@Override` on `close()` | **Live** — enables try-with-resources and guards future `new ApiClient()` call sites |
| `transport/TransportVersionCheckAction.java` | `try { … } finally { apiClient.close(); }` → `try (ApiClient apiClient = new ApiClient())` | **Live** — same semantics as #1391, less code |
| `cti/catalog/client/ResourceUrlResolver.java` | default no-op `close()` | Unreferenced — #1391 closes `TokenExchangeServiceImpl` directly |
| `cti/catalog/client/SignedUrlResolver.java` | `close()` override releasing the token-exchange client | Unreferenced — same reason |
| `cti/catalog/service/ConsumerService.java` | declares `close()` on the interface | Unreferenced — #1391 uses the concrete `ConsumerServiceImpl` type |

The unreferenced hooks compile and test clean (`ConsumerServiceImpl` satisfies `close()` via
`AbstractService`; tests use Mockito mocks), and they express the ownership contract at the
interface rather than at the call site. They are dead code today, and dropping them is reasonable.

Also included: merge commit resolving conflicts with #1391 in `AbstractConsumerService.java` and
`TransportVersionCheckAction.java`.

### Results and Evidence

**Live validation — metric is `epoll` + `eventfd` FD count on the indexer PID (the leaked reactor
selectors). `socket:` counts churn and self-heal; `epoll`/`efd` is the leak signal.**

Pre-fix signature, single-node AIO VM, 30s/5min sampler:

```
16:44 idle       total=818 sock=28 epoll=12 efd=12   <- clean baseline
16:59 sync#1     total=874 sock=46 epoll=28 efd=28
17:04 passes     total=882 sock=43 epoll=32 efd=32
18:05 +50m idle  total=870 sock=38 epoll=30 efd=30   <- NO recovery over 50 min idle
18:10 sched job  total=897 sock=44 epoll=42 efd=42   <- hourly CatalogSyncJob, no user action
=> monotonic 12 -> 42 over ~1.5h, never released. ~+16 epoll+efd per full sync pass.
```

Post-fix, 2-node cluster, ~37 min run:

- Free/unregistered, 5× `POST /update` on each node: `epoll`/`efd` **flat 6/6**, no bump.
- Node-1 switched to Pro (exercises `SignedUrlResolver` + token-exchange path, the heavier site), 3 manual passes + on-failure retry churn: rose to 12 during active downloads (461 MB vulnerability snapshot + ruleset shadow indices), **reclaimed to 6 when idle**. Over the full run node-1 took only the values {6, 10, 12} — 22 samples at idle 6, never above 12.
- Node-2 **flat 6/6 across all 75 samples** (0 variance), confirming the sync ran only on the receiving node.
- Notably, repeated *failing* passes (a pre-existing shadow-swap alias bug, unrelated to this issue) drove the exception path repeatedly and descriptors still stayed bounded and reclaimed — evidence the `finally` closes clients on exception paths too, not just clean returns.

#### Verdict: descriptors are released when no longer needed and stay bounded across repeated passes. Acceptance criteria met.


**Re-run on the merged build (this branch + #1391), single-node AIO, 30s sampler:**

```
-- startup bootstrap sync, full 3-consumer download (from indexer log) --
18:48:56  ruleset      snapshot downloaded + 124 integrations / 158 rules / 14 detectors ingested
18:49:15  iocs         snapshot downloaded + engine notified
18:50:09  vulnerabilities snapshot downloaded (595699_*.zip)
18:54:53  post-bootstrap baseline    total=809 sock=34 epoll=6 efd=6   <- back to clean after full sync

-- cycle 1: POST /update (202) at 18:55 --
18:55:26  total=817 sock=33 epoll=6 efd=6
18:58:26  total=828 sock=34 epoll=6 efd=6   settled, max epoll/efd over window = 6

-- cycle 2: POST /update (202) at 18:58:54 --
18:58:56  total=831 sock=35 epoll=8 efd=8   <- client created, reactor up
18:59:27  total=829 sock=34 epoll=6 efd=6   <- RECLAIMED
19:00:27  total=833 sock=35 epoll=6 efd=6
```

The cycle-2 `6 → 8 → 6` excursion is the fix observable in a single pass: the reactor starts, then its descriptors are released. Pre-fix, that same step was permanent and cumulative (`+16` per full pass, `12 → 42` over 1.5h).


**Re-run 07-27-2026, single-node AIO, more than 2 hs**

<img width="950" height="790" alt="image" src="https://github.com/user-attachments/assets/f572e65e-48c9-43f9-95d3-e256553db26b" />

Changed subscription to Pro:
<img width="850" height="599" alt="image" src="https://github.com/user-attachments/assets/ab83c371-f8a5-48ef-b355-3a376b23f91d" />


### Artifacts Affected
- `wazuh-indexer-content-manager` plugin JAR (`wazuh-indexer-content-manager-<version>.jar`).

### Configuration Changes
**None.** 

### Documentation Updates
**None.** 

### Tests Introduced
**None.** 

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
