### PR TITLE
Reduce iocs and ruleset memory footprint

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -16,6 +16,7 @@
  */
 package com.wazuh.contentmanager.cti.catalog.index;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -487,13 +488,11 @@ public class ContentIndex {
         }
 
         // 3. Process
-        ObjectNode processedDoc = this.processPayload(currentDoc);
+        String processedJson = this.processPayloadToString(currentDoc);
 
         // 4. Index
         IndexRequest request =
-                new IndexRequest(this.getWriteIndex())
-                        .id(id)
-                        .source(processedDoc.toString(), XContentType.JSON);
+                new IndexRequest(this.getWriteIndex()).id(id).source(processedJson, XContentType.JSON);
         this.client.index(request).get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
     }
 
@@ -560,11 +559,11 @@ public class ContentIndex {
             }
             patchTarget.put(Constants.KEY_OFFSET, task.offset());
 
-            ObjectNode processedDoc = this.processPayload(patchTarget);
+            String processedJson = this.processPayloadToString(patchTarget);
             bulkRequest.add(
                     new IndexRequest(this.getWriteIndex())
                             .id(task.id())
-                            .source(processedDoc.toString(), XContentType.JSON));
+                            .source(processedJson, XContentType.JSON));
 
             if (bulkRequest.estimatedSizeInBytes() >= maxBytes) {
                 this.executeBulkUpdate(bulkRequest, timeout);
@@ -850,6 +849,59 @@ public class ContentIndex {
         } catch (Exception e) {
             log.error(Constants.E_LOG_PROCESS_PAYLOAD_FAILED, e.getMessage(), e);
             return MAPPER.createObjectNode();
+        }
+    }
+
+    /**
+     * Same transformation as {@link #processPayload} but serializes directly to a JSON string,
+     * avoiding the intermediate {@link ObjectNode} tree allocation.
+     *
+     * @param payload The JSON payload to process.
+     * @return The processed payload as a JSON string, or an empty JSON object on failure.
+     */
+    public String processPayloadToString(JsonNode payload) {
+        try {
+            Resource resource;
+            switch (this.indexName) {
+                case Constants.INDEX_IOCS:
+                    Ioc ioc = Ioc.fromPayload(payload);
+                    return MAPPER.writeValueAsString(ioc);
+                case Constants.INDEX_DECODERS:
+                    resource = Decoder.fromPayload(payload);
+                    break;
+                case Constants.INDEX_KVDBS:
+                    resource = Kvdb.fromPayload(payload);
+                    break;
+                case Constants.INDEX_FILTERS:
+                    resource = Filter.fromPayload(payload);
+                    break;
+                case Constants.INDEX_POLICIES:
+                    resource = Resource.fromPayload(payload);
+                    if (payload.has(Constants.KEY_DOCUMENT)) {
+                        Policy policy = Policy.fromPayload(payload.get(Constants.KEY_DOCUMENT));
+                        ObjectNode policyNode = MAPPER.valueToTree(policy);
+                        Resource.nestMetadataFields(policyNode);
+                        resource.setDocument(policyNode);
+                        java.util.Map<String, String> hashMap = new java.util.HashMap<>();
+                        hashMap.put(Constants.KEY_SHA256, Resource.computeSha256(policyNode.toString()));
+                        resource.setHash(hashMap);
+                    }
+                    break;
+                case Constants.INDEX_CVES:
+                    Cve cve = Cve.fromPayload(payload);
+                    return MAPPER.writeValueAsString(cve);
+                default:
+                    resource = Resource.fromPayload(payload);
+                    break;
+            }
+
+            return MAPPER.writeValueAsString(resource);
+        } catch (JsonProcessingException e) {
+            log.error(Constants.E_LOG_PROCESS_PAYLOAD_FAILED, e.getMessage(), e);
+            return "{}";
+        } catch (Exception e) {
+            log.error(Constants.E_LOG_PROCESS_PAYLOAD_FAILED, e.getMessage(), e);
+            return "{}";
         }
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Decoder.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Decoder.java
@@ -60,16 +60,14 @@ public class Decoder extends Resource {
      */
     public static Decoder fromPayload(JsonNode payload) {
         Decoder decoder = new Decoder();
-        // 1. Basic logic for every resource
-        Resource resource = new Resource();
-        resource.populateResource(decoder, payload);
 
-        // 2. Decoder-specific logic (YAML generation)
+        // YAML from the raw document before in-place mutations
         if (payload.has(Constants.KEY_DOCUMENT)) {
             JsonNode docNode = payload.get(Constants.KEY_DOCUMENT);
             decoder.setYaml(YamlUtils.toYaml(docNode, DECODER_ORDER_KEYS));
         }
 
+        new Resource().populateResourceInPlace(decoder, payload);
         return decoder;
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Filter.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Filter.java
@@ -41,12 +41,12 @@ public class Filter extends Resource {
      */
     public static Filter fromPayload(JsonNode payload) {
         Filter filter = new Filter();
-        new Resource().populateResource(filter, payload);
 
         if (payload.has(Constants.KEY_DOCUMENT)) {
             filter.setYaml(YamlUtils.toYaml(payload.get(Constants.KEY_DOCUMENT)));
         }
 
+        new Resource().populateResourceInPlace(filter, payload);
         return filter;
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Ioc.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Ioc.java
@@ -56,7 +56,8 @@ public class Ioc {
      * @param payload The raw JSON object containing the IoC data.
      * @return A fully populated Ioc instance.
      */
-    public static Ioc fromPayload(JsonNode payload) {
+    public static Ioc fromPayload(JsonNode payload)
+            throws com.fasterxml.jackson.core.JsonProcessingException {
         Long offsetValue = null;
         if (payload.has(Constants.KEY_OFFSET)) {
             offsetValue = payload.get(Constants.KEY_OFFSET).asLong();
@@ -69,7 +70,7 @@ public class Ioc {
             ((ObjectNode) payload).remove(Constants.KEY_TYPE);
         }
 
-        Ioc ioc = Ioc.MAPPER.convertValue(payload, Ioc.class);
+        Ioc ioc = Ioc.MAPPER.treeToValue(payload, Ioc.class);
         ioc.setOffset(offsetValue);
         if (payload.has(Constants.KEY_DOCUMENT)) {
             String sha256 = Resource.computeSha256(payload.get(Constants.KEY_DOCUMENT).toString());

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Kvdb.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Kvdb.java
@@ -41,12 +41,12 @@ public class Kvdb extends Resource {
      */
     public static Kvdb fromPayload(JsonNode payload) {
         Kvdb kvdb = new Kvdb();
-        new Resource().populateResource(kvdb, payload);
 
         if (payload.has(Constants.KEY_DOCUMENT)) {
             kvdb.setYaml(YamlUtils.toYaml(payload.get(Constants.KEY_DOCUMENT)));
         }
 
+        new Resource().populateResourceInPlace(kvdb, payload);
         return kvdb;
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/Resource.java
@@ -154,6 +154,36 @@ public class Resource {
         this.populateSpaceObject(resource, payload);
     }
 
+    /**
+     * Same as {@link #populateResource} but mutates the document node in place instead of
+     * deep-copying it. Callers that need the original document (e.g. for YAML generation) must
+     * capture it before calling this method.
+     */
+    protected void populateResourceInPlace(Resource resource, JsonNode payload) {
+        if (payload.has(Constants.KEY_OFFSET)) {
+            resource.setOffset(payload.get(Constants.KEY_OFFSET).asLong());
+            if (payload.isObject()) {
+                ((ObjectNode) payload).remove(Constants.KEY_OFFSET);
+            }
+        }
+
+        if (payload.has(JSON_DOCUMENT_KEY) && payload.get(JSON_DOCUMENT_KEY).isObject()) {
+            ObjectNode rawDoc = (ObjectNode) payload.get(JSON_DOCUMENT_KEY);
+            Resource.preprocessDocument(rawDoc);
+            Resource.nestMetadataFields(rawDoc);
+
+            resource.setDocument(rawDoc);
+
+            String hashStr = Resource.computeSha256(rawDoc.toString());
+            if (!hashStr.isEmpty()) {
+                Map<String, String> hashMap = new HashMap<>();
+                hashMap.put("sha256", hashStr);
+                resource.setHash(hashMap);
+            }
+        }
+        this.populateSpaceObject(resource, payload);
+    }
+
     private void populateSpaceObject(Resource resource, JsonNode payload) {
         Map<String, Object> spaceMap = new HashMap<>();
         String spaceName = Space.STANDARD.toString();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -317,8 +317,7 @@ public class SnapshotServiceImpl implements SnapshotService {
                         if (Constants.KEY_CVES.equals(type) && cveType != null) {
                             syntheticPayload.put(Constants.KEY_TYPE, cveType);
                         }
-                        ObjectNode processedPayload = indexHandler.processPayload(syntheticPayload);
-                        sourceJson = processedPayload.toString();
+                        sourceJson = indexHandler.processPayloadToString(syntheticPayload);
                     }
 
                     IndexRequest indexRequest =
@@ -327,6 +326,7 @@ public class SnapshotServiceImpl implements SnapshotService {
                                     .id(envelope.resourceName);
 
                     bulkRequest.add(indexRequest);
+                    envelope = null;
                     docCount++;
 
                     if (docCount >= this.pluginSettings.getMaxItemsPerBulk()

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/IocTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/IocTests.java
@@ -50,7 +50,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test fromPayload with a complete IoC payload matching the CTI structure. */
-    public void testFromPayload_CompletePayload() {
+    public void testFromPayload_CompletePayload() throws Exception {
         // Arrange
         ObjectNode payload = this.buildCompletePayload();
 
@@ -92,7 +92,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test that offset is extracted from the payload and stored at root level. */
-    public void testFromPayload_OffsetExtracted() {
+    public void testFromPayload_OffsetExtracted() throws Exception {
         // Arrange
         ObjectNode payload = this.buildCompletePayload();
         payload.put("offset", 42L);
@@ -106,7 +106,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test that offset is serialized at the root level in the output JSON. */
-    public void testFromPayload_OffsetSerializedAtRoot() {
+    public void testFromPayload_OffsetSerializedAtRoot() throws Exception {
         // Arrange
         ObjectNode payload = this.buildCompletePayload();
         payload.put("offset", 99L);
@@ -121,7 +121,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test that offset is null when not present in the payload. */
-    public void testFromPayload_OffsetNullWhenMissing() {
+    public void testFromPayload_OffsetNullWhenMissing() throws Exception {
         // Arrange
         ObjectNode payload = this.buildCompletePayload();
 
@@ -137,7 +137,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test that serializing an Ioc back to JSON produces the correct nested structure. */
-    public void testRoundTrip_SerializationPreservesNestedStructure() {
+    public void testRoundTrip_SerializationPreservesNestedStructure() throws Exception {
         // Arrange
         ObjectNode payload = this.buildCompletePayload();
 
@@ -163,7 +163,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test fromPayload with null values for optional fields. */
-    public void testFromPayload_NullOptionalFields() {
+    public void testFromPayload_NullOptionalFields() throws Exception {
         // Arrange
         ObjectNode document = this.mapper.createObjectNode();
         document.put("id", "12345");
@@ -189,7 +189,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test fromPayload with an empty document. */
-    public void testFromPayload_EmptyDocument() {
+    public void testFromPayload_EmptyDocument() throws Exception {
         // Arrange
         ObjectNode payload = this.mapper.createObjectNode();
         payload.set("document", this.mapper.createObjectNode());
@@ -219,9 +219,9 @@ public class IocTests extends OpenSearchTestCase {
         payload.set("document", document);
 
         // Act & Assert
-        IllegalArgumentException exception =
+        com.fasterxml.jackson.core.JsonProcessingException exception =
                 expectThrows(
-                        IllegalArgumentException.class,
+                        com.fasterxml.jackson.core.JsonProcessingException.class,
                         () -> {
                             Ioc.fromPayload(payload);
                         });
@@ -230,7 +230,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test fromPayload with minimal payload (only required structure). */
-    public void testFromPayload_MinimalPayload() {
+    public void testFromPayload_MinimalPayload() throws Exception {
         // Arrange
         ObjectNode payload = this.mapper.createObjectNode();
 
@@ -243,7 +243,7 @@ public class IocTests extends OpenSearchTestCase {
     }
 
     /** Test that confidence is deserialized as Long. */
-    public void testFromPayload_ConfidenceAsLong() {
+    public void testFromPayload_ConfidenceAsLong() throws Exception {
         // Arrange
         ObjectNode document = this.mapper.createObjectNode();
         document.put("id", "1");

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -120,9 +120,8 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
                         "cti:catalog:consumer:ruleset", indicesMap, this.consumersIndex, this.environment);
         this.snapshotService.setSnapshotClient(this.snapshotClient);
 
-        // Updated matchers to use JsonNode instead of JsonObject
-        when(this.contentIndexMock.processPayload(any(JsonNode.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(this.contentIndexMock.processPayloadToString(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0, JsonNode.class).toString());
         when(this.contentIndexMock.getWriteIndex()).thenReturn(".test-context-test-consumer-kvdb");
     }
 
@@ -215,7 +214,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
 
         // Assert
         verify(this.contentIndexMock, never()).clear();
-        verify(this.contentIndexMock).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock).processPayloadToString(any(JsonNode.class));
         ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(this.contentIndexMock, atLeastOnce()).executeBulk(bulkCaptor.capture());
 
@@ -265,7 +264,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         this.snapshotService.initialize(this.remoteConsumer);
 
         // Assert
-        verify(this.contentIndexMock).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock).processPayloadToString(any(JsonNode.class));
         ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(this.contentIndexMock).executeBulk(bulkCaptor.capture());
 
@@ -295,8 +294,8 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         this.snapshotService.initialize(this.remoteConsumer);
 
         // Assert
-        // Verify delegation to ContentIndex.processPayload
-        verify(this.contentIndexMock).processPayload(any(JsonNode.class));
+        // Verify delegation to ContentIndex.processPayloadToString
+        verify(this.contentIndexMock).processPayloadToString(any(JsonNode.class));
         verify(this.contentIndexMock).executeBulk(any(BulkRequest.class));
     }
 
@@ -320,7 +319,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         this.snapshotService.initialize(this.remoteConsumer);
 
         // Assert
-        verify(this.contentIndexMock).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock).processPayloadToString(any(JsonNode.class));
         verify(this.contentIndexMock).executeBulk(any(BulkRequest.class));
     }
 
@@ -367,7 +366,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         this.snapshotService.initialize(this.remoteConsumer);
 
         // Assert
-        verify(this.contentIndexMock).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock).processPayloadToString(any(JsonNode.class));
         verify(this.contentIndexMock).executeBulk(any(BulkRequest.class));
     }
 
@@ -397,7 +396,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         this.snapshotService.initialize(this.remoteConsumer);
 
         // Assert
-        verify(this.contentIndexMock, atLeastOnce()).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock, atLeastOnce()).processPayloadToString(any(JsonNode.class));
         ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(this.contentIndexMock, atLeastOnce()).executeBulk(bulkCaptor.capture());
 
@@ -431,7 +430,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         this.snapshotService.initialize(this.remoteConsumer);
 
         // Assert
-        verify(this.contentIndexMock).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock).processPayloadToString(any(JsonNode.class));
         verify(this.contentIndexMock).executeBulk(any(BulkRequest.class));
     }
 
@@ -746,7 +745,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
 
         svc.initialize(zip, null);
 
-        verify(this.contentIndexMock, never()).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock, never()).processPayloadToString(any(JsonNode.class));
         ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(this.contentIndexMock, atLeastOnce()).executeBulk(bulkCaptor.capture());
 
@@ -945,7 +944,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         verify(this.contentIndexMock, atLeastOnce()).clear();
 
         // Documents should be processed and indexed
-        verify(this.contentIndexMock, atLeastOnce()).processPayload(any(JsonNode.class));
+        verify(this.contentIndexMock, atLeastOnce()).processPayloadToString(any(JsonNode.class));
         verify(this.contentIndexMock, atLeastOnce()).executeBulk(any(BulkRequest.class));
         verify(this.contentIndexMock).waitForPendingUpdates();
 


### PR DESCRIPTION
## Description

Reduces the per-document heap allocation during snapshot ZIP ingestion for non-CVE resource types. The existing pipeline materializes 3-4 simultaneous copies of each document's Jackson tree in memory (deep copy, synthetic payload, processed payload, serialized string). These changes cut that down to ~2 by eliminating unnecessary intermediate tree allocations and avoiding a redundant serialize-then-deserialize round-trip in IoC processing.

Closes #1351

## Proposed Changes

- **`ContentIndex.processPayloadToString`**: New method that serializes the processed payload directly to a JSON `String` via `writeValueAsString()`, skipping the intermediate `ObjectNode` tree that `processPayload()` builds only to be immediately `.toString()`'d. Switched `doUpdate()`, `batchUpdate()`, and `SnapshotServiceImpl.processZipEntry()` to use it. The original `processPayload()` is retained for callers that inspect or mutate the returned tree (`create`, `prepareCreateRequest`).

- **`Resource.populateResourceInPlace`**: New variant of `populateResource` that mutates the document `ObjectNode` in place instead of calling `.deepCopy()`. `Decoder`, `Filter`, and `Kvdb` `fromPayload()` methods are reordered to generate YAML from the raw document *before* calling the in-place variant, preserving the invariant that YAML reflects unprocessed content.

- **`Ioc.fromPayload`**: Replaced `MAPPER.convertValue(payload, Ioc.class)` with `MAPPER.treeToValue(payload, Ioc.class)` to avoid the unnecessary token-serialize-then-deserialize round-trip when the input is already a `JsonNode`.

- **`SnapshotServiceImpl.processZipEntry`**: Added `envelope = null` after bulk addition to allow the `LazyEnvelope` (and its cached `documentNode`) to be garbage-collected before the next iteration rather than lingering through bulk flush logic.

### Results and Evidence

All 520 unit tests pass:

```
./gradlew :wazuh-indexer-content-manager:test
BUILD SUCCESSFUL in 46s
```

### Artifacts Affected

- `wazuh-indexer-content-manager` plugin JAR

### Configuration Changes

None. No new settings or changes to defaults.

### Documentation Updates

None required — internal refactor with no user-facing behavior change.

### Tests Introduced

No new tests added. Existing tests (`SnapshotServiceImplTests`, `IocTests`, `ContentIndexTests`, `DecoderTests`, `FilterTests`, `KvdbTests`, `ResourceTests`) were updated to reflect the API changes:

- `SnapshotServiceImplTests`: Mock stubs and verifications switched from `processPayload` to `processPayloadToString`.
- `IocTests`: Test methods updated with `throws Exception` for the new checked exception from `treeToValue`. The unknown-fields test now expects `JsonProcessingException` instead of `IllegalArgumentException` (which `convertValue` previously wrapped).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
