### PR TITLE
Preserve the user's enabled choice on integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 - [BUG] Missing threat-intel indices [(#1362)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1362)
 - Update the Content Manager OpenAPI (`openapi.yml`) to match the current API [(#1353)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1353)
 - [BUG] Vulnerability Detection empty for all agents after a transient snapshot bootstrap failure [(#1383)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1383)
+- [BUG] User's enabled state is lost on CTI updates [(#1403)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1403)
 
 ## Prior versions
 - []()

--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -379,9 +379,13 @@ are present on the document in every space (`standard`, `draft`, `test`, `custom
 
 The resolution rule is `enabled = user_enabled ?? cti_enabled`, evaluated when content is
 ingested from CTI and whenever the client creates or updates an integration — never on read.
-Once a user has set a value it wins over every subsequent CTI update, including full
-resynchronisations and subscription plan changes. In a plan change CTI reassigns `document.id`,
-so overrides are carried across by `document.metadata.title`.
+Once a user has set a value it wins over every subsequent CTI update, including incremental
+patches and full resynchronisations.
+
+Overrides are matched by `document.id`. A full resynchronisation deletes the standard-space
+documents before repopulating them, so they are read and held in memory beforehand and re-applied
+as each document is rebuilt. **Known limitation:** a subscription plan change may republish an
+integration under a different `document.id`, and the override is not carried across in that case.
 
 Until CTI publishes `cti_enabled`, it still writes `document.enabled` directly; in that case the
 resolution leaves `enabled` as received, so the user's override still takes precedence and
@@ -978,7 +982,7 @@ The plugin includes integration tests defined in the `tests/content-manager` dir
 | Resource / operation   | Scenario count | Covers                                                                                                                                                                                                                                                                                                                              |
 | ---------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Integrations: create   | 9              | Success; duplicate title; missing title/author/category; explicit `id` in resource; missing resource object; empty body; no authentication                                                                                                                                                                                          |
-| Integrations: update   | 13             | Success; title collision with an existing draft integration; missing required fields; not found; invalid UUID; `id` in request body; attempting to add/remove dependency lists; no authentication; protected integration rejected; toggling `user_enabled` on a user-managed integration in the standard space derives `enabled`; user-managed standard update changes only `user_enabled` (other fields preserved); protected standard integration rejected; toggling `user_enabled` leaves the CTI-owned `detector` block immutable; a user's `enabled` override survives a document republished under a new `document.id` with the same title (resync / plan change) |
+| Integrations: update   | 12             | Success; title collision with an existing draft integration; missing required fields; not found; invalid UUID; `id` in request body; attempting to add/remove dependency lists; no authentication; protected integration rejected; toggling `user_enabled` on a user-managed integration in the standard space derives `enabled`; user-managed standard update changes only `user_enabled` (other fields preserved); protected standard integration rejected; toggling `user_enabled` leaves the CTI-owned `detector` block immutable |
 | Integrations: delete   | 7              | Success (no attached resources); has attached resources; not found; invalid UUID; missing ID; not in draft space; no authentication                                                                                                                                                                                                 |
 | Decoders: create       | 7              | Success; missing integration reference; explicit `id` in resource; integration not in draft space; missing resource object; empty body; no authentication                                                                                                                                                                           |
 | Decoders: update       | 7              | Success; not found; invalid UUID; not in draft space; missing resource object; empty body; no authentication                                                                                                                                                                                                                        |

--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -367,8 +367,9 @@ When a `standard` integration's effective `enabled` changes, its related Securit
 ### Integration `enabled` resolution
 
 Every integration document carries three boolean fields, each with a single writer. All three
-are present the same way in every space (`standard`, `draft`, `test`, `custom`), exactly like
-`mode`:
+are present on the document in every space (`standard`, `draft`, `test`, `custom`), exactly like
+`mode` — which is a property of the stored document, not of what a client may send. See
+[Where the client can write](#where-the-client-can-write) below for that distinction:
 
 | Field | Written by | Meaning |
 | --- | --- | --- |
@@ -386,21 +387,29 @@ Until CTI publishes `cti_enabled`, it still writes `document.enabled` directly; 
 resolution leaves `enabled` as received, so the user's override still takes precedence and
 current behaviour is otherwise unchanged.
 
-The client always sends `user_enabled`, uniformly across spaces, so the request shape is
-identical regardless of where an integration lives. The parallel with `mode` is that the field
-is present in every space even where its value is predictable — but unlike `mode`, which is
-server-set and never accepted from a request, `user_enabled` is the one field the client does
-send:
+#### Where the client can write
 
-- On create, `user_enabled` is optional and defaults to `true` when absent or `null`, the same
-  way `enabled` used to be defaulted.
-- On a `draft`-space update, `user_enabled` is required, alongside `category` and the metadata
-  fields.
-- On a `standard`-space update, `user_enabled` is the only field read; every other field the
-  client sends is ignored and the stored document is preserved untouched.
+The API exposes integration writes in two spaces only, so those are the only places a client
+ever sends `user_enabled`:
 
-`enabled` and `cti_enabled` are server-managed in every space: both are stripped from request
-bodies and cannot be set by a client, exactly like `mode`.
+| Operation | Spaces accepted | `user_enabled` |
+| --- | --- | --- |
+| `POST /integrations` | `draft` | Optional; defaults to `true` when absent or `null`, the same way `enabled` used to be defaulted. |
+| `PUT /integrations/{id}` | `draft`, `standard` | Required. |
+
+- On a `draft`-space update it is required alongside `category` and the metadata fields.
+- On a `standard`-space update it is the only field read; every other field the client sends is
+  ignored and the stored document is preserved untouched.
+
+`test` and `custom` have no write endpoint for integrations — `PUT` rejects them with
+`400 RESOURCE_SPACE_MISMATCH` (`TransportUpdateIntegrationAction.validSpaces`). Documents reach
+those spaces only through promotion (`draft → test → custom`), which copies `user_enabled` and
+`enabled` along with the rest of the document. Changing the enabled state of an integration that
+already lives in `custom` therefore means editing its `draft` copy and promoting the change
+through the chain, not calling `PUT` on the `custom` document.
+
+Wherever a client can write, `enabled` and `cti_enabled` are stripped from the request body and
+cannot be set, exactly like `mode`.
 
 "Absent `user_enabled` means the user never decided" still holds, but since create always
 defaults the field and update always requires it, the absent case now only arises for a

--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -357,7 +357,7 @@ The value is set by whoever produces the content: CTI content carries its own `m
 | Integration | Space | `PUT /integrations/{id}` |
 | --- | --- | --- |
 | `protected` | any | Rejected with `400 Bad Request`. |
-| `user-managed` | `draft` | Fully editable (metadata, category, `enabled`). |
+| `user-managed` | `draft` | Fully editable (metadata, category, `user_enabled`). |
 | `user-managed` | `standard` | Only `user_enabled` can change; every other field, including `enabled`, is preserved from the stored document. |
 
 When a `standard` integration's effective `enabled` changes, its related Security Analytics **detector is disabled/enabled in lockstep** as part of the same update flow. The detector shares the integration's document id, so the Content Manager calls the Security Analytics `WSetDetectorEnabledAction` (`setDetectorEnabled(id, enabled)`) to flip **only** the `enabled` flag on the existing detector, preserving its inputs, triggers and monitors. If the detector sync fails the whole update is aborted, so the two never drift.
@@ -366,30 +366,47 @@ When a `standard` integration's effective `enabled` changes, its related Securit
 
 ### Integration `enabled` resolution
 
-A standard integration carries three boolean fields, each with a single writer:
+Every integration document carries three boolean fields, each with a single writer. All three
+are present the same way in every space (`standard`, `draft`, `test`, `custom`), exactly like
+`mode`:
 
 | Field | Written by | Meaning |
 | --- | --- | --- |
-| `document.cti_enabled` | CTI | The state CTI publishes. |
-| `document.user_enabled` | Content Manager | The user's explicit choice. **Absent** means the user never set it. |
-| `document.enabled` | Content Manager | The effective state. Everything that reads an integration's enabled state reads this. |
+| `document.cti_enabled` | CTI | The state CTI publishes. Absent on integrations created through the REST API, since that content does not come from CTI. |
+| `document.user_enabled` | Content Manager | The user's explicit choice, set from the `user_enabled` field the client sends. |
+| `document.enabled` | Content Manager | The effective state, derived and never accepted from a request. Everything that reads an integration's enabled state reads this. |
 
 The resolution rule is `enabled = user_enabled ?? cti_enabled`, evaluated when content is
-ingested from CTI and when the user toggles the integration — never on read. Once a user has
-set a value it wins over every subsequent CTI update, including full resynchronisations and
-subscription plan changes. In a plan change CTI reassigns `document.id`, so overrides are
-carried across by `document.metadata.title`.
+ingested from CTI and whenever the client creates or updates an integration — never on read.
+Once a user has set a value it wins over every subsequent CTI update, including full
+resynchronisations and subscription plan changes. In a plan change CTI reassigns `document.id`,
+so overrides are carried across by `document.metadata.title`.
 
 Until CTI publishes `cti_enabled`, it still writes `document.enabled` directly; in that case the
 resolution leaves `enabled` as received, so the user's override still takes precedence and
 current behaviour is otherwise unchanged.
 
-On a `standard`-space update, `user_enabled` is the field the client sends — it is the only
-mutable field there, and `enabled` is not accepted from the request. `cti_enabled` is
-server-managed in every space: it is stripped from request bodies and cannot be set by a
-client, exactly like `mode`. `user_enabled` has no meaning outside the `standard` space and is
-likewise stripped from `draft`-space requests, including integration creation (which always
-starts in `draft`).
+The client always sends `user_enabled`, uniformly across spaces, so the request shape is
+identical regardless of where an integration lives. The parallel with `mode` is that the field
+is present in every space even where its value is predictable — but unlike `mode`, which is
+server-set and never accepted from a request, `user_enabled` is the one field the client does
+send:
+
+- On create, `user_enabled` is optional and defaults to `true` when absent or `null`, the same
+  way `enabled` used to be defaulted.
+- On a `draft`-space update, `user_enabled` is required, alongside `category` and the metadata
+  fields.
+- On a `standard`-space update, `user_enabled` is the only field read; every other field the
+  client sends is ignored and the stored document is preserved untouched.
+
+`enabled` and `cti_enabled` are server-managed in every space: both are stripped from request
+bodies and cannot be set by a client, exactly like `mode`.
+
+"Absent `user_enabled` means the user never decided" still holds, but since create always
+defaults the field and update always requires it, the absent case now only arises for a
+CTI-published `standard` integration the user has not yet touched. Readers should still test for
+presence rather than truthiness — an explicit `false` is a real decision — but should not expect
+the absent case on integrations created through the API.
 
 ---
 

--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -358,9 +358,38 @@ The value is set by whoever produces the content: CTI content carries its own `m
 | --- | --- | --- |
 | `protected` | any | Rejected with `400 Bad Request`. |
 | `user-managed` | `draft` | Fully editable (metadata, category, `enabled`). |
-| `user-managed` | `standard` | Only `enabled` can change; every other field is preserved from the stored document. |
+| `user-managed` | `standard` | Only `user_enabled` can change; every other field, including `enabled`, is preserved from the stored document. |
 
-When a `standard` integration's `enabled` is toggled, its related Security Analytics **detector is disabled/enabled in lockstep** as part of the same update flow. The detector shares the integration's document id, so the Content Manager calls the Security Analytics `WSetDetectorEnabledAction` (`setDetectorEnabled(id, enabled)`) to flip **only** the `enabled` flag on the existing detector, preserving its inputs, triggers and monitors. If the detector sync fails the whole update is aborted, so the two never drift.
+When a `standard` integration's effective `enabled` changes, its related Security Analytics **detector is disabled/enabled in lockstep** as part of the same update flow. The detector shares the integration's document id, so the Content Manager calls the Security Analytics `WSetDetectorEnabledAction` (`setDetectorEnabled(id, enabled)`) to flip **only** the `enabled` flag on the existing detector, preserving its inputs, triggers and monitors. If the detector sync fails the whole update is aborted, so the two never drift.
+
+---
+
+### Integration `enabled` resolution
+
+A standard integration carries three boolean fields, each with a single writer:
+
+| Field | Written by | Meaning |
+| --- | --- | --- |
+| `document.cti_enabled` | CTI | The state CTI publishes. |
+| `document.user_enabled` | Content Manager | The user's explicit choice. **Absent** means the user never set it. |
+| `document.enabled` | Content Manager | The effective state. Everything that reads an integration's enabled state reads this. |
+
+The resolution rule is `enabled = user_enabled ?? cti_enabled`, evaluated when content is
+ingested from CTI and when the user toggles the integration — never on read. Once a user has
+set a value it wins over every subsequent CTI update, including full resynchronisations and
+subscription plan changes. In a plan change CTI reassigns `document.id`, so overrides are
+carried across by `document.metadata.title`.
+
+Until CTI publishes `cti_enabled`, it still writes `document.enabled` directly; in that case the
+resolution leaves `enabled` as received, so the user's override still takes precedence and
+current behaviour is otherwise unchanged.
+
+On a `standard`-space update, `user_enabled` is the field the client sends — it is the only
+mutable field there, and `enabled` is not accepted from the request. `cti_enabled` is
+server-managed in every space: it is stripped from request bodies and cannot be set by a
+client, exactly like `mode`. `user_enabled` has no meaning outside the `standard` space and is
+likewise stripped from `draft`-space requests, including integration creation (which always
+starts in `draft`).
 
 ---
 
@@ -923,7 +952,7 @@ The plugin includes integration tests defined in the `tests/content-manager` dir
 | Resource / operation   | Scenario count | Covers                                                                                                                                                                                                                                                                                                                              |
 | ---------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Integrations: create   | 9              | Success; duplicate title; missing title/author/category; explicit `id` in resource; missing resource object; empty body; no authentication                                                                                                                                                                                          |
-| Integrations: update   | 12             | Success; title collision with an existing draft integration; missing required fields; not found; invalid UUID; `id` in request body; attempting to add/remove dependency lists; no authentication; protected integration rejected; toggling `enabled` on a user-managed integration in the standard space; user-managed standard update changes only `enabled` (other fields preserved); protected standard integration rejected |
+| Integrations: update   | 13             | Success; title collision with an existing draft integration; missing required fields; not found; invalid UUID; `id` in request body; attempting to add/remove dependency lists; no authentication; protected integration rejected; toggling `user_enabled` on a user-managed integration in the standard space derives `enabled`; user-managed standard update changes only `user_enabled` (other fields preserved); protected standard integration rejected; toggling `user_enabled` leaves the CTI-owned `detector` block immutable; a user's `enabled` override survives a document republished under a new `document.id` with the same title (resync / plan change) |
 | Integrations: delete   | 7              | Success (no attached resources); has attached resources; not found; invalid UUID; missing ID; not in draft space; no authentication                                                                                                                                                                                                 |
 | Decoders: create       | 7              | Success; missing integration reference; explicit `id` in resource; integration not in draft space; missing resource object; empty body; no authentication                                                                                                                                                                           |
 | Decoders: update       | 7              | Success; not found; invalid UUID; not in draft space; missing resource object; empty body; no authentication                                                                                                                                                                                                                        |

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -891,6 +891,12 @@ paths:
 
         **Note:** Integrations created through this endpoint are always stored with `mode: user-managed`.
         The `mode` field is set server-side and must NOT be included in the request body.
+
+        **Note:** `user_enabled` is optional. When omitted or `null`, it defaults to `true` — the
+        same way `enabled` used to be defaulted. The effective `enabled` is then derived by the
+        indexer as `user_enabled ?? cti_enabled`; there is no `cti_enabled` for an integration
+        created here, since this content does not come from CTI, so the derivation always yields
+        `user_enabled`. `enabled` is never accepted from the request body.
       operationId: createIntegration
       requestBody:
         required: true
@@ -917,7 +923,7 @@ paths:
                       references:
                         - "https://wazuh.com"
                     category: "cloud-services"
-                    enabled: true
+                    user_enabled: true
       responses:
         "201":
           $ref: "#/components/responses/ResourceCreated"
@@ -949,17 +955,20 @@ paths:
         The `mode` field is server-managed: it must NOT be included in the request body and is preserved from the stored document.
 
         **Required fields in resource:**
-        - `author` - Integration author name
-        - `category` - Integration category
-        - `decoders` - Array of decoder definitions
-        - `enabled` - Whether the integration is enabled
-        - `kvdbs` - Array of KVDB references
-        - `rules` - Array of rule references
-        - `title` - Integration title
+        - `user_enabled` - The user's enabled/disabled choice
+        - `author` - Integration author name (also required for a `draft`-space update)
+        - `category` - Integration category (also required for a `draft`-space update)
+        - `decoders` - Array of decoder definitions (also required for a `draft`-space update)
+        - `kvdbs` - Array of KVDB references (also required for a `draft`-space update)
+        - `rules` - Array of rule references (also required for a `draft`-space update)
+        - `title` - Integration title (also required for a `draft`-space update)
 
-        **Note:** The fields above apply to a `draft`-space update. A `standard`-space update
-        only accepts `user_enabled`; sending `enabled` there has no effect since it is derived,
-        not stored.
+        **Note:** The request body has the same shape in every space — `user_enabled` is always
+        the field the client sends, the same way `mode` already is. Only `user_enabled` is
+        required and read on a `standard`-space update; every other field the client sends is
+        ignored and the stored document's values are preserved untouched (`metadata.modified` is
+        the one exception, kept if supplied). The fields marked above as also required apply only
+        to a `draft`-space update.
 
         **Note:** The `id` field must NOT be included in the request body; the ID is taken from the URL path parameter.
       operationId: updateIntegration
@@ -991,7 +1000,7 @@ paths:
                         - "https://wazuh.com"
                         - "https://azure.microsoft.com"
                     category: "cloud-services"
-                    enabled: true
+                    user_enabled: true
                     rules: []
                     decoders: []
                     kvdbs: []
@@ -1781,21 +1790,26 @@ components:
 
         enabled:
           type: boolean
-          description: Whether the integration is enabled
+          readOnly: true
+          description: >-
+            The effective enabled state. Derived by the indexer as `user_enabled ?? cti_enabled`
+            and never accepted from a request body; it must NOT be included in the request body
+            and is stripped if sent.
 
         user_enabled:
           type: boolean
-          readOnly: true
           description: >-
-            The user's explicit enabled choice for a standard user-managed integration. Has no
-            meaning for a newly created integration, which is always created in the `draft`
-            space; it must NOT be included in the request body and is stripped if sent.
+            The user's explicit enabled choice. Optional: when omitted or `null`, it defaults to
+            `true`, the same way `enabled` used to be defaulted. Present the same way in every
+            space, exactly like `mode`.
         cti_enabled:
           type: boolean
           readOnly: true
           description: >-
             The enabled state published by CTI. Never accepted from a request body in any
-            space; it must NOT be included in the request body and is stripped if sent.
+            space; it must NOT be included in the request body and is stripped if sent. Absent on
+            integrations created through this endpoint, since that content does not come from
+            CTI — the derivation of `enabled` above then always yields `user_enabled`.
 
     # Request schema for updating an integration (PUT)
     IntegrationResourceUpdate:
@@ -1804,10 +1818,16 @@ components:
       required:
         - metadata
         - category
-        - enabled
+        - user_enabled
         - rules
         - decoders
         - kvdbs
+      # NOTE: This single schema cannot express that only `user_enabled` is actually enforced on
+      # a `standard`-space update — the target space is resolved from the stored document, not
+      # from the request, so the schema cannot discriminate on it. `metadata`, `category`,
+      # `rules`, `decoders` and `kvdbs` above are required for a `draft`-space update; a
+      # `standard`-space update reads only `user_enabled` and ignores the rest. See the endpoint
+      # description for the full breakdown.
       properties:
         metadata:
           allOf:
@@ -1826,27 +1846,28 @@ components:
 
         enabled:
           type: boolean
+          readOnly: true
           description: >-
-            Whether the integration is enabled. Applies to a `draft`-space update, where it is
-            the only source of the integration's enabled state. Has no effect on a
-            `standard`-space update: there `enabled` is derived by the indexer from
-            `user_enabled` and `cti_enabled` and is NOT accepted from the request.
+            The effective enabled state. Derived by the indexer as `user_enabled ?? cti_enabled`
+            and never accepted from a request body, in any space; it must NOT be included in the
+            request body and is stripped if sent.
 
         user_enabled:
           type: boolean
           description: >-
-            The user's explicit enabled choice for a `standard` user-managed integration. It is
-            the only field a `standard`-space update accepts; the effective `enabled` is then
-            derived by the indexer as `user_enabled ?? cti_enabled`, and that choice is
-            preserved across subsequent CTI content updates, full resynchronisations and
-            subscription plan changes. Has no meaning in the `draft` space, where it is stripped
-            if sent.
+            The user's explicit enabled choice. Required and present the same way in every
+            space, exactly like `mode`. It is the only field a `standard`-space update reads —
+            every other field sent there is ignored and the stored document is preserved as-is.
+            The effective `enabled` is derived by the indexer as `user_enabled ?? cti_enabled`,
+            and that choice is preserved across subsequent CTI content updates, full
+            resynchronisations and subscription plan changes.
         cti_enabled:
           type: boolean
           readOnly: true
           description: >-
             The enabled state published by CTI. Never accepted from a request body, in any
-            space; it must NOT be included in the request body and is stripped if sent.
+            space; it must NOT be included in the request body and is stripped if sent. Absent on
+            user-created integrations, since that content does not come from CTI.
 
         # The following arrays are mandatory to allow reordering
         rules:

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -939,7 +939,12 @@ paths:
         Behaviour depends on the integration's `mode` and the space it lives in:
         - `mode: protected` (Wazuh core content) — cannot be modified in any space; returns `400 Bad Request`.
         - `mode: user-managed` in the `draft` space — fully editable; validated against the Wazuh engine before being stored.
-        - `mode: user-managed` in the `standard` space — only the `enabled` field can change; every other field is preserved from the stored document.
+        - `mode: user-managed` in the `standard` space — only `user_enabled` can change; every other field, including `enabled`, is preserved from the stored document. `enabled` is derived by the indexer from `user_enabled` and `cti_enabled` and is NOT accepted from the request.
+
+        A change to `user_enabled` on a `user-managed` integration in the `standard` space is
+        recorded as the user's explicit choice and is preserved across all subsequent content
+        updates from CTI, including incremental updates, full resynchronisations and
+        subscription plan changes.
 
         The `mode` field is server-managed: it must NOT be included in the request body and is preserved from the stored document.
 
@@ -951,6 +956,10 @@ paths:
         - `kvdbs` - Array of KVDB references
         - `rules` - Array of rule references
         - `title` - Integration title
+
+        **Note:** The fields above apply to a `draft`-space update. A `standard`-space update
+        only accepts `user_enabled`; sending `enabled` there has no effect since it is derived,
+        not stored.
 
         **Note:** The `id` field must NOT be included in the request body; the ID is taken from the URL path parameter.
       operationId: updateIntegration
@@ -1774,6 +1783,20 @@ components:
           type: boolean
           description: Whether the integration is enabled
 
+        user_enabled:
+          type: boolean
+          readOnly: true
+          description: >-
+            The user's explicit enabled choice for a standard user-managed integration. Has no
+            meaning for a newly created integration, which is always created in the `draft`
+            space; it must NOT be included in the request body and is stripped if sent.
+        cti_enabled:
+          type: boolean
+          readOnly: true
+          description: >-
+            The enabled state published by CTI. Never accepted from a request body in any
+            space; it must NOT be included in the request body and is stripped if sent.
+
     # Request schema for updating an integration (PUT)
     IntegrationResourceUpdate:
       type: object
@@ -1803,7 +1826,27 @@ components:
 
         enabled:
           type: boolean
-          description: Whether the integration is enabled
+          description: >-
+            Whether the integration is enabled. Applies to a `draft`-space update, where it is
+            the only source of the integration's enabled state. Has no effect on a
+            `standard`-space update: there `enabled` is derived by the indexer from
+            `user_enabled` and `cti_enabled` and is NOT accepted from the request.
+
+        user_enabled:
+          type: boolean
+          description: >-
+            The user's explicit enabled choice for a `standard` user-managed integration. It is
+            the only field a `standard`-space update accepts; the effective `enabled` is then
+            derived by the indexer as `user_enabled ?? cti_enabled`, and that choice is
+            preserved across subsequent CTI content updates, full resynchronisations and
+            subscription plan changes. Has no meaning in the `draft` space, where it is stripped
+            if sent.
+        cti_enabled:
+          type: boolean
+          readOnly: true
+          description: >-
+            The enabled state published by CTI. Never accepted from a request body, in any
+            space; it must NOT be included in the request body and is stripped if sent.
 
         # The following arrays are mandatory to allow reordering
         rules:

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -93,6 +93,7 @@ import com.wazuh.contentmanager.cti.catalog.service.SnapshotServiceImpl;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.cti.catalog.service.SubscriptionService;
 import com.wazuh.contentmanager.cti.catalog.service.SubscriptionServiceImpl;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
 import com.wazuh.contentmanager.cti.console.service.PlansService;
 import com.wazuh.contentmanager.cti.console.service.PlansServiceImpl;
 import com.wazuh.contentmanager.engine.service.EngineService;
@@ -130,6 +131,7 @@ public class ContentManagerPlugin extends Plugin
     private TelemetryPingJob telemetryPingJob;
     private EngineService engine;
     private SpaceService spaceService;
+    private UserOverridesService userOverridesService;
     private SecurityAnalyticsService securityAnalyticsService;
     private Environment environment;
     private ClusterService clusterService;
@@ -223,6 +225,7 @@ public class ContentManagerPlugin extends Plugin
 
         // Initialize services
         this.spaceService = new SpaceService(this.client);
+        this.userOverridesService = new UserOverridesService(this.client, this.spaceService);
         if (PluginSettings.getInstance().isEngineMockEnabled()) {
             this.securityAnalyticsService = new MockSecurityAnalyticsService();
         } else {
@@ -269,6 +272,7 @@ public class ContentManagerPlugin extends Plugin
                 this.engine,
                 this.logtestService,
                 this.spaceService,
+                this.userOverridesService,
                 this.securityAnalyticsService);
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -41,7 +41,6 @@ import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
@@ -368,56 +367,54 @@ public class ContentIndex {
 
     /**
      * Reads a boolean {@code document} field for every document in the given space, keyed by {@code
-     * document.metadata.title}. Documents without the field are omitted, so the caller can tell
-     * "absent" from "false".
+     * document.id}. Documents without the field are omitted, so the caller can tell "absent" from
+     * "false".
      *
-     * <p>Reads resolve through the alias, so during a shadow swap this returns the <b>live</b>
-     * content while the shadow index is still being populated.
+     * <p>Reads resolve through the alias, so during a shadow swap this sees the <b>live</b> content
+     * while the shadow index is still being populated.
      *
-     * <p>This is a low-level read helper: it does not decide whether a caller may tolerate a failed
-     * read, so it does not swallow exceptions. A missing or closed index is the one failure mode
-     * tolerated here (see {@link IndicesOptions#lenientExpandOpen()} below) because a fresh
-     * installation has no integrations index yet; every other failure (e.g. a search timeout or a
-     * cluster-level search failure) is propagated so the caller — which knows whether an empty result
-     * is safe to act on — can decide whether to proceed or abort.
+     * <p>A missing or closed index is the one failure mode tolerated here (see {@link
+     * IndicesOptions#lenientExpandOpen()}) because a fresh installation has no integrations index
+     * yet, and it yields an empty map. Every other failure reaches {@link ActionListener#onFailure},
+     * so the caller — which knows whether an empty result is safe to act on — decides whether to
+     * proceed or abort.
      *
      * @param spaceName the space to read, e.g. {@code "standard"}.
      * @param fieldName the boolean field under {@code document} to collect.
-     * @return title to value; empty when nothing matches, including when the index does not exist
-     *     yet.
-     * @throws IOException if a hit's source cannot be parsed as JSON.
-     * @throws InterruptedException if the thread is interrupted while waiting for the search.
-     * @throws ExecutionException if the search request fails.
-     * @throws TimeoutException if the search exceeds the client timeout setting.
+     * @param listener receives document id to value; empty when nothing matches, including when the
+     *     index does not exist yet.
      */
-    public Map<String, Boolean> fetchBooleanFieldByTitle(String spaceName, String fieldName)
-            throws IOException, InterruptedException, ExecutionException, TimeoutException {
-        Map<String, Boolean> values = new HashMap<>();
-        String titlePath =
-                Constants.KEY_DOCUMENT + "." + Constants.KEY_METADATA + "." + Constants.KEY_TITLE;
+    public void fetchBooleanFieldById(
+            String spaceName, String fieldName, ActionListener<Map<String, Boolean>> listener) {
+        String idPath = Constants.KEY_DOCUMENT + "." + Constants.KEY_ID;
         String fieldPath = Constants.KEY_DOCUMENT + "." + fieldName;
         SearchSourceBuilder source =
                 new SearchSourceBuilder()
                         .query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName))
-                        .fetchSource(new String[] {titlePath, fieldPath}, new String[0])
+                        .fetchSource(new String[] {idPath, fieldPath}, new String[0])
                         .size(10000);
         SearchRequest request =
                 new SearchRequest(this.indexName)
                         .indicesOptions(IndicesOptions.lenientExpandOpen())
                         .source(source);
-        SearchResponse response =
-                this.client.search(request).get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
 
-        for (SearchHit hit : response.getHits().getHits()) {
-            JsonNode root = MAPPER.readTree(hit.getSourceAsString());
-            JsonNode document = root.path(Constants.KEY_DOCUMENT);
-            JsonNode value = document.path(fieldName);
-            JsonNode title = document.path(Constants.KEY_METADATA).path(Constants.KEY_TITLE);
-            if (value.isBoolean() && title.isTextual()) {
-                values.put(title.asText(), value.asBoolean());
-            }
-        }
-        return values;
+        this.client.search(
+                request,
+                ActionListener.wrap(
+                        response -> {
+                            Map<String, Boolean> values = new HashMap<>();
+                            for (SearchHit hit : response.getHits().getHits()) {
+                                JsonNode document =
+                                        MAPPER.readTree(hit.getSourceAsString()).path(Constants.KEY_DOCUMENT);
+                                JsonNode value = document.path(fieldName);
+                                JsonNode id = document.path(Constants.KEY_ID);
+                                if (value.isBoolean() && id.isTextual()) {
+                                    values.put(id.asText(), value.asBoolean());
+                                }
+                            }
+                            listener.onResponse(values);
+                        },
+                        listener::onFailure));
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -40,12 +40,14 @@ import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.breaker.CircuitBreakingException;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
@@ -54,7 +56,9 @@ import org.opensearch.transport.client.Client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -358,6 +362,50 @@ public class ContentIndex {
             log.error(Constants.E_LOG_GET_DOCUMENT_FAILED, id, this.indexName, e.getMessage());
         }
         return null;
+    }
+
+    /**
+     * Reads a boolean {@code document} field for every document in the given space, keyed by {@code
+     * document.metadata.title}. Documents without the field are omitted, so the caller can tell
+     * "absent" from "false".
+     *
+     * <p>Reads resolve through the alias, so during a shadow swap this returns the <b>live</b>
+     * content while the shadow index is still being populated.
+     *
+     * @param spaceName the space to read, e.g. {@code "standard"}.
+     * @param fieldName the boolean field under {@code document} to collect.
+     * @return title to value; empty when nothing matches or the read fails.
+     */
+    public Map<String, Boolean> fetchBooleanFieldByTitle(String spaceName, String fieldName) {
+        Map<String, Boolean> values = new HashMap<>();
+        String titlePath =
+                Constants.KEY_DOCUMENT + "." + Constants.KEY_METADATA + "." + Constants.KEY_TITLE;
+        String fieldPath = Constants.KEY_DOCUMENT + "." + fieldName;
+        try {
+            SearchSourceBuilder source =
+                    new SearchSourceBuilder()
+                            .query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName))
+                            .fetchSource(new String[] {titlePath, fieldPath}, new String[0])
+                            .size(10000);
+            SearchResponse response =
+                    this.client
+                            .search(new SearchRequest(this.indexName).source(source))
+                            .get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
+
+            for (SearchHit hit : response.getHits().getHits()) {
+                JsonNode root = MAPPER.readTree(hit.getSourceAsString());
+                JsonNode document = root.path(Constants.KEY_DOCUMENT);
+                JsonNode value = document.path(fieldName);
+                JsonNode title = document.path(Constants.KEY_METADATA).path(Constants.KEY_TITLE);
+                if (value.isBoolean() && title.isTextual()) {
+                    values.put(title.asText(), value.asBoolean());
+                }
+            }
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to read [{}] by title from [{}]: {}", fieldName, this.indexName, e.getMessage());
+        }
+        return values;
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -486,6 +486,8 @@ public class ContentIndex {
             currentDoc.put(Constants.KEY_OFFSET, offset);
         }
 
+        this.resolveIntegrationEnabled(currentDoc);
+
         // 3. Process
         ObjectNode processedDoc = this.processPayload(currentDoc);
 
@@ -560,6 +562,8 @@ public class ContentIndex {
             }
             patchTarget.put(Constants.KEY_OFFSET, task.offset());
 
+            this.resolveIntegrationEnabled(patchTarget);
+
             ObjectNode processedDoc = this.processPayload(patchTarget);
             bulkRequest.add(
                     new IndexRequest(this.getWriteIndex())
@@ -577,6 +581,22 @@ public class ContentIndex {
         }
 
         return tasks.get(tasks.size() - 1).offset();
+    }
+
+    /**
+     * Re-resolves an integration's effective enabled state after a patch has been applied. No-op for
+     * every other index, so the shared update paths stay untouched for rules, decoders and kvdbs.
+     *
+     * @param patchTarget the patched root node.
+     */
+    private void resolveIntegrationEnabled(ObjectNode patchTarget) {
+        if (!Constants.INDEX_INTEGRATIONS.equals(this.indexName)) {
+            return;
+        }
+        JsonNode document = patchTarget.get(Constants.KEY_DOCUMENT);
+        if (document instanceof ObjectNode documentNode) {
+            IntegrationEnabledResolver.resolve(documentNode);
+        }
     }
 
     private void executeBulkUpdate(BulkRequest bulkRequest, long timeout) throws Exception {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -403,9 +403,6 @@ public class ContentIndex {
                         .size(10000);
         SearchRequest request =
                 new SearchRequest(this.indexName)
-                        // Tolerate a missing or closed integrations index (e.g. a fresh installation that
-                        // has not run its first snapshot yet): treat it as an empty result instead of
-                        // failing, so the very first snapshot is not aborted for lack of an index to read.
                         .indicesOptions(IndicesOptions.lenientExpandOpen())
                         .source(source);
         SearchResponse response =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -41,6 +41,7 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -372,38 +373,51 @@ public class ContentIndex {
      * <p>Reads resolve through the alias, so during a shadow swap this returns the <b>live</b>
      * content while the shadow index is still being populated.
      *
+     * <p>This is a low-level read helper: it does not decide whether a caller may tolerate a failed
+     * read, so it does not swallow exceptions. A missing or closed index is the one failure mode
+     * tolerated here (see {@link IndicesOptions#lenientExpandOpen()} below) because a fresh
+     * installation has no integrations index yet; every other failure (e.g. a search timeout or a
+     * cluster-level search failure) is propagated so the caller — which knows whether an empty result
+     * is safe to act on — can decide whether to proceed or abort.
+     *
      * @param spaceName the space to read, e.g. {@code "standard"}.
      * @param fieldName the boolean field under {@code document} to collect.
-     * @return title to value; empty when nothing matches or the read fails.
+     * @return title to value; empty when nothing matches, including when the index does not exist
+     *     yet.
+     * @throws IOException if a hit's source cannot be parsed as JSON.
+     * @throws InterruptedException if the thread is interrupted while waiting for the search.
+     * @throws ExecutionException if the search request fails.
+     * @throws TimeoutException if the search exceeds the client timeout setting.
      */
-    public Map<String, Boolean> fetchBooleanFieldByTitle(String spaceName, String fieldName) {
+    public Map<String, Boolean> fetchBooleanFieldByTitle(String spaceName, String fieldName)
+            throws IOException, InterruptedException, ExecutionException, TimeoutException {
         Map<String, Boolean> values = new HashMap<>();
         String titlePath =
                 Constants.KEY_DOCUMENT + "." + Constants.KEY_METADATA + "." + Constants.KEY_TITLE;
         String fieldPath = Constants.KEY_DOCUMENT + "." + fieldName;
-        try {
-            SearchSourceBuilder source =
-                    new SearchSourceBuilder()
-                            .query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName))
-                            .fetchSource(new String[] {titlePath, fieldPath}, new String[0])
-                            .size(10000);
-            SearchResponse response =
-                    this.client
-                            .search(new SearchRequest(this.indexName).source(source))
-                            .get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
+        SearchSourceBuilder source =
+                new SearchSourceBuilder()
+                        .query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName))
+                        .fetchSource(new String[] {titlePath, fieldPath}, new String[0])
+                        .size(10000);
+        SearchRequest request =
+                new SearchRequest(this.indexName)
+                        // Tolerate a missing or closed integrations index (e.g. a fresh installation that
+                        // has not run its first snapshot yet): treat it as an empty result instead of
+                        // failing, so the very first snapshot is not aborted for lack of an index to read.
+                        .indicesOptions(IndicesOptions.lenientExpandOpen())
+                        .source(source);
+        SearchResponse response =
+                this.client.search(request).get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
 
-            for (SearchHit hit : response.getHits().getHits()) {
-                JsonNode root = MAPPER.readTree(hit.getSourceAsString());
-                JsonNode document = root.path(Constants.KEY_DOCUMENT);
-                JsonNode value = document.path(fieldName);
-                JsonNode title = document.path(Constants.KEY_METADATA).path(Constants.KEY_TITLE);
-                if (value.isBoolean() && title.isTextual()) {
-                    values.put(title.asText(), value.asBoolean());
-                }
+        for (SearchHit hit : response.getHits().getHits()) {
+            JsonNode root = MAPPER.readTree(hit.getSourceAsString());
+            JsonNode document = root.path(Constants.KEY_DOCUMENT);
+            JsonNode value = document.path(fieldName);
+            JsonNode title = document.path(Constants.KEY_METADATA).path(Constants.KEY_TITLE);
+            if (value.isBoolean() && title.isTextual()) {
+                values.put(title.asText(), value.asBoolean());
             }
-        } catch (Exception e) {
-            log.warn(
-                    "Failed to read [{}] by title from [{}]: {}", fieldName, this.indexName, e.getMessage());
         }
         return values;
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/IndexSwapHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/IndexSwapHelper.java
@@ -166,6 +166,9 @@ public final class IndexSwapHelper {
             new ReindexRequestBuilder(client, ReindexAction.INSTANCE)
                     .source(livePhysical)
                     .destination(shadowPhysical)
+                    // This also carries the user-overrides registry document across the swap: it has no
+                    // space.name, so it satisfies this must_not and lands in the new physical index
+                    // alongside the user's own spaces.
                     .filter(
                             QueryBuilders.boolQuery()
                                     .mustNot(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, "standard")))

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/IntegrationEnabledResolver.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/IntegrationEnabledResolver.java
@@ -38,9 +38,7 @@ import com.wazuh.contentmanager.utils.Constants;
  */
 public final class IntegrationEnabledResolver {
 
-    private IntegrationEnabledResolver() {
-        // utility class
-    }
+    private IntegrationEnabledResolver() {}
 
     /**
      * @param document the {@code document} node of an integration, may be {@code null}.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/IntegrationEnabledResolver.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/IntegrationEnabledResolver.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import com.wazuh.contentmanager.utils.Constants;
+
+/**
+ * Resolution rules for the three enabled fields carried by a standard integration document.
+ *
+ * <ul>
+ *   <li>{@code cti_enabled} — the state published by CTI.
+ *   <li>{@code user_enabled} — the user's explicit choice. <b>Absent means the user never
+ *       decided</b>; an explicit {@code false} is a real decision, so presence (never truthiness)
+ *       is what these methods test.
+ *   <li>{@code enabled} — the effective state, resolved from the two above. The only one existing
+ *       consumers read.
+ * </ul>
+ *
+ * <p>Stateless and IO-free on purpose: callers sit on ingest paths shared by every resource type,
+ * so the rules live here rather than being spread across those paths.
+ */
+public final class IntegrationEnabledResolver {
+
+    private IntegrationEnabledResolver() {
+        // utility class
+    }
+
+    /**
+     * @param document the {@code document} node of an integration, may be {@code null}.
+     * @return {@code true} when the user has explicitly set a value.
+     */
+    public static boolean hasUserOverride(JsonNode document) {
+        return isPresent(document, Constants.KEY_USER_ENABLED);
+    }
+
+    /**
+     * Re-attaches a previously stored user override onto a document rebuilt from CTI content.
+     *
+     * @param target the {@code document} node to update in place.
+     * @param previousOverride the stored override, or {@code null} when there was none.
+     */
+    public static void carryOverUserOverride(ObjectNode target, Boolean previousOverride) {
+        if (target == null || previousOverride == null) {
+            return;
+        }
+        target.put(Constants.KEY_USER_ENABLED, previousOverride.booleanValue());
+    }
+
+    /**
+     * Applies the resolution rule in place: the user's choice wins when present, otherwise CTI's
+     * published value is used.
+     *
+     * <p>When neither field is present the current {@code enabled} is left untouched. That is the
+     * transition path: until CTI publishes {@code cti_enabled} it still writes {@code enabled}
+     * directly, and overwriting it would discard the value that just arrived.
+     *
+     * <p>Idempotent, so it is safe to call on every ingest as a self-healing step.
+     *
+     * @param document the {@code document} node to update in place.
+     */
+    public static void resolve(ObjectNode document) {
+        if (document == null) {
+            return;
+        }
+        if (hasUserOverride(document)) {
+            document.put(Constants.KEY_ENABLED, document.get(Constants.KEY_USER_ENABLED).asBoolean());
+            return;
+        }
+        if (isPresent(document, Constants.KEY_CTI_ENABLED)) {
+            document.put(Constants.KEY_ENABLED, document.get(Constants.KEY_CTI_ENABLED).asBoolean());
+        }
+    }
+
+    private static boolean isPresent(JsonNode document, String field) {
+        return document != null && document.has(field) && !document.get(field).isNull();
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/UserOverrides.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/UserOverrides.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.wazuh.contentmanager.utils.Constants;
+
+/**
+ * The user's overrides for one space, as held in the registry document.
+ *
+ * <p>The {@code standard} space is rebuilt from CTI, so anything a user writes there needs an
+ * explicit mechanism to survive. Integrations keep the user's choice in their own document, as
+ * {@code document.user_enabled}; the policy settings and the filters the user created live here
+ * instead, because the rebuild replaces the policy document wholesale and deletes the filters
+ * outright.
+ *
+ * <p>Absence is meaningful throughout: a {@code null} setting means the user never decided that
+ * field and CTI keeps deciding it. Enrichments are held as a delta rather than as a list so that
+ * values CTI publishes later still reach a user who customised the selection.
+ *
+ * <p>This class is serialization only; all indexing lives in {@code UserOverridesService}.
+ */
+public final class UserOverrides {
+
+    private final PolicySettings policy;
+    private final List<StoredFilter> filters;
+
+    /**
+     * @param policy the policy settings the user decided, or {@code null} if none.
+     * @param filters the filters the user created; never {@code null} once constructed.
+     */
+    public UserOverrides(PolicySettings policy, List<StoredFilter> filters) {
+        this.policy = policy;
+        this.filters = filters != null ? filters : new ArrayList<>();
+    }
+
+    /**
+     * @return the policy settings the user decided, or {@code null} if they never saved the policy.
+     */
+    public PolicySettings getPolicy() {
+        return this.policy;
+    }
+
+    /**
+     * @return the filters the user created in this space; empty if none.
+     */
+    public List<StoredFilter> getFilters() {
+        return this.filters;
+    }
+
+    /**
+     * Reads one space's overrides out of the registry.
+     *
+     * @param registryRoot the {@code user_overrides} node of the registry document, or {@code null}
+     *     when the registry does not exist yet.
+     * @param spaceName the space to read.
+     * @return that space's overrides; empty when there are none.
+     */
+    public static UserOverrides forSpace(JsonNode registryRoot, String spaceName) {
+        if (registryRoot == null || !registryRoot.has(spaceName)) {
+            return new UserOverrides(null, new ArrayList<>());
+        }
+        JsonNode spaceNode = registryRoot.get(spaceName);
+
+        PolicySettings settings = null;
+        if (spaceNode.has(Constants.KEY_POLICY_SETTINGS)) {
+            settings = PolicySettings.from(spaceNode.get(Constants.KEY_POLICY_SETTINGS));
+        }
+
+        List<StoredFilter> stored = new ArrayList<>();
+        if (spaceNode.has(Constants.KEY_STORED_FILTERS)) {
+            for (JsonNode entry : spaceNode.get(Constants.KEY_STORED_FILTERS)) {
+                stored.add(
+                        new StoredFilter(
+                                entry.path(Constants.KEY_ID).asText(null),
+                                entry.path(Constants.KEY_DOCUMENT).asText(null)));
+            }
+        }
+        return new UserOverrides(settings, stored);
+    }
+
+    /**
+     * Writes this instance into the registry under {@code spaceName}, replacing whatever was there.
+     *
+     * @param registryRoot the {@code user_overrides} node to write into.
+     * @param spaceName the space to write.
+     */
+    public void writeInto(ObjectNode registryRoot, String spaceName) {
+        ObjectNode spaceNode = registryRoot.objectNode();
+
+        if (this.policy != null) {
+            spaceNode.set(Constants.KEY_POLICY_SETTINGS, this.policy.toNode(registryRoot));
+        }
+
+        ArrayNode filtersNode = registryRoot.arrayNode();
+        for (StoredFilter filter : this.filters) {
+            ObjectNode entry = registryRoot.objectNode();
+            entry.put(Constants.KEY_ID, filter.getId());
+            entry.put(Constants.KEY_DOCUMENT, filter.getDocument());
+            filtersNode.add(entry);
+        }
+        spaceNode.set(Constants.KEY_STORED_FILTERS, filtersNode);
+
+        registryRoot.set(spaceName, spaceNode);
+    }
+
+    /**
+     * The four settings a user can change on the standard policy.
+     *
+     * <p>All four are recorded on every save, by design: editing the standard policy makes its
+     * settings the user's from then on. A {@code null} field means the user never saved at all.
+     */
+    public static final class PolicySettings {
+
+        private final Boolean enabled;
+        private final Boolean indexUnclassifiedEvents;
+        private final Boolean indexDiscardedEvents;
+        private final EnrichmentDelta enrichments;
+
+        /**
+         * @param enabled the policy's {@code enabled} flag, or {@code null} if undecided.
+         * @param indexUnclassifiedEvents the {@code index_unclassified_events} flag, or {@code null}.
+         * @param indexDiscardedEvents the {@code index_discarded_events} flag, or {@code null}.
+         * @param enrichments the enrichment delta, or {@code null}.
+         */
+        public PolicySettings(
+                Boolean enabled,
+                Boolean indexUnclassifiedEvents,
+                Boolean indexDiscardedEvents,
+                EnrichmentDelta enrichments) {
+            this.enabled = enabled;
+            this.indexUnclassifiedEvents = indexUnclassifiedEvents;
+            this.indexDiscardedEvents = indexDiscardedEvents;
+            this.enrichments = enrichments;
+        }
+
+        /**
+         * @return the {@code enabled} flag the user chose, or {@code null} if undecided.
+         */
+        public Boolean getEnabled() {
+            return this.enabled;
+        }
+
+        /**
+         * @return the {@code index_unclassified_events} flag the user chose, or {@code null}.
+         */
+        public Boolean getIndexUnclassifiedEvents() {
+            return this.indexUnclassifiedEvents;
+        }
+
+        /**
+         * @return the {@code index_discarded_events} flag the user chose, or {@code null}.
+         */
+        public Boolean getIndexDiscardedEvents() {
+            return this.indexDiscardedEvents;
+        }
+
+        /**
+         * @return the enrichment delta, or {@code null} if the user never changed the selection.
+         */
+        public EnrichmentDelta getEnrichments() {
+            return this.enrichments;
+        }
+
+        /**
+         * @param node the stored {@code policy} node.
+         * @return the settings it holds, with absent fields left {@code null}.
+         */
+        static PolicySettings from(JsonNode node) {
+            EnrichmentDelta delta = null;
+            if (node.has(Constants.KEY_ENRICHMENTS)) {
+                delta = EnrichmentDelta.from(node.get(Constants.KEY_ENRICHMENTS));
+            }
+            return new PolicySettings(
+                    node.has(Constants.KEY_ENABLED) ? node.get(Constants.KEY_ENABLED).asBoolean() : null,
+                    node.has(Constants.KEY_INDEX_UNCLASSIFIED_EVENTS)
+                            ? node.get(Constants.KEY_INDEX_UNCLASSIFIED_EVENTS).asBoolean()
+                            : null,
+                    node.has(Constants.KEY_INDEX_DISCARDED_EVENTS)
+                            ? node.get(Constants.KEY_INDEX_DISCARDED_EVENTS).asBoolean()
+                            : null,
+                    delta);
+        }
+
+        /**
+         * @param factory any node from the target document, used only as a node factory.
+         * @return these settings as a node, omitting the fields the user never decided.
+         */
+        ObjectNode toNode(ObjectNode factory) {
+            ObjectNode node = factory.objectNode();
+            if (this.enabled != null) {
+                node.put(Constants.KEY_ENABLED, this.enabled.booleanValue());
+            }
+            if (this.indexUnclassifiedEvents != null) {
+                node.put(
+                        Constants.KEY_INDEX_UNCLASSIFIED_EVENTS, this.indexUnclassifiedEvents.booleanValue());
+            }
+            if (this.indexDiscardedEvents != null) {
+                node.put(Constants.KEY_INDEX_DISCARDED_EVENTS, this.indexDiscardedEvents.booleanValue());
+            }
+            if (this.enrichments != null) {
+                node.set(Constants.KEY_ENRICHMENTS, this.enrichments.toNode(factory));
+            }
+            return node;
+        }
+    }
+
+    /**
+     * What the user removed from, and added to, the enrichment list CTI publishes.
+     *
+     * <p>Stored as a delta rather than as the resulting list on purpose: an enrichment CTI starts
+     * publishing after the user customised their selection still reaches them, which a stored list
+     * would freeze out.
+     */
+    public static final class EnrichmentDelta {
+
+        private final Set<String> removed;
+        private final Set<String> added;
+
+        /**
+         * @param removed enrichments the user unchecked, or {@code null} for none.
+         * @param added enrichments the user checked on top of CTI's list, or {@code null} for none.
+         */
+        public EnrichmentDelta(Set<String> removed, Set<String> added) {
+            this.removed = removed != null ? removed : Set.of();
+            this.added = added != null ? added : Set.of();
+        }
+
+        /**
+         * @return the enrichments the user unchecked.
+         */
+        public Set<String> getRemoved() {
+            return this.removed;
+        }
+
+        /**
+         * @return the enrichments the user checked on top of CTI's list.
+         */
+        public Set<String> getAdded() {
+            return this.added;
+        }
+
+        /**
+         * Resolves the effective enrichment list.
+         *
+         * @param ctiList the list CTI published, as found in the rebuilt policy.
+         * @return that list minus the removals, plus the additions. Set semantics, so a value CTI also
+         *     publishes cannot be duplicated by an addition.
+         */
+        public List<String> applyTo(List<String> ctiList) {
+            Set<String> result = new LinkedHashSet<>(ctiList != null ? ctiList : List.of());
+            result.removeAll(this.removed);
+            result.addAll(this.added);
+            return new ArrayList<>(result);
+        }
+
+        /**
+         * @param node the stored {@code enrichments} node.
+         * @return the delta it holds.
+         */
+        static EnrichmentDelta from(JsonNode node) {
+            return new EnrichmentDelta(
+                    readSet(node, Constants.KEY_ENRICHMENTS_REMOVED),
+                    readSet(node, Constants.KEY_ENRICHMENTS_ADDED));
+        }
+
+        private static Set<String> readSet(JsonNode node, String field) {
+            Set<String> values = new LinkedHashSet<>();
+            if (node.has(field)) {
+                node.get(field).forEach(entry -> values.add(entry.asText()));
+            }
+            return values;
+        }
+
+        /**
+         * @param factory any node from the target document, used only as a node factory.
+         * @return this delta as a node.
+         */
+        ObjectNode toNode(ObjectNode factory) {
+            ObjectNode node = factory.objectNode();
+            ArrayNode removedNode = factory.arrayNode();
+            this.removed.forEach(removedNode::add);
+            ArrayNode addedNode = factory.arrayNode();
+            this.added.forEach(addedNode::add);
+            node.set(Constants.KEY_ENRICHMENTS_REMOVED, removedNode);
+            node.set(Constants.KEY_ENRICHMENTS_ADDED, addedNode);
+            return node;
+        }
+    }
+
+    /**
+     * A filter the user created, kept as a serialized JSON string.
+     *
+     * <p>A string, not a nested object: the policies mapping is {@code dynamic: true}, so nesting a
+     * filter's fields there would auto-map every field of every stored filter into the policies
+     * index, and two filters with conflicting field types would make the write fail outright.
+     */
+    public static final class StoredFilter {
+
+        private final String id;
+        private final String document;
+
+        /**
+         * @param id the filter's document id, reused when it is recreated.
+         * @param document the filter's full stored document, serialized.
+         */
+        public StoredFilter(String id, String document) {
+            this.id = id;
+            this.document = document;
+        }
+
+        /**
+         * @return the filter's document id.
+         */
+        public String getId() {
+            return this.id;
+        }
+
+        /**
+         * @return the filter's full stored document, serialized.
+         */
+        public String getDocument() {
+            return this.document;
+        }
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -395,6 +395,65 @@ public abstract class AbstractConsumerService {
      * @return a {@link SyncResult} carrying whether content was updated and whether a configured feed
      *     could not be reached.
      */
+    /**
+     * Captures the user's integration enabled overrides and only then wipes the standard space, in
+     * that order.
+     *
+     * <p>The two steps live in one method because their order is a correctness requirement, not a
+     * preference: the overrides are stored in the very documents the wipe deletes. Reading them
+     * afterwards — which is what {@code initialize} does on its own — searches an emptied index,
+     * yields an empty map indistinguishable from "the user never chose anything", and silently
+     * rebuilds every integration with CTI's values. That was the original bug, reproduced on a live
+     * cluster.
+     *
+     * <p>A failed capture aborts before anything is deleted, so the next sync cycle retries from an
+     * intact index. A failed wipe is logged and tolerated, matching the previous behaviour.
+     *
+     * @param snapshotService the snapshot service that will repopulate the indices.
+     * @param indicesMap the content indices keyed by type.
+     * @param consumerType the consumer type, for logging.
+     * @return {@code true} when the capture succeeded and the wipe was attempted; {@code false} when
+     *     the overrides could not be read and the caller must abort without destroying anything.
+     */
+    protected boolean captureOverridesThenWipe(
+            SnapshotServiceImpl snapshotService,
+            Map<String, ContentIndex> indicesMap,
+            String consumerType) {
+        try {
+            snapshotService.captureUserOverrides();
+        } catch (Exception e) {
+            log.error(Constants.E_LOG_USER_OVERRIDES_READ_FAILED, consumerType, e.getMessage());
+            return false;
+        }
+
+        // Ruleset snapshots also affect Security Analytics/Space resources; other catalogs only
+        // clear indices.
+        if (this.isRulesetConsumer()) {
+            try {
+                SecurityAnalyticsService securityAnalyticsService =
+                        new SecurityAnalyticsServiceImpl(this.client);
+                CompletableFuture<Void> sapFuture = new CompletableFuture<>();
+                securityAnalyticsService.deleteSpaceResources(
+                        Space.STANDARD,
+                        ActionListener.wrap(r -> sapFuture.complete(null), sapFuture::completeExceptionally));
+                sapFuture.get(60, TimeUnit.SECONDS);
+
+                SpaceService spaceService = new SpaceService(this.client);
+                CompletableFuture<Void> spaceFuture = new CompletableFuture<>();
+                spaceService.deleteSpaceResources(
+                        Space.STANDARD,
+                        ActionListener.wrap(
+                                r -> spaceFuture.complete(null), spaceFuture::completeExceptionally));
+                spaceFuture.get(60, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                log.error(Constants.E_LOG_CLEAR_RESOURCES_FAILED, consumerType, e.getMessage());
+            }
+        } else {
+            indicesMap.values().forEach(ContentIndex::clear);
+        }
+        return true;
+    }
+
     private SyncResult syncConsumerServices() {
         String consumerType = this.getConsumerType();
 
@@ -653,31 +712,8 @@ public abstract class AbstractConsumerService {
                 if (hasEffectiveCatalog
                         && remoteConsumer != null
                         && remoteConsumer.getSnapshotLink() != null) {
-                    // Ruleset snapshots also affect Security Analytics/Space resources; other catalogs only
-                    // clear indices.
-                    if (this.isRulesetConsumer()) {
-                        try {
-                            SecurityAnalyticsService securityAnalyticsService =
-                                    new SecurityAnalyticsServiceImpl(this.client);
-                            CompletableFuture<Void> sapFuture = new CompletableFuture<>();
-                            securityAnalyticsService.deleteSpaceResources(
-                                    Space.STANDARD,
-                                    ActionListener.wrap(
-                                            r -> sapFuture.complete(null), sapFuture::completeExceptionally));
-                            sapFuture.get(60, TimeUnit.SECONDS);
-
-                            SpaceService spaceService = new SpaceService(this.client);
-                            CompletableFuture<Void> spaceFuture = new CompletableFuture<>();
-                            spaceService.deleteSpaceResources(
-                                    Space.STANDARD,
-                                    ActionListener.wrap(
-                                            r -> spaceFuture.complete(null), spaceFuture::completeExceptionally));
-                            spaceFuture.get(60, TimeUnit.SECONDS);
-                        } catch (Exception e) {
-                            log.error(Constants.E_LOG_CLEAR_RESOURCES_FAILED, consumerType, e.getMessage());
-                        }
-                    } else {
-                        indicesMap.values().forEach(ContentIndex::clear);
+                    if (!this.captureOverridesThenWipe(snapshotService, indicesMap, consumerType)) {
+                        return new SyncResult(false, feedUnreachable);
                     }
 
                     log.debug(Constants.D_LOG_SNAPSHOT_INIT_CUSTOM_URL, catalogUri);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -387,63 +387,6 @@ public abstract class AbstractConsumerService {
     }
 
     /**
-     * Captures the user's integration enabled overrides and only then wipes the standard space, in
-     * that order.
-     *
-     * <p>The two steps live in one method because their order is a correctness requirement, not a
-     * preference: the overrides are stored in the very documents the wipe deletes. Reading them
-     * afterwards would search an emptied index, yield an empty map indistinguishable from "the user
-     * never chose anything", and silently rebuild every integration with CTI's values.
-     *
-     * <p>A failed capture aborts before anything is deleted, so the next sync cycle retries from an
-     * intact index. A failed wipe is logged and tolerated, matching the previous behaviour.
-     *
-     * @param snapshotService the snapshot service that will repopulate the indices.
-     * @param indicesMap the content indices keyed by type.
-     * @param consumerType the consumer type, for logging.
-     * @return {@code true} when the capture succeeded and the wipe was attempted; {@code false} when
-     *     the overrides could not be read and the caller must abort without destroying anything.
-     */
-    protected boolean captureOverridesThenWipe(
-            SnapshotServiceImpl snapshotService,
-            Map<String, ContentIndex> indicesMap,
-            String consumerType) {
-        try {
-            snapshotService.captureUserOverrides();
-        } catch (Exception e) {
-            log.error(Constants.E_LOG_USER_OVERRIDES_READ_FAILED, consumerType, e.getMessage());
-            return false;
-        }
-
-        // Ruleset snapshots also affect Security Analytics/Space resources; other catalogs only
-        // clear indices.
-        if (this.isRulesetConsumer()) {
-            try {
-                SecurityAnalyticsService securityAnalyticsService =
-                        new SecurityAnalyticsServiceImpl(this.client);
-                CompletableFuture<Void> sapFuture = new CompletableFuture<>();
-                securityAnalyticsService.deleteSpaceResources(
-                        Space.STANDARD,
-                        ActionListener.wrap(r -> sapFuture.complete(null), sapFuture::completeExceptionally));
-                sapFuture.get(60, TimeUnit.SECONDS);
-
-                SpaceService spaceService = new SpaceService(this.client);
-                CompletableFuture<Void> spaceFuture = new CompletableFuture<>();
-                spaceService.deleteSpaceResources(
-                        Space.STANDARD,
-                        ActionListener.wrap(
-                                r -> spaceFuture.complete(null), spaceFuture::completeExceptionally));
-                spaceFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception e) {
-                log.error(Constants.E_LOG_CLEAR_RESOURCES_FAILED, consumerType, e.getMessage());
-            }
-        } else {
-            indicesMap.values().forEach(ContentIndex::clear);
-        }
-        return true;
-    }
-
-    /**
      * Performs the core synchronization logic for consumer services. Retrieves local and remote
      * consumer state, creates any missing indices with their mappings and aliases, initializes from
      * snapshot if this is a first-time sync (offset = 0), and applies incremental updates if the
@@ -710,8 +653,42 @@ public abstract class AbstractConsumerService {
                 if (hasEffectiveCatalog
                         && remoteConsumer != null
                         && remoteConsumer.getSnapshotLink() != null) {
-                    if (!this.captureOverridesThenWipe(snapshotService, indicesMap, consumerType)) {
+                    // The user's integration enabled overrides live in the documents the next block
+                    // deletes, so they must be read first. Aborting here leaves the indices intact
+                    // for the next sync cycle; proceeding with an unreadable override map would
+                    // rebuild every integration with CTI's values and lose the user's decisions.
+                    try {
+                        snapshotService.captureUserOverrides();
+                    } catch (Exception e) {
+                        log.error(Constants.E_LOG_USER_OVERRIDES_READ_FAILED, consumerType, e.getMessage());
                         return new SyncResult(false, feedUnreachable);
+                    }
+
+                    // Ruleset snapshots also affect Security Analytics/Space resources; other catalogs only
+                    // clear indices.
+                    if (this.isRulesetConsumer()) {
+                        try {
+                            SecurityAnalyticsService securityAnalyticsService =
+                                    new SecurityAnalyticsServiceImpl(this.client);
+                            CompletableFuture<Void> sapFuture = new CompletableFuture<>();
+                            securityAnalyticsService.deleteSpaceResources(
+                                    Space.STANDARD,
+                                    ActionListener.wrap(
+                                            r -> sapFuture.complete(null), sapFuture::completeExceptionally));
+                            sapFuture.get(60, TimeUnit.SECONDS);
+
+                            SpaceService spaceService = new SpaceService(this.client);
+                            CompletableFuture<Void> spaceFuture = new CompletableFuture<>();
+                            spaceService.deleteSpaceResources(
+                                    Space.STANDARD,
+                                    ActionListener.wrap(
+                                            r -> spaceFuture.complete(null), spaceFuture::completeExceptionally));
+                            spaceFuture.get(60, TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            log.error(Constants.E_LOG_CLEAR_RESOURCES_FAILED, consumerType, e.getMessage());
+                        }
+                    } else {
+                        indicesMap.values().forEach(ContentIndex::clear);
                     }
 
                     log.debug(Constants.D_LOG_SNAPSHOT_INIT_CUSTOM_URL, catalogUri);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -387,24 +387,13 @@ public abstract class AbstractConsumerService {
     }
 
     /**
-     * Performs the core synchronization logic for consumer services. Retrieves local and remote
-     * consumer state, creates any missing indices with their mappings and aliases, initializes from
-     * snapshot if this is a first-time sync (offset = 0), and applies incremental updates if the
-     * remote offset is ahead.
-     *
-     * @return a {@link SyncResult} carrying whether content was updated and whether a configured feed
-     *     could not be reached.
-     */
-    /**
      * Captures the user's integration enabled overrides and only then wipes the standard space, in
      * that order.
      *
      * <p>The two steps live in one method because their order is a correctness requirement, not a
      * preference: the overrides are stored in the very documents the wipe deletes. Reading them
-     * afterwards — which is what {@code initialize} does on its own — searches an emptied index,
-     * yields an empty map indistinguishable from "the user never chose anything", and silently
-     * rebuilds every integration with CTI's values. That was the original bug, reproduced on a live
-     * cluster.
+     * afterwards would search an emptied index, yield an empty map indistinguishable from "the user
+     * never chose anything", and silently rebuild every integration with CTI's values.
      *
      * <p>A failed capture aborts before anything is deleted, so the next sync cycle retries from an
      * intact index. A failed wipe is logged and tolerated, matching the previous behaviour.
@@ -454,6 +443,15 @@ public abstract class AbstractConsumerService {
         return true;
     }
 
+    /**
+     * Performs the core synchronization logic for consumer services. Retrieves local and remote
+     * consumer state, creates any missing indices with their mappings and aliases, initializes from
+     * snapshot if this is a first-time sync (offset = 0), and applies incremental updates if the
+     * remote offset is ahead.
+     *
+     * @return a {@link SyncResult} carrying whether content was updated and whether a configured feed
+     *     could not be reached.
+     */
     private SyncResult syncConsumerServices() {
         String consumerType = this.getConsumerType();
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
@@ -59,7 +59,8 @@ public class ConsumerRulesetService extends AbstractConsumerService {
     private final ObjectMapper mapper;
 
     private final SecurityAnalyticsServiceImpl securityAnalyticsService;
-    private final SpaceService spaceService;
+    private SpaceService spaceService;
+    private UserOverridesService userOverridesService;
     private final EngineService engineService;
 
     private Set<String> preSwapIntegrationIds = Collections.emptySet();
@@ -81,6 +82,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
         super(client, consumersIndex, environment);
         this.securityAnalyticsService = new SecurityAnalyticsServiceImpl(client);
         this.spaceService = new SpaceService(client);
+        this.userOverridesService = new UserOverridesService(client, this.spaceService);
         this.engineService = engineService;
 
         this.mapper = new ObjectMapper();
@@ -169,6 +171,20 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                     Constants.INDEX_INTEGRATIONS,
                     Constants.INDEX_POLICIES);
 
+            // Re-apply the user's overrides before anything reads the rebuilt content. The Security
+            // Analytics sync below, the space hash and the engine payload must all see the merged
+            // values, not the ones CTI just wrote. This one hook covers every path that gets here --
+            // full resync, rollback to a snapshot, incremental patches and a plan change.
+            //
+            // A failure must not abort the sync: the registry is a durable document, so the worst case
+            // is that the overrides are re-applied one synchronization later. Unlike the integrations'
+            // pre-snapshot capture, there is nothing here that is about to be destroyed.
+            try {
+                this.<Void>awaitResult(l -> this.userOverridesService.apply(Space.STANDARD.toString(), l));
+            } catch (IOException e) {
+                log.error(Constants.E_LOG_USER_OVERRIDES_REGISTRY_READ_FAILED, e.getMessage());
+            }
+
             // Sync Integrations
             Map<String, JsonNode> integrationDocs = Collections.emptyMap();
             try {
@@ -207,6 +223,16 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             }
             this.loadStandardSpaceIntoEngine();
         }
+    }
+
+    /** Injects a {@link SpaceService} instance, used by tests to provide a mock. */
+    void setSpaceService(SpaceService spaceService) {
+        this.spaceService = spaceService;
+    }
+
+    /** Injects a {@link UserOverridesService} instance, used by tests to provide a mock. */
+    void setUserOverridesService(UserOverridesService userOverridesService) {
+        this.userOverridesService = userOverridesService;
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -197,10 +197,10 @@ public class SnapshotServiceImpl implements SnapshotService {
                 return false;
             }
 
-            // 2. Load user overrides (through the alias, so this sees live pre-swap state), then
-            // stream and index JSON entries directly from the ZIP. Skipped when the caller already
-            // captured them before wiping the live indices.
+            // 2. Load user overrides
             this.captureUserOverridesIfNeeded();
+
+            // 3. Stream and index JSON entries directly from the ZIP
             startMs = System.currentTimeMillis();
             this.processZip(snapshotZip);
 
@@ -249,19 +249,15 @@ public class SnapshotServiceImpl implements SnapshotService {
      * a plan-change swap this captures the live pre-swap state while the shadow index is being
      * populated.
      *
-     * <p><b>Must be called while the documents carrying the overrides still exist.</b> Not every
-     * caller wipes the indices inside {@code initialize}: the reinitialisation path in {@code
-     * AbstractConsumerService} deletes every standard-space document <i>before</i> calling {@code
-     * initialize}, so it must invoke this method itself beforehand. Reading afterwards would search
-     * an already-emptied index, silently yield an empty map and drop every override. The {@link
-     * #overridesCaptured} flag then stops {@code initialize} from re-reading and undoing that
-     * capture.
+     * <p><b>Must be called while the documents carrying the overrides still exist.</b> The
+     * reinitialisation path in {@code AbstractConsumerService} deletes every standard-space document
+     * before calling {@code initialize}, so it calls this method itself beforehand; the {@link
+     * #overridesCaptured} flag then stops {@code initialize} from reading the now-emptied index and
+     * discarding that capture.
      *
-     * <p>If the read fails, the failure is logged at ERROR and rethrown so the caller aborts the
-     * snapshot instead of proceeding with an empty override map — an empty map is indistinguishable
-     * from "the user never set any override", so treating a failed read as "no overrides" would
-     * silently rebuild every integration with CTI's values and permanently lose every user override.
-     * Callers must abort <i>before</i> their own destructive step for that to be worth anything.
+     * <p>A read failure is rethrown rather than treated as "no overrides", since the two are
+     * indistinguishable otherwise and swallowing it would silently rebuild every integration with
+     * CTI's values. Callers must abort before their own destructive step for that to matter.
      *
      * @throws IOException if a stored override document cannot be parsed as JSON.
      * @throws InterruptedException if the thread is interrupted while waiting for the read.
@@ -416,9 +412,7 @@ public class SnapshotServiceImpl implements SnapshotService {
                         if (Constants.KEY_CVES.equals(type) && cveType != null) {
                             syntheticPayload.put(Constants.KEY_TYPE, cveType);
                         }
-                        // Re-apply the user's override before the payload is processed, so the
-                        // stored document hash is computed over the content that is actually
-                        // indexed, and so the string-only processing path is preserved.
+                        // Merge before processing, so the stored hash covers the merged content.
                         if (Constants.KEY_INTEGRATION.equals(type)) {
                             this.mergeIntegrationEnabled(syntheticPayload);
                         }
@@ -508,15 +502,13 @@ public class SnapshotServiceImpl implements SnapshotService {
         long startMs = System.currentTimeMillis();
 
         try {
-            // Capture user overrides before the indices are cleared, so they can be
-            // re-applied as the snapshot repopulates them. Skipped when the caller already
-            // captured them before wiping the live indices.
+            // 1. Load user overrides
             this.captureUserOverridesIfNeeded();
 
-            // 1. Clear indices
+            // 2. Clear indices
             this.indicesMap.values().forEach(ContentIndex::clear);
 
-            // 2. Stream and index JSON entries directly from the ZIP
+            // 3. Stream and index JSON entries directly from the ZIP
             AccessController.doPrivilegedChecked(
                     () -> {
                         this.processZip(localZip);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -28,6 +28,7 @@ import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.secure_sm.AccessController;
 
@@ -37,7 +38,9 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.wazuh.contentmanager.cti.catalog.client.RegularUrlResolver;
@@ -74,8 +77,8 @@ public class SnapshotServiceImpl implements SnapshotService {
     /** The maximum offset encountered while processing snapshot files. */
     private long maxOffsetSeen;
 
-    /** Title to user override, loaded once per snapshot run before any document is written. */
-    private Map<String, Boolean> userEnabledByTitle = Collections.emptyMap();
+    /** Document id to user override, loaded once per snapshot run before any document is written. */
+    private Map<String, Boolean> userEnabledById = Collections.emptyMap();
 
     /**
      * Whether {@link #captureUserOverrides()} already ran for this snapshot service.
@@ -245,9 +248,7 @@ public class SnapshotServiceImpl implements SnapshotService {
     }
 
     /**
-     * Loads the current user overrides for standard integrations. Reads through the alias, so during
-     * a plan-change swap this captures the live pre-swap state while the shadow index is being
-     * populated.
+     * Loads the current user overrides for standard integrations, keyed by {@code document.id}.
      *
      * <p><b>Must be called while the documents carrying the overrides still exist.</b> The
      * reinitialisation path in {@code AbstractConsumerService} deletes every standard-space document
@@ -259,6 +260,10 @@ public class SnapshotServiceImpl implements SnapshotService {
      * indistinguishable otherwise and swallowing it would silently rebuild every integration with
      * CTI's values. Callers must abort before their own destructive step for that to matter.
      *
+     * <p>The read itself is asynchronous; the wait lives here because the callers up to {@code
+     * syncConsumerServices} are sequential and need the map before they may continue. The cause is
+     * unwrapped from its {@link ExecutionException} so callers and logs see the original failure.
+     *
      * @throws IOException if a stored override document cannot be parsed as JSON.
      * @throws InterruptedException if the thread is interrupted while waiting for the read.
      * @throws ExecutionException if the underlying search request fails.
@@ -268,22 +273,33 @@ public class SnapshotServiceImpl implements SnapshotService {
             throws IOException, InterruptedException, ExecutionException, TimeoutException {
         ContentIndex integrations = this.indicesMap.get(Constants.KEY_INTEGRATION);
         if (integrations == null) {
-            this.userEnabledByTitle = Collections.emptyMap();
+            this.userEnabledById = Collections.emptyMap();
             this.overridesCaptured = true;
             return;
         }
+
+        CompletableFuture<Map<String, Boolean>> future = new CompletableFuture<>();
+        integrations.fetchBooleanFieldById(
+                Space.STANDARD.toString(),
+                Constants.KEY_USER_ENABLED,
+                ActionListener.wrap(future::complete, future::completeExceptionally));
         try {
-            this.userEnabledByTitle =
-                    integrations.fetchBooleanFieldByTitle(
-                            Space.STANDARD.toString(), Constants.KEY_USER_ENABLED);
-        } catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {
+            this.userEnabledById = future.get(this.pluginSettings.getClientTimeout(), TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            log.error(Constants.E_LOG_USER_OVERRIDES_READ_FAILED, this.consumerType, e.getMessage());
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException io) {
+                throw io;
+            }
+            throw e;
+        } catch (InterruptedException | TimeoutException e) {
             log.error(Constants.E_LOG_USER_OVERRIDES_READ_FAILED, this.consumerType, e.getMessage());
             throw e;
         }
         this.overridesCaptured = true;
         log.info(
                 "Captured {} integration enabled override(s) to carry across the snapshot",
-                this.userEnabledByTitle.size());
+                this.userEnabledById.size());
     }
 
     /**
@@ -313,10 +329,9 @@ public class SnapshotServiceImpl implements SnapshotService {
         if (!(document instanceof ObjectNode documentNode)) {
             return;
         }
-        String title = documentNode.path(Constants.KEY_METADATA).path(Constants.KEY_TITLE).asText(null);
-        if (title != null) {
-            IntegrationEnabledResolver.carryOverUserOverride(
-                    documentNode, this.userEnabledByTitle.get(title));
+        String id = documentNode.path(Constants.KEY_ID).asText(null);
+        if (id != null) {
+            IntegrationEnabledResolver.carryOverUserOverride(documentNode, this.userEnabledById.get(id));
         }
         IntegrationEnabledResolver.resolve(documentNode);
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -45,9 +45,11 @@ import com.wazuh.contentmanager.cti.catalog.client.ResourceUrlResolver;
 import com.wazuh.contentmanager.cti.catalog.client.SnapshotClient;
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
+import com.wazuh.contentmanager.cti.catalog.index.IntegrationEnabledResolver;
 import com.wazuh.contentmanager.cti.catalog.model.Cve;
 import com.wazuh.contentmanager.cti.catalog.model.LocalConsumer;
 import com.wazuh.contentmanager.cti.catalog.model.RemoteConsumer;
+import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -71,6 +73,9 @@ public class SnapshotServiceImpl implements SnapshotService {
 
     /** The maximum offset encountered while processing snapshot files. */
     private long maxOffsetSeen;
+
+    /** Title to user override, loaded once per snapshot run before any document is written. */
+    private Map<String, Boolean> userEnabledByTitle = Collections.emptyMap();
 
     /**
      * Constructs a new SnapshotServiceImpl.
@@ -182,7 +187,9 @@ public class SnapshotServiceImpl implements SnapshotService {
                 return false;
             }
 
-            // 2. Stream and index JSON entries directly from the ZIP
+            // 2. Load user overrides (through the alias, so this sees live pre-swap state), then
+            // stream and index JSON entries directly from the ZIP.
+            this.loadUserOverrides();
             startMs = System.currentTimeMillis();
             this.processZip(snapshotZip);
 
@@ -224,6 +231,46 @@ public class SnapshotServiceImpl implements SnapshotService {
             this.cleanup(snapshotZip);
             return false;
         }
+    }
+
+    /**
+     * Loads the current user overrides for standard integrations. Reads through the alias, so during
+     * a plan-change swap this captures the live pre-swap state while the shadow index is being
+     * populated.
+     */
+    private void loadUserOverrides() {
+        ContentIndex integrations = this.indicesMap.get(Constants.KEY_INTEGRATION);
+        if (integrations == null) {
+            this.userEnabledByTitle = Collections.emptyMap();
+            return;
+        }
+        this.userEnabledByTitle =
+                integrations.fetchBooleanFieldByTitle(
+                        Space.STANDARD.toString(), Constants.KEY_USER_ENABLED);
+        if (!this.userEnabledByTitle.isEmpty()) {
+            log.info(
+                    "Loaded {} integration enabled override(s) to carry across the snapshot",
+                    this.userEnabledByTitle.size());
+        }
+    }
+
+    /**
+     * Re-applies the user's override, if any, to an integration document rebuilt from the snapshot,
+     * then resolves the effective state.
+     *
+     * @param processedPayload the processed document wrapper about to be indexed.
+     */
+    private void mergeIntegrationEnabled(ObjectNode processedPayload) {
+        JsonNode document = processedPayload.get(Constants.KEY_DOCUMENT);
+        if (!(document instanceof ObjectNode documentNode)) {
+            return;
+        }
+        String title = documentNode.path(Constants.KEY_METADATA).path(Constants.KEY_TITLE).asText(null);
+        if (title != null) {
+            IntegrationEnabledResolver.carryOverUserOverride(
+                    documentNode, this.userEnabledByTitle.get(title));
+        }
+        IntegrationEnabledResolver.resolve(documentNode);
     }
 
     /**
@@ -318,6 +365,9 @@ public class SnapshotServiceImpl implements SnapshotService {
                             syntheticPayload.put(Constants.KEY_TYPE, cveType);
                         }
                         ObjectNode processedPayload = indexHandler.processPayload(syntheticPayload);
+                        if (Constants.KEY_INTEGRATION.equals(type)) {
+                            this.mergeIntegrationEnabled(processedPayload);
+                        }
                         sourceJson = processedPayload.toString();
                     }
 
@@ -403,6 +453,10 @@ public class SnapshotServiceImpl implements SnapshotService {
         long startMs = System.currentTimeMillis();
 
         try {
+            // Capture user overrides before the indices are cleared, so they can be
+            // re-applied as the snapshot repopulates them.
+            this.loadUserOverrides();
+
             // 1. Clear indices
             this.indicesMap.values().forEach(ContentIndex::clear);
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -78,6 +78,16 @@ public class SnapshotServiceImpl implements SnapshotService {
     private Map<String, Boolean> userEnabledByTitle = Collections.emptyMap();
 
     /**
+     * Whether {@link #captureUserOverrides()} already ran for this snapshot service.
+     *
+     * <p>The overrides must be read while the documents that carry them still exist. Some callers
+     * wipe the live indices <b>before</b> invoking {@code initialize}, so they capture explicitly
+     * beforehand and this flag stops {@code initialize} from re-reading an already-emptied index and
+     * discarding what was captured.
+     */
+    private boolean overridesCaptured;
+
+    /**
      * Constructs a new SnapshotServiceImpl.
      *
      * @param consumerType The consumer type identifier used as local document id.
@@ -188,8 +198,9 @@ public class SnapshotServiceImpl implements SnapshotService {
             }
 
             // 2. Load user overrides (through the alias, so this sees live pre-swap state), then
-            // stream and index JSON entries directly from the ZIP.
-            this.loadUserOverrides();
+            // stream and index JSON entries directly from the ZIP. Skipped when the caller already
+            // captured them before wiping the live indices.
+            this.captureUserOverridesIfNeeded();
             startMs = System.currentTimeMillis();
             this.processZip(snapshotZip);
 
@@ -238,24 +249,31 @@ public class SnapshotServiceImpl implements SnapshotService {
      * a plan-change swap this captures the live pre-swap state while the shadow index is being
      * populated.
      *
+     * <p><b>Must be called while the documents carrying the overrides still exist.</b> Not every
+     * caller wipes the indices inside {@code initialize}: the reinitialisation path in {@code
+     * AbstractConsumerService} deletes every standard-space document <i>before</i> calling {@code
+     * initialize}, so it must invoke this method itself beforehand. Reading afterwards would search
+     * an already-emptied index, silently yield an empty map and drop every override. The {@link
+     * #overridesCaptured} flag then stops {@code initialize} from re-reading and undoing that
+     * capture.
+     *
      * <p>If the read fails, the failure is logged at ERROR and rethrown so the caller aborts the
      * snapshot instead of proceeding with an empty override map — an empty map is indistinguishable
      * from "the user never set any override", so treating a failed read as "no overrides" would
      * silently rebuild every integration with CTI's values and permanently lose every user override.
-     * Both {@code initialize} overloads call this before any destructive step (before {@link
-     * #processZip} and before {@code ContentIndex#clear}), so aborting here is safe: nothing has been
-     * written or cleared yet, and the sync retries on the next cycle.
+     * Callers must abort <i>before</i> their own destructive step for that to be worth anything.
      *
      * @throws IOException if a stored override document cannot be parsed as JSON.
      * @throws InterruptedException if the thread is interrupted while waiting for the read.
      * @throws ExecutionException if the underlying search request fails.
      * @throws TimeoutException if the read exceeds the client timeout setting.
      */
-    private void loadUserOverrides()
+    public void captureUserOverrides()
             throws IOException, InterruptedException, ExecutionException, TimeoutException {
         ContentIndex integrations = this.indicesMap.get(Constants.KEY_INTEGRATION);
         if (integrations == null) {
             this.userEnabledByTitle = Collections.emptyMap();
+            this.overridesCaptured = true;
             return;
         }
         try {
@@ -266,11 +284,26 @@ public class SnapshotServiceImpl implements SnapshotService {
             log.error(Constants.E_LOG_USER_OVERRIDES_READ_FAILED, this.consumerType, e.getMessage());
             throw e;
         }
-        if (!this.userEnabledByTitle.isEmpty()) {
-            log.info(
-                    "Loaded {} integration enabled override(s) to carry across the snapshot",
-                    this.userEnabledByTitle.size());
+        this.overridesCaptured = true;
+        log.info(
+                "Captured {} integration enabled override(s) to carry across the snapshot",
+                this.userEnabledByTitle.size());
+    }
+
+    /**
+     * Captures the overrides unless a caller already did it before wiping the indices.
+     *
+     * @throws IOException if the read fails.
+     * @throws InterruptedException if the thread is interrupted while reading.
+     * @throws ExecutionException if the read fails asynchronously.
+     * @throws TimeoutException if the read exceeds the client timeout setting.
+     */
+    private void captureUserOverridesIfNeeded()
+            throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        if (this.overridesCaptured) {
+            return;
         }
+        this.captureUserOverrides();
     }
 
     /**
@@ -476,8 +509,9 @@ public class SnapshotServiceImpl implements SnapshotService {
 
         try {
             // Capture user overrides before the indices are cleared, so they can be
-            // re-applied as the snapshot repopulates them.
-            this.loadUserOverrides();
+            // re-applied as the snapshot repopulates them. Skipped when the caller already
+            // captured them before wiping the live indices.
+            this.captureUserOverridesIfNeeded();
 
             // 1. Clear indices
             this.indicesMap.values().forEach(ContentIndex::clear);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -237,16 +237,35 @@ public class SnapshotServiceImpl implements SnapshotService {
      * Loads the current user overrides for standard integrations. Reads through the alias, so during
      * a plan-change swap this captures the live pre-swap state while the shadow index is being
      * populated.
+     *
+     * <p>If the read fails, the failure is logged at ERROR and rethrown so the caller aborts the
+     * snapshot instead of proceeding with an empty override map — an empty map is indistinguishable
+     * from "the user never set any override", so treating a failed read as "no overrides" would
+     * silently rebuild every integration with CTI's values and permanently lose every user override.
+     * Both {@code initialize} overloads call this before any destructive step (before {@link
+     * #processZip} and before {@code ContentIndex#clear}), so aborting here is safe: nothing has been
+     * written or cleared yet, and the sync retries on the next cycle.
+     *
+     * @throws IOException if a stored override document cannot be parsed as JSON.
+     * @throws InterruptedException if the thread is interrupted while waiting for the read.
+     * @throws ExecutionException if the underlying search request fails.
+     * @throws TimeoutException if the read exceeds the client timeout setting.
      */
-    private void loadUserOverrides() {
+    private void loadUserOverrides()
+            throws IOException, InterruptedException, ExecutionException, TimeoutException {
         ContentIndex integrations = this.indicesMap.get(Constants.KEY_INTEGRATION);
         if (integrations == null) {
             this.userEnabledByTitle = Collections.emptyMap();
             return;
         }
-        this.userEnabledByTitle =
-                integrations.fetchBooleanFieldByTitle(
-                        Space.STANDARD.toString(), Constants.KEY_USER_ENABLED);
+        try {
+            this.userEnabledByTitle =
+                    integrations.fetchBooleanFieldByTitle(
+                            Space.STANDARD.toString(), Constants.KEY_USER_ENABLED);
+        } catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {
+            log.error(Constants.E_LOG_USER_OVERRIDES_READ_FAILED, this.consumerType, e.getMessage());
+            throw e;
+        }
         if (!this.userEnabledByTitle.isEmpty()) {
             log.info(
                     "Loaded {} integration enabled override(s) to carry across the snapshot",

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -175,6 +175,10 @@ public class SpaceService {
                                     }
                                     SearchRequest searchRequest = new SearchRequest(indexName);
                                     SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+                                    // Selecting by space is also what keeps the user-overrides registry
+                                    // document alive: it carries no space.name on purpose. Widening this to
+                                    // match every document in the index would delete it, and silently lose
+                                    // the user's policy settings and the filters they created.
                                     sourceBuilder.query(QueryBuilders.termQuery(Constants.Q_SPACE_NAME, spaceName));
                                     sourceBuilder.size(10000);
                                     sourceBuilder.fetchSource(false);
@@ -1040,7 +1044,15 @@ public class SpaceService {
     private void searchPoliciesAndProcessAsync(
             List<String> targetSpaces, ActionListener<Set<String>> listener) {
         SearchRequest searchRequest = new SearchRequest(Constants.INDEX_POLICIES);
-        searchRequest.source().query(QueryBuilders.matchAllQuery()).size(10000);
+        // Only actual policies. Every policy carries space.name -- it is how the wipe, getPolicy and
+        // the promotion flow all find them -- so requiring it here keeps documents that merely live in
+        // this index from being processed as if they were policies. The user-overrides registry is one
+        // such document: it deliberately has no space.name, and without this filter it fell through the
+        // space check below and had a meaningless space.hash written into it on every recalculation.
+        searchRequest
+                .source()
+                .query(QueryBuilders.boolQuery().filter(QueryBuilders.existsQuery(Constants.Q_SPACE_NAME)))
+                .size(10000);
 
         this.client.search(
                 searchRequest,

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/UserOverridesService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/UserOverridesService.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.transport.client.Client;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+import com.wazuh.contentmanager.cti.catalog.model.Resource;
+import com.wazuh.contentmanager.cti.catalog.model.UserOverrides;
+import com.wazuh.contentmanager.utils.Constants;
+
+/**
+ * Reads and writes the single registry document that holds the user's overrides for a space: the
+ * policy settings they changed and a serialized copy of the filters they created.
+ *
+ * <p>The document lives in the policies index under {@link Constants#USER_OVERRIDES_DOC_ID} and
+ * deliberately carries no {@code space} field. That absence is what keeps it out of the
+ * pre-snapshot wipe, which selects by {@code space.name}, and what makes the plan-change reindex
+ * carry it into the new physical index. Its space keys live inside the {@code user_overrides}
+ * object instead.
+ *
+ * <p>Every write is a read-modify-write on one shared document, so writers are serialized
+ * optimistically with {@code ifSeqNo}/{@code ifPrimaryTerm} rather than with a mutex: a conflict
+ * re-reads and re-applies the change against the winner's document, bounded by {@link
+ * Constants#MAX_USER_OVERRIDES_UPDATE_ATTEMPTS}.
+ */
+public class UserOverridesService {
+
+    private static final Logger log = LogManager.getLogger(UserOverridesService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Client client;
+    private final SpaceService spaceService;
+
+    /**
+     * Constructor.
+     *
+     * @param client OpenSearch client used for the registry's get and index operations.
+     * @param spaceService used to locate a space's policy and its real document id when re-applying.
+     */
+    public UserOverridesService(Client client, SpaceService spaceService) {
+        this.client = client;
+        this.spaceService = spaceService;
+    }
+
+    /**
+     * Reads one space's stored overrides.
+     *
+     * @param spaceName the space to read.
+     * @param listener receives the overrides; empty when the registry does not exist yet, which is
+     *     the normal state of a cluster where nobody has changed anything.
+     */
+    public void read(String spaceName, ActionListener<UserOverrides> listener) {
+        this.client.get(
+                registryGetRequest(),
+                ActionListener.wrap(
+                        response -> listener.onResponse(parse(response, spaceName)),
+                        e -> {
+                            log.error(Constants.E_LOG_USER_OVERRIDES_REGISTRY_READ_FAILED, e.getMessage());
+                            listener.onFailure(e);
+                        }));
+    }
+
+    /**
+     * Applies {@code mutator} to one space's stored overrides and writes the result back.
+     *
+     * <p>The mutator receives the overrides currently stored for that space and returns the ones to
+     * store. Only that space's key is replaced; the other spaces in the document are left untouched.
+     *
+     * @param spaceName the space whose overrides are being changed.
+     * @param mutator receives the current overrides and returns the ones to store.
+     * @param listener notified once the registry has been written.
+     */
+    public void update(
+            String spaceName, UnaryOperator<UserOverrides> mutator, ActionListener<Void> listener) {
+        this.tryUpdate(spaceName, mutator, 1, listener);
+    }
+
+    private void tryUpdate(
+            String spaceName,
+            UnaryOperator<UserOverrides> mutator,
+            int attempt,
+            ActionListener<Void> listener) {
+        this.client.get(
+                registryGetRequest(),
+                ActionListener.wrap(
+                        response -> {
+                            IndexRequest request = buildWriteRequest(response);
+                            ObjectNode root = readRoot(response);
+
+                            ObjectNode registry = (ObjectNode) root.get(Constants.KEY_USER_OVERRIDES);
+                            mutator
+                                    .apply(UserOverrides.forSpace(registry, spaceName))
+                                    .writeInto(registry, spaceName);
+
+                            this.client.index(
+                                    request.source(root.toString(), XContentType.JSON),
+                                    ActionListener.wrap(
+                                            indexed -> listener.onResponse(null),
+                                            e -> this.onWriteFailure(spaceName, mutator, attempt, e, listener)));
+                        },
+                        e -> {
+                            log.error(Constants.E_LOG_USER_OVERRIDES_REGISTRY_READ_FAILED, e.getMessage());
+                            listener.onFailure(e);
+                        }));
+    }
+
+    /**
+     * Retries the whole read-modify-write on a version conflict.
+     *
+     * <p>Re-reading is the point: retrying with the document already in hand would write the same
+     * stale content again and discard the concurrent writer's change just as surely as having no
+     * guard at all.
+     */
+    private void onWriteFailure(
+            String spaceName,
+            UnaryOperator<UserOverrides> mutator,
+            int attempt,
+            Exception e,
+            ActionListener<Void> listener) {
+        boolean conflict = ExceptionsHelper.unwrap(e, VersionConflictEngineException.class) != null;
+        if (conflict && attempt < Constants.MAX_USER_OVERRIDES_UPDATE_ATTEMPTS) {
+            log.debug(Constants.D_LOG_USER_OVERRIDES_REGISTRY_CONFLICT, attempt);
+            this.tryUpdate(spaceName, mutator, attempt + 1, listener);
+            return;
+        }
+        log.error(Constants.E_LOG_USER_OVERRIDES_REGISTRY_WRITE_FAILED, e.getMessage());
+        listener.onFailure(e);
+    }
+
+    /**
+     * Re-applies a space's stored overrides after it has been rebuilt from CTI.
+     *
+     * <p>Runs after every sync that changed anything, so it must be idempotent: filters are recreated
+     * under their original ids and their ids appended to the policy only when missing.
+     *
+     * <p>The order matters. Filters are restored first so their ids exist by the time the policy's
+     * {@code filters} array is rewritten, and the policy is written once with everything merged
+     * rather than once per change.
+     *
+     * @param spaceName the space to restore.
+     * @param listener notified once everything has been applied. A missing policy or an unreadable
+     *     stored filter resolves successfully: the registry is durable, so the next sync retries.
+     */
+    public void apply(String spaceName, ActionListener<Void> listener) {
+        this.read(
+                spaceName,
+                ActionListener.wrap(
+                        overrides -> {
+                            if (overrides.getPolicy() == null && overrides.getFilters().isEmpty()) {
+                                listener.onResponse(null);
+                                return;
+                            }
+                            this.restoreFilters(
+                                    overrides,
+                                    ActionListener.wrap(
+                                            restoredIds ->
+                                                    this.applyToPolicy(spaceName, overrides, restoredIds, listener),
+                                            listener::onFailure));
+                        },
+                        listener::onFailure));
+    }
+
+    /**
+     * Recreates the user's filters, each under the id it originally had.
+     *
+     * <p>Reusing the id is what lets the policy's {@code filters} array keep pointing at the same
+     * values, and what makes a second apply a no-op rather than a duplicate.
+     *
+     * @param overrides the stored overrides.
+     * @param listener receives the ids that were restored, in registry order.
+     */
+    private void restoreFilters(UserOverrides overrides, ActionListener<List<String>> listener) {
+        List<String> ids = new ArrayList<>();
+        BulkRequest bulk = new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (UserOverrides.StoredFilter stored : overrides.getFilters()) {
+            try {
+                MAPPER.readTree(stored.getDocument());
+            } catch (Exception e) {
+                // One corrupt entry must not cost the user the rest of their filters.
+                log.warn(Constants.W_LOG_USER_OVERRIDES_FILTER_UNREADABLE, stored.getId(), e.getMessage());
+                continue;
+            }
+            bulk.add(
+                    new IndexRequest(Constants.INDEX_FILTERS)
+                            .id(stored.getId())
+                            .source(stored.getDocument(), XContentType.JSON));
+            ids.add(stored.getId());
+        }
+
+        if (bulk.numberOfActions() == 0) {
+            listener.onResponse(ids);
+            return;
+        }
+        this.client.bulk(
+                bulk, ActionListener.wrap(response -> listener.onResponse(ids), listener::onFailure));
+    }
+
+    /**
+     * Merges the stored settings into the rebuilt policy and writes it back once.
+     *
+     * <p>Everything the rebuild wrote that is not a user-owned setting passes through untouched --
+     * {@code space}, {@code offset} and the rest of {@code document}. Losing {@code space.name} in
+     * particular would make the policy invisible to every space-scoped query in the plugin.
+     */
+    private void applyToPolicy(
+            String spaceName,
+            UserOverrides overrides,
+            List<String> restoredFilterIds,
+            ActionListener<Void> listener) {
+        this.spaceService.getPolicy(
+                spaceName,
+                ActionListener.wrap(
+                        policySource -> {
+                            if (policySource == null) {
+                                log.warn(Constants.W_LOG_USER_OVERRIDES_POLICY_MISSING, spaceName);
+                                listener.onResponse(null);
+                                return;
+                            }
+
+                            ObjectNode wrapper = MAPPER.valueToTree(policySource);
+                            ObjectNode document = (ObjectNode) wrapper.get(Constants.KEY_DOCUMENT);
+                            if (document == null) {
+                                log.warn(Constants.W_LOG_USER_OVERRIDES_POLICY_MISSING, spaceName);
+                                listener.onResponse(null);
+                                return;
+                            }
+
+                            mergeSettings(document, overrides.getPolicy());
+                            int attached = attachFilterIds(document, restoredFilterIds);
+                            refreshHash(wrapper, document);
+
+                            log.info(
+                                    Constants.I_LOG_USER_OVERRIDES_APPLIED,
+                                    spaceName,
+                                    overrides.getPolicy() != null,
+                                    attached);
+
+                            this.writePolicy(spaceName, document, wrapper, listener);
+                        },
+                        listener::onFailure));
+    }
+
+    /** Writes the merged policy back under its real document id. */
+    private void writePolicy(
+            String spaceName, ObjectNode document, ObjectNode wrapper, ActionListener<Void> listener) {
+        this.spaceService.findDocumentIdAsync(
+                Constants.INDEX_POLICIES,
+                spaceName,
+                document.path(Constants.KEY_ID).asText(null),
+                ActionListener.wrap(
+                        realId -> {
+                            if (realId == null) {
+                                log.warn(Constants.W_LOG_USER_OVERRIDES_POLICY_MISSING, spaceName);
+                                listener.onResponse(null);
+                                return;
+                            }
+                            this.client.index(
+                                    new IndexRequest(Constants.INDEX_POLICIES)
+                                            .id(realId)
+                                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                                            .source(wrapper.toString(), XContentType.JSON),
+                                    ActionListener.wrap(indexed -> listener.onResponse(null), listener::onFailure));
+                        },
+                        listener::onFailure));
+    }
+
+    /**
+     * Writes the settings the user owns over CTI's values.
+     *
+     * <p>A {@code null} setting means the user never decided that field, so CTI's value stays. That
+     * is the same absence-is-meaningful rule the integrations' {@code user_enabled} follows.
+     */
+    private static void mergeSettings(ObjectNode document, UserOverrides.PolicySettings settings) {
+        if (settings == null) {
+            return;
+        }
+        if (settings.getEnabled() != null) {
+            document.put(Constants.KEY_ENABLED, settings.getEnabled().booleanValue());
+        }
+        if (settings.getIndexUnclassifiedEvents() != null) {
+            document.put(
+                    Constants.KEY_INDEX_UNCLASSIFIED_EVENTS,
+                    settings.getIndexUnclassifiedEvents().booleanValue());
+        }
+        if (settings.getIndexDiscardedEvents() != null) {
+            document.put(
+                    Constants.KEY_INDEX_DISCARDED_EVENTS, settings.getIndexDiscardedEvents().booleanValue());
+        }
+        if (settings.getEnrichments() != null) {
+            List<String> ctiList = new ArrayList<>();
+            document.path(Constants.KEY_ENRICHMENTS).forEach(entry -> ctiList.add(entry.asText()));
+
+            ArrayNode merged = document.arrayNode();
+            settings.getEnrichments().applyTo(ctiList).forEach(merged::add);
+            document.set(Constants.KEY_ENRICHMENTS, merged);
+        }
+    }
+
+    /**
+     * Appends the restored filter ids to the policy's {@code filters} array, which the rebuild
+     * empties.
+     *
+     * <p>Ids already present are skipped, which is what makes applying twice harmless.
+     *
+     * @return how many ids were appended.
+     */
+    private static int attachFilterIds(ObjectNode document, List<String> filterIds) {
+        ArrayNode filters =
+                document.has(Constants.KEY_FILTERS) && document.get(Constants.KEY_FILTERS).isArray()
+                        ? (ArrayNode) document.get(Constants.KEY_FILTERS)
+                        : document.putArray(Constants.KEY_FILTERS);
+
+        Set<String> present = new LinkedHashSet<>();
+        filters.forEach(entry -> present.add(entry.asText()));
+
+        int attached = 0;
+        for (String id : filterIds) {
+            if (present.add(id)) {
+                filters.add(id);
+                attached++;
+            }
+        }
+        return attached;
+    }
+
+    /**
+     * Recomputes {@code hash.sha256} over the merged document.
+     *
+     * <p>The sync compares this hash to decide whether content changed, so leaving the rebuild's hash
+     * in place would make it describe a document that no longer exists.
+     */
+    private static void refreshHash(ObjectNode wrapper, ObjectNode document) {
+        ObjectNode hashNode =
+                wrapper.has(Constants.KEY_HASH) && wrapper.get(Constants.KEY_HASH).isObject()
+                        ? (ObjectNode) wrapper.get(Constants.KEY_HASH)
+                        : wrapper.putObject(Constants.KEY_HASH);
+        hashNode.put(Constants.KEY_SHA256, Resource.computeSha256(document.toString()));
+    }
+
+    /**
+     * A mutator that stores a filter the user created, or refreshes the copy of one they edited.
+     *
+     * <p>The document is kept as a serialized string rather than a nested object: the policies
+     * mapping is {@code dynamic: true}, so nesting a filter's fields there would auto-map every field
+     * of every stored filter into the policies index.
+     *
+     * <p>Everything else in the space's overrides passes through untouched. That matters because the
+     * policy settings and the filters share one registry document, so returning a fresh instance here
+     * would erase the settings the user had saved.
+     *
+     * @param filterId the filter's document id, reused when the filter is recreated.
+     * @param document the filter's full stored document, serialized.
+     * @return a mutator suitable for {@link #update(String, UnaryOperator, ActionListener)}.
+     */
+    public static UnaryOperator<UserOverrides> storeFilter(String filterId, String document) {
+        return current -> {
+            List<UserOverrides.StoredFilter> filters = new ArrayList<>(current.getFilters());
+            filters.removeIf(stored -> filterId.equals(stored.getId()));
+            filters.add(new UserOverrides.StoredFilter(filterId, document));
+            return new UserOverrides(current.getPolicy(), filters);
+        };
+    }
+
+    /**
+     * A mutator that drops a filter the user deleted, so the next rebuild does not recreate it.
+     *
+     * <p>Removing an id that was never stored is a no-op: the caller does not have to know whether
+     * the filter had been recorded, which keeps the delete path free of an extra read.
+     *
+     * @param filterId the filter's document id.
+     * @return a mutator suitable for {@link #update(String, UnaryOperator, ActionListener)}.
+     */
+    public static UnaryOperator<UserOverrides> removeFilter(String filterId) {
+        return current -> {
+            List<UserOverrides.StoredFilter> filters = new ArrayList<>(current.getFilters());
+            filters.removeIf(stored -> filterId.equals(stored.getId()));
+            return new UserOverrides(current.getPolicy(), filters);
+        };
+    }
+
+    private static GetRequest registryGetRequest() {
+        return new GetRequest(Constants.INDEX_POLICIES, Constants.USER_OVERRIDES_DOC_ID);
+    }
+
+    /**
+     * Builds the write request for the registry, guarded against concurrent writers.
+     *
+     * <p>An existing document is written with the sequence number and primary term just read, so a
+     * writer that raced us loses and retries. A document that does not exist yet has no sequence
+     * number to compare, so {@code opType=CREATE} takes that role: of two callers creating the
+     * registry at once, exactly one succeeds.
+     */
+    private static IndexRequest buildWriteRequest(GetResponse response) {
+        IndexRequest request =
+                new IndexRequest(Constants.INDEX_POLICIES)
+                        .id(Constants.USER_OVERRIDES_DOC_ID)
+                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        if (response.isExists()) {
+            return request.setIfSeqNo(response.getSeqNo()).setIfPrimaryTerm(response.getPrimaryTerm());
+        }
+        return request.opType(DocWriteRequest.OpType.CREATE);
+    }
+
+    /**
+     * @return the registry document's root, with the {@code user_overrides} object guaranteed
+     *     present.
+     */
+    private static ObjectNode readRoot(GetResponse response) throws Exception {
+        ObjectNode root =
+                response.isExists()
+                        ? (ObjectNode) MAPPER.readTree(response.getSourceAsString())
+                        : MAPPER.createObjectNode();
+
+        if (!root.has(Constants.KEY_USER_OVERRIDES)) {
+            root.set(Constants.KEY_USER_OVERRIDES, MAPPER.createObjectNode());
+        }
+        return root;
+    }
+
+    private static UserOverrides parse(GetResponse response, String spaceName) throws Exception {
+        if (!response.isExists()) {
+            return UserOverrides.forSpace(null, spaceName);
+        }
+        ObjectNode root = (ObjectNode) MAPPER.readTree(response.getSourceAsString());
+        return UserOverrides.forSpace(root.get(Constants.KEY_USER_OVERRIDES), spaceName);
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
@@ -408,9 +408,15 @@ public abstract class AbstractTransportCreateActionSpaces
                                                                                     "Created",
                                                                                     this.getResourceType(),
                                                                                     id);
-                                                                            respond(
-                                                                                    listener,
-                                                                                    new RestResponse(id, RestStatus.CREATED.getStatus()));
+                                                                            this.afterResourceCommitted(
+                                                                                    id,
+                                                                                    spaceName,
+                                                                                    ctiWrapper,
+                                                                                    () ->
+                                                                                            respond(
+                                                                                                    listener,
+                                                                                                    new RestResponse(
+                                                                                                            id, RestStatus.CREATED.getStatus())));
                                                                         },
                                                                         e -> respondWithError(listener, e))),
                                                 e -> {
@@ -462,6 +468,23 @@ public abstract class AbstractTransportCreateActionSpaces
 
     protected boolean requiresIntegrationId() {
         return true;
+    }
+
+    /**
+     * Called once the resource has been indexed, linked to its parent and the space hash recalculated
+     * -- that is, once the creation is committed and the request is about to be answered.
+     *
+     * <p>Exists so a subclass can persist something derived from the new resource without failing the
+     * request if that persistence fails. The default does nothing.
+     *
+     * @param id the created resource's document id.
+     * @param spaceName the space it was created in.
+     * @param ctiWrapper the document exactly as it was indexed.
+     * @param onDone must be run once, whatever the outcome, to answer the request.
+     */
+    protected void afterResourceCommitted(
+            String id, String spaceName, ObjectNode ctiWrapper, Runnable onDone) {
+        onDone.run();
     }
 
     protected abstract String getIndexName();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
@@ -242,7 +242,11 @@ public abstract class AbstractTransportDeleteActionSpaces
                                     ActionListener.wrap(
                                             changed -> {
                                                 log.info(Constants.I_LOG_SUCCESS, "Deleted", this.getResourceType(), id);
-                                                respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
+                                                this.afterResourceDeleted(
+                                                        id,
+                                                        spaceName,
+                                                        () ->
+                                                                respond(listener, new RestResponse(id, RestStatus.OK.getStatus())));
                                             },
                                             e -> respondWithError(listener, id, e)));
                         },
@@ -326,6 +330,22 @@ public abstract class AbstractTransportDeleteActionSpaces
             cause = cause.getCause();
         }
         return false;
+    }
+
+    /**
+     * Called once the resource has been unlinked from its parent, deleted and the space hash
+     * recalculated -- that is, once the deletion is committed and the request is about to be
+     * answered.
+     *
+     * <p>Exists so a subclass can drop something it had persisted for this resource without failing
+     * the request if that fails. The default does nothing.
+     *
+     * @param id the deleted resource's document id.
+     * @param spaceName the space it was deleted from.
+     * @param onDone must be run once, whatever the outcome, to answer the request.
+     */
+    protected void afterResourceDeleted(String id, String spaceName, Runnable onDone) {
+        onDone.run();
     }
 
     protected abstract String getIndexName();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
@@ -334,7 +334,13 @@ public abstract class AbstractTransportUpdateActionSpaces
                                         ActionListener.wrap(
                                                 changed -> {
                                                     log.info(Constants.I_LOG_SUCCESS, "Updated", this.getResourceType(), id);
-                                                    respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
+                                                    this.afterResourceCommitted(
+                                                            id,
+                                                            spaceName,
+                                                            ctiWrapper,
+                                                            () ->
+                                                                    respond(
+                                                                            listener, new RestResponse(id, RestStatus.OK.getStatus())));
                                                 },
                                                 e -> respondWithError(listener, id, e))),
                         e -> respondWithError(listener, id, e)));
@@ -441,6 +447,23 @@ public abstract class AbstractTransportUpdateActionSpaces
 
     protected boolean supportsYamlField() {
         return false;
+    }
+
+    /**
+     * Called once the resource has been reindexed and the space hash recalculated -- that is, once
+     * the update is committed and the request is about to be answered.
+     *
+     * <p>Exists so a subclass can persist something derived from the updated resource without failing
+     * the request if that persistence fails. The default does nothing.
+     *
+     * @param id the updated resource's document id.
+     * @param spaceName the space it lives in.
+     * @param ctiWrapper the document exactly as it was indexed.
+     * @param onDone must be run once, whatever the outcome, to answer the request.
+     */
+    protected void afterResourceCommitted(
+            String id, String spaceName, ObjectNode ctiWrapper, Runnable onDone) {
+        onDone.run();
     }
 
     protected abstract String getIndexName();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/FilterOverrideRecorder.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/FilterOverrideRecorder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.action.ActionListener;
+
+import java.util.function.UnaryOperator;
+
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.model.UserOverrides;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
+import com.wazuh.contentmanager.utils.Constants;
+
+/**
+ * Shared tail end of the three filter actions' registry bookkeeping.
+ *
+ * <p>Creating, updating and deleting a filter each live in a different transport hierarchy, but all
+ * three need the same two decisions afterwards: skip every space but {@code standard}, and never
+ * let a registry problem fail a request that has already succeeded.
+ */
+final class FilterOverrideRecorder {
+
+    private static final Logger log = LogManager.getLogger(FilterOverrideRecorder.class);
+
+    private FilterOverrideRecorder() {}
+
+    /**
+     * Applies {@code mutator} to the standard space's stored overrides, then runs {@code onDone}.
+     *
+     * <p>Other spaces are skipped outright: {@code draft}, {@code test} and {@code custom} are never
+     * rebuilt from CTI, so their filters survive a sync without any help.
+     *
+     * <p>A registry failure is logged and swallowed. By the time this runs the filter itself has been
+     * written, unlinked or deleted, and the space hash recalculated -- the user's request did
+     * succeed. The cost of the failure is that this filter will not survive the next rebuild, which
+     * the log message says explicitly.
+     *
+     * @param userOverridesService the registry.
+     * @param spaceName the space the filter operation happened in.
+     * @param mutator what to change in the registry, from {@link UserOverridesService#storeFilter} or
+     *     {@link UserOverridesService#removeFilter}.
+     * @param filterId the filter's document id, for the log message.
+     * @param onDone run once, whatever the outcome, to answer the request.
+     */
+    static void record(
+            UserOverridesService userOverridesService,
+            String spaceName,
+            UnaryOperator<UserOverrides> mutator,
+            String filterId,
+            Runnable onDone) {
+        if (!Space.STANDARD.equals(spaceName)) {
+            onDone.run();
+            return;
+        }
+
+        userOverridesService.update(
+                spaceName,
+                mutator,
+                ActionListener.wrap(
+                        v -> onDone.run(),
+                        e -> {
+                            log.warn(
+                                    Constants.W_LOG_USER_OVERRIDES_FILTER_RECORD_FAILED, filterId, e.getMessage());
+                            onDone.run();
+                        }));
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateFilterAction.java
@@ -36,6 +36,7 @@ import com.wazuh.contentmanager.action.CreateFilterAction;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -47,13 +48,28 @@ public class TransportCreateFilterAction extends AbstractTransportCreateActionSp
     private static final Set<Space> validSpaces = Set.of(Space.DRAFT, Space.STANDARD);
     private String spaceName = "";
 
+    private final UserOverridesService userOverridesService;
+
     @Inject
     public TransportCreateFilterAction(
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
+            EngineService engine,
+            UserOverridesService userOverridesService) {
         super(CreateFilterAction.NAME, transportService, actionFilters, client, engine);
+        this.userOverridesService = userOverridesService;
+    }
+
+    @Override
+    protected void afterResourceCommitted(
+            String id, String spaceName, ObjectNode ctiWrapper, Runnable onDone) {
+        FilterOverrideRecorder.record(
+                this.userOverridesService,
+                spaceName,
+                UserOverridesService.storeFilter(id, ctiWrapper.toString()),
+                id,
+                onDone);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationAction.java
@@ -117,9 +117,8 @@ public class TransportCreateIntegrationAction extends AbstractTransportCreateAct
                             // Integrations created through the API are always user-managed.
                             ((ObjectNode) resource).put(Constants.KEY_MODE, Constants.MODE_USER_MANAGED);
 
-                            // 'user_enabled' carries the user's choice in every space. Default it
-                            // the way 'enabled' used to be defaulted, then derive 'enabled' from it
-                            // so the resolution rule lives in exactly one place.
+                            // 'cti_enabled' is server-managed; 'user_enabled' defaults to true, as
+                            // 'enabled' used to, and 'enabled' is derived from it via the resolver.
                             ObjectNode resourceNode = (ObjectNode) resource;
                             resourceNode.remove(Constants.KEY_CTI_ENABLED);
                             if (!resourceNode.has(Constants.KEY_USER_ENABLED)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationAction.java
@@ -116,6 +116,12 @@ public class TransportCreateIntegrationAction extends AbstractTransportCreateAct
                             // Integrations created through the API are always user-managed.
                             ((ObjectNode) resource).put(Constants.KEY_MODE, Constants.MODE_USER_MANAGED);
 
+                            // Integrations are created in 'draft', where neither field has any
+                            // meaning: stop a forged override from entering here and surviving
+                            // promotion to 'standard'.
+                            ((ObjectNode) resource).remove(Constants.KEY_USER_ENABLED);
+                            ((ObjectNode) resource).remove(Constants.KEY_CTI_ENABLED);
+
                             listener.onResponse(null);
                         },
                         listener::onFailure));

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationAction.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import com.wazuh.contentmanager.action.CreateIntegrationAction;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
+import com.wazuh.contentmanager.cti.catalog.index.IntegrationEnabledResolver;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.IntegrationService;
@@ -116,11 +117,16 @@ public class TransportCreateIntegrationAction extends AbstractTransportCreateAct
                             // Integrations created through the API are always user-managed.
                             ((ObjectNode) resource).put(Constants.KEY_MODE, Constants.MODE_USER_MANAGED);
 
-                            // Integrations are created in 'draft', where neither field has any
-                            // meaning: stop a forged override from entering here and surviving
-                            // promotion to 'standard'.
-                            ((ObjectNode) resource).remove(Constants.KEY_USER_ENABLED);
-                            ((ObjectNode) resource).remove(Constants.KEY_CTI_ENABLED);
+                            // 'user_enabled' carries the user's choice in every space. Default it
+                            // the way 'enabled' used to be defaulted, then derive 'enabled' from it
+                            // so the resolution rule lives in exactly one place.
+                            ObjectNode resourceNode = (ObjectNode) resource;
+                            resourceNode.remove(Constants.KEY_CTI_ENABLED);
+                            if (!resourceNode.has(Constants.KEY_USER_ENABLED)
+                                    || resourceNode.get(Constants.KEY_USER_ENABLED).isNull()) {
+                                resourceNode.put(Constants.KEY_USER_ENABLED, true);
+                            }
+                            IntegrationEnabledResolver.resolve(resourceNode);
 
                             listener.onResponse(null);
                         },

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportDeleteFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportDeleteFilterAction.java
@@ -34,6 +34,7 @@ import com.wazuh.contentmanager.action.DeleteFilterAction;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -43,13 +44,23 @@ public class TransportDeleteFilterAction extends AbstractTransportDeleteActionSp
     private static final Set<Space> validSpaces = Set.of(Space.DRAFT, Space.STANDARD);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private final UserOverridesService userOverridesService;
+
     @Inject
     public TransportDeleteFilterAction(
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
+            EngineService engine,
+            UserOverridesService userOverridesService) {
         super(DeleteFilterAction.NAME, transportService, actionFilters, client, engine);
+        this.userOverridesService = userOverridesService;
+    }
+
+    @Override
+    protected void afterResourceDeleted(String id, String spaceName, Runnable onDone) {
+        FilterOverrideRecorder.record(
+                this.userOverridesService, spaceName, UserOverridesService.removeFilter(id), id, onDone);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateFilterAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateFilterAction.java
@@ -17,6 +17,7 @@
 package com.wazuh.contentmanager.transport;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.common.inject.Inject;
@@ -30,6 +31,7 @@ import java.util.Set;
 
 import com.wazuh.contentmanager.action.UpdateFilterAction;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.utils.Constants;
@@ -39,13 +41,28 @@ public class TransportUpdateFilterAction extends AbstractTransportUpdateActionSp
 
     private static final Set<Space> validSpaces = Set.of(Space.DRAFT, Space.STANDARD);
 
+    private final UserOverridesService userOverridesService;
+
     @Inject
     public TransportUpdateFilterAction(
             TransportService transportService,
             ActionFilters actionFilters,
             Client client,
-            EngineService engine) {
+            EngineService engine,
+            UserOverridesService userOverridesService) {
         super(UpdateFilterAction.NAME, transportService, actionFilters, client, engine);
+        this.userOverridesService = userOverridesService;
+    }
+
+    @Override
+    protected void afterResourceCommitted(
+            String id, String spaceName, ObjectNode ctiWrapper, Runnable onDone) {
+        FilterOverrideRecorder.record(
+                this.userOverridesService,
+                spaceName,
+                UserOverridesService.storeFilter(id, ctiWrapper.toString()),
+                id,
+                onDone);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
@@ -64,9 +64,8 @@ import static org.opensearch.rest.RestRequest.Method.PUT;
  * </ul>
  *
  * <p>{@code user_enabled} carries the user's explicit choice and is required in both spaces. The
- * effective {@code enabled} is derived from it by {@link
- * com.wazuh.contentmanager.cti.catalog.index.IntegrationEnabledResolver} and is never accepted from
- * a request body, and neither is {@code cti_enabled}.
+ * effective {@code enabled} is derived from it by {@link IntegrationEnabledResolver} and is never
+ * accepted from a request body, and neither is {@code cti_enabled}.
  */
 public class TransportUpdateIntegrationAction extends AbstractTransportUpdateActionSpaces {
 
@@ -179,8 +178,7 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
         }
 
         if (Space.STANDARD.equals(space)) {
-            // Only 'user_enabled' is mutable in the standard space: it carries the user's
-            // decision, and the effective 'enabled' is derived from it.
+            // Only 'user_enabled' is mutable in the standard space
             boolean userEnabled = resourceNode.path(Constants.KEY_USER_ENABLED).asBoolean(true);
             String modified =
                     resourceNode.path(Constants.KEY_METADATA).path(Constants.KEY_MODIFIED).asText(null);
@@ -197,8 +195,7 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
             return null;
         }
 
-        // Outside the standard space there is no CTI value, so the effective 'enabled' is the
-        // user's choice. Deriving it through the resolver keeps the rule in one place.
+        // No CTI value outside the standard space, so 'enabled' is always the user's choice
         IntegrationEnabledResolver.resolve(resourceNode);
 
         @SuppressWarnings("unchecked")

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
@@ -60,8 +60,13 @@ import static org.opensearch.rest.RestRequest.Method.PUT;
  *   <li><b>protected</b> integrations (Wazuh core content) cannot be modified in any space.
  *   <li><b>user-managed</b> integrations in the {@code draft} space are fully editable.
  *   <li><b>user-managed</b> integrations in the {@code standard} space only allow toggling {@code
- *       enabled}; every other field is preserved from the stored document.
+ *       user_enabled}; every other field is preserved from the stored document.
  * </ul>
+ *
+ * <p>{@code user_enabled} carries the user's explicit choice and is required in both spaces. The
+ * effective {@code enabled} is derived from it by {@link
+ * com.wazuh.contentmanager.cti.catalog.index.IntegrationEnabledResolver} and is never accepted from
+ * a request body, and neither is {@code cti_enabled}.
  */
 public class TransportUpdateIntegrationAction extends AbstractTransportUpdateActionSpaces {
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
@@ -35,6 +35,7 @@ import java.util.Set;
 
 import com.wazuh.contentmanager.action.UpdateIntegrationAction;
 import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
+import com.wazuh.contentmanager.cti.catalog.index.IntegrationEnabledResolver;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
@@ -119,19 +120,14 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
                     Constants.E_400_RESOURCE_SPACE_INVALID, RestStatus.BAD_REQUEST.getStatus());
         }
 
-        // 'enabled' is the only field that can be changed for standard integrations
-        RestResponse fieldValidation =
-                this.documentValidations.validateRequiredFields(resource, List.of(Constants.KEY_ENABLED));
-        if (fieldValidation != null) {
-            return fieldValidation;
-        }
-
+        // 'user_enabled' is the only field that can be changed for standard integrations
         if (Space.STANDARD.equals(resolvedSpace)) {
-            return null;
+            return this.documentValidations.validateRequiredFields(
+                    resource, List.of(Constants.KEY_USER_ENABLED));
         }
 
         // Draft integrations are fully editable
-        fieldValidation =
+        RestResponse fieldValidation =
                 this.documentValidations.validateRequiredFields(
                         resource, List.of(Constants.KEY_CATEGORY, Constants.KEY_ENABLED));
         if (fieldValidation != null) {
@@ -164,15 +160,17 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
         }
         JsonNode existingDocument = existingDoc.get(Constants.KEY_DOCUMENT);
 
-        // The mode is server-managed and cannot be changed through the API
+        // Server-managed fields: never accepted from the request.
         resourceNode.remove(Constants.KEY_MODE);
+        resourceNode.remove(Constants.KEY_CTI_ENABLED);
         if (existingDocument.has(Constants.KEY_MODE)) {
             resourceNode.set(Constants.KEY_MODE, existingDocument.get(Constants.KEY_MODE));
         }
 
         if (Space.STANDARD.equals(space)) {
-            // Only 'enabled' is mutable in the standard space
-            boolean enabled = resourceNode.path(Constants.KEY_ENABLED).asBoolean(true);
+            // Only 'user_enabled' is mutable in the standard space: it carries the user's
+            // decision, and the effective 'enabled' is derived from it.
+            boolean userEnabled = resourceNode.path(Constants.KEY_USER_ENABLED).asBoolean(true);
             String modified =
                     resourceNode.path(Constants.KEY_METADATA).path(Constants.KEY_MODIFIED).asText(null);
 
@@ -180,12 +178,16 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
             resourceNode.removeAll();
             resourceNode.setAll(restored);
             resourceNode.put(Constants.KEY_ID, id);
-            resourceNode.put(Constants.KEY_ENABLED, enabled);
+            resourceNode.put(Constants.KEY_USER_ENABLED, userEnabled);
+            IntegrationEnabledResolver.resolve(resourceNode);
             if (modified != null) {
                 Resource.getOrCreateMetadataNode(resourceNode).put(Constants.KEY_MODIFIED, modified);
             }
             return null;
         }
+
+        // 'user_enabled' has no meaning outside the standard space.
+        resourceNode.remove(Constants.KEY_USER_ENABLED);
 
         @SuppressWarnings("unchecked")
         Map<String, Object> existing = MAPPER.convertValue(existingDocument, Map.class);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationAction.java
@@ -120,16 +120,22 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
                     Constants.E_400_RESOURCE_SPACE_INVALID, RestStatus.BAD_REQUEST.getStatus());
         }
 
-        // 'user_enabled' is the only field that can be changed for standard integrations
+        // 'user_enabled' carries the user's decision in every space; 'enabled' is derived.
+        RestResponse fieldValidation =
+                this.documentValidations.validateRequiredFields(
+                        resource, List.of(Constants.KEY_USER_ENABLED));
+        if (fieldValidation != null) {
+            return fieldValidation;
+        }
+
+        // Only 'user_enabled' is mutable for standard integrations
         if (Space.STANDARD.equals(resolvedSpace)) {
-            return this.documentValidations.validateRequiredFields(
-                    resource, List.of(Constants.KEY_USER_ENABLED));
+            return null;
         }
 
         // Draft integrations are fully editable
-        RestResponse fieldValidation =
-                this.documentValidations.validateRequiredFields(
-                        resource, List.of(Constants.KEY_CATEGORY, Constants.KEY_ENABLED));
+        fieldValidation =
+                this.documentValidations.validateRequiredFields(resource, List.of(Constants.KEY_CATEGORY));
         if (fieldValidation != null) {
             return fieldValidation;
         }
@@ -186,8 +192,9 @@ public class TransportUpdateIntegrationAction extends AbstractTransportUpdateAct
             return null;
         }
 
-        // 'user_enabled' has no meaning outside the standard space.
-        resourceNode.remove(Constants.KEY_USER_ENABLED);
+        // Outside the standard space there is no CTI value, so the effective 'enabled' is the
+        // user's choice. Deriving it through the resolver keeps the rule in one place.
+        IntegrationEnabledResolver.resolve(resourceNode);
 
         @SuppressWarnings("unchecked")
         Map<String, Object> existing = MAPPER.convertValue(existingDocument, Map.class);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,7 +49,9 @@ import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Policy;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.model.UserOverrides;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.rest.utils.PayloadValidations;
@@ -68,6 +71,7 @@ public class TransportUpdatePolicyAction
     private final EngineService engineService;
     private final Client client;
     private final PayloadValidations payloadValidations;
+    private final UserOverridesService userOverridesService;
 
     @Inject
     public TransportUpdatePolicyAction(
@@ -75,12 +79,14 @@ public class TransportUpdatePolicyAction
             ActionFilters actionFilters,
             SpaceService spaceService,
             EngineService engineService,
-            Client client) {
+            Client client,
+            UserOverridesService userOverridesService) {
         super(UpdatePolicyAction.NAME, transportService, actionFilters, UpdatePolicyRequest::new);
         this.spaceService = spaceService;
         this.engineService = engineService;
         this.client = client;
         this.payloadValidations = new PayloadValidations();
+        this.userOverridesService = userOverridesService;
     }
 
     @Override
@@ -300,13 +306,23 @@ public class TransportUpdatePolicyAction
             hashNode.put(Constants.KEY_SHA256, hash);
             document.set(Constants.KEY_HASH, hashNode);
 
+            // Only the standard space is rebuilt from CTI, so only its settings need recording.
+            final PendingOverride pendingOverride =
+                    Space.STANDARD.equals(spaceName)
+                            ? new PendingOverride(
+                                    incomingPolicy,
+                                    (List<String>)
+                                            currentPolicyDoc.getOrDefault(
+                                                    Constants.KEY_ENRICHMENTS, Collections.emptyList()))
+                            : null;
+
             // Find the real document _id (async)
             this.spaceService.findDocumentIdAsync(
                     Constants.INDEX_POLICIES,
                     spaceName,
                     docId,
                     ActionListener.wrap(
-                            realId -> afterFindDocumentId(realId, document, spaceName, listener),
+                            realId -> afterFindDocumentId(realId, document, spaceName, pendingOverride, listener),
                             e -> respondWithError(listener, e)));
 
         } catch (IllegalArgumentException e) {
@@ -323,6 +339,7 @@ public class TransportUpdatePolicyAction
             String documentId,
             ObjectNode document,
             String spaceName,
+            PendingOverride pendingOverride,
             ActionListener<MessageStatusResponse> listener) {
         if (documentId == null) {
             listener.onResponse(
@@ -338,12 +355,16 @@ public class TransportUpdatePolicyAction
                 documentId,
                 document,
                 ActionListener.wrap(
-                        indexResponse -> afterIndex(indexResponse.getId(), spaceName, listener),
+                        indexResponse ->
+                                afterIndex(indexResponse.getId(), spaceName, pendingOverride, listener),
                         e -> respondWithError(listener, e)));
     }
 
     private void afterIndex(
-            String policyId, String spaceName, ActionListener<MessageStatusResponse> listener) {
+            String policyId,
+            String spaceName,
+            PendingOverride pendingOverride,
+            ActionListener<MessageStatusResponse> listener) {
         // Recalculate space hash (async)
         this.spaceService.calculateAndUpdate(
                 List.of(spaceName),
@@ -352,9 +373,101 @@ public class TransportUpdatePolicyAction
                             if (changedSpaces.contains(Space.STANDARD.toString())) {
                                 this.loadStandardSpaceIntoEngine();
                             }
-                            listener.onResponse(new MessageStatusResponse(policyId, RestStatus.OK));
+                            this.recordPolicySettings(
+                                    pendingOverride,
+                                    () -> listener.onResponse(new MessageStatusResponse(policyId, RestStatus.OK)));
                         },
                         e -> respondWithError(listener, e)));
+    }
+
+    /**
+     * What the user-overrides registry needs to record once the policy write has been committed.
+     *
+     * <p>{@code null} for every space other than {@code standard}, which is the only one rebuilt from
+     * CTI and therefore the only one whose settings can be lost.
+     *
+     * @param incomingPolicy the policy the client sent.
+     * @param currentEnrichments the enrichments stored before this update, needed to work out what
+     *     the user just changed.
+     */
+    private record PendingOverride(Policy incomingPolicy, List<String> currentEnrichments) {}
+
+    /**
+     * Records the settings the user can change on the standard policy, so the next rebuild of that
+     * space can put them back.
+     *
+     * <p>Runs after the policy has been indexed, never before: recording a change that failed to
+     * apply would make the next sync apply it anyway, turning a rejected request into a delayed one.
+     *
+     * <p>All four settings are recorded on every save, by design — editing the standard policy makes
+     * its settings the user's from then on. Enrichments are the exception: they are stored as a delta
+     * against the list CTI publishes, so an enrichment CTI adds later still reaches a user who
+     * customised the selection.
+     *
+     * <p>A registry failure is logged and swallowed. The policy is already written, so the user's
+     * request succeeded; failing it here would be a lie.
+     *
+     * @param pending what to record, or {@code null} when there is nothing to record.
+     * @param onDone run once recording has finished, successfully or not.
+     */
+    private void recordPolicySettings(PendingOverride pending, Runnable onDone) {
+        if (pending == null) {
+            onDone.run();
+            return;
+        }
+
+        List<String> incomingEnrichments = pending.incomingPolicy().getEnrichments();
+        Set<String> incoming =
+                new LinkedHashSet<>(
+                        incomingEnrichments != null ? incomingEnrichments : Collections.emptyList());
+        Set<String> effective = new LinkedHashSet<>(pending.currentEnrichments());
+
+        Set<String> removedNow = new LinkedHashSet<>(effective);
+        removedNow.removeAll(incoming);
+        Set<String> addedNow = new LinkedHashSet<>(incoming);
+        addedNow.removeAll(effective);
+
+        this.userOverridesService.update(
+                Space.STANDARD.toString(),
+                current -> mergeRecordedSettings(current, pending.incomingPolicy(), removedNow, addedNow),
+                ActionListener.wrap(
+                        v -> onDone.run(),
+                        e -> {
+                            log.error(Constants.E_LOG_USER_OVERRIDES_REGISTRY_WRITE_FAILED, e.getMessage());
+                            onDone.run();
+                        }));
+    }
+
+    /**
+     * Folds this save's enrichment change into whatever the registry already holds.
+     *
+     * <p>Removing something the user had added, or adding back something they had removed, cancels
+     * the earlier entry rather than accumulating both — otherwise a value could sit in both sets at
+     * once and the delta would stop describing the user's intent.
+     *
+     * <p>The stored filters pass through untouched: the policy and the filters share one registry
+     * document, so returning anything else here would delete the user's filters.
+     */
+    private static UserOverrides mergeRecordedSettings(
+            UserOverrides current, Policy incomingPolicy, Set<String> removedNow, Set<String> addedNow) {
+        Set<String> removed = new LinkedHashSet<>();
+        Set<String> added = new LinkedHashSet<>();
+        if (current.getPolicy() != null && current.getPolicy().getEnrichments() != null) {
+            removed.addAll(current.getPolicy().getEnrichments().getRemoved());
+            added.addAll(current.getPolicy().getEnrichments().getAdded());
+        }
+        removed.addAll(removedNow);
+        removed.removeAll(addedNow);
+        added.addAll(addedNow);
+        added.removeAll(removedNow);
+
+        return new UserOverrides(
+                new UserOverrides.PolicySettings(
+                        incomingPolicy.getEnabled(),
+                        incomingPolicy.getIndexUnclassifiedEvents(),
+                        incomingPolicy.getIndexDiscardedEvents(),
+                        new UserOverrides.EnrichmentDelta(removed, added)),
+                current.getFilters());
     }
 
     @SuppressWarnings("unchecked")

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -286,6 +286,9 @@ public class Constants {
     public static final String D_LOG_SNAPSHOT_WAIT_PENDING_BULK =
             "Waiting for pending bulk updates to finish...";
     public static final String E_LOG_SNAPSHOT_PROCESS_FAILED = "Error processing snapshot: {}";
+    public static final String E_LOG_USER_OVERRIDES_READ_FAILED =
+            "Failed to read stored integration enabled overrides for consumer [{}]; aborting snapshot"
+                    + " so user decisions are not lost: {}";
     public static final String D_LOG_SNAPSHOT_NO_INDEX_FOR_TYPE =
             "No ContentIndex found for type [{}]. Skipping.";
     public static final String D_LOG_SNAPSHOT_PARSE_LINE_FAILED =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -604,6 +604,13 @@ public class Constants {
     public static final String KEY_MODIFIED = "modified";
     public static final String KEY_OFFSET = "offset";
     public static final String KEY_ENABLED = "enabled";
+
+    /** Document field holding the user's explicit enabled choice. Absent means never set. */
+    public static final String KEY_USER_ENABLED = "user_enabled";
+
+    /** Document field holding the enabled state published by CTI. */
+    public static final String KEY_CTI_ENABLED = "cti_enabled";
+
     public static final String KEY_MODE = "mode";
     public static final String KEY_DETECTOR = "detector";
     public static final String KEY_SOURCE = "source";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -286,6 +286,24 @@ public class Constants {
     public static final String D_LOG_SNAPSHOT_WAIT_PENDING_BULK =
             "Waiting for pending bulk updates to finish...";
     public static final String E_LOG_SNAPSHOT_PROCESS_FAILED = "Error processing snapshot: {}";
+
+    // Log messages - user overrides registry (UserOverridesService)
+    public static final String E_LOG_USER_OVERRIDES_REGISTRY_READ_FAILED =
+            "Failed to read the user overrides registry: {}";
+    public static final String E_LOG_USER_OVERRIDES_REGISTRY_WRITE_FAILED =
+            "Failed to write the user overrides registry: {}";
+    public static final String D_LOG_USER_OVERRIDES_REGISTRY_CONFLICT =
+            "User overrides registry write conflicted on attempt {}; re-reading and retrying.";
+    public static final String I_LOG_USER_OVERRIDES_APPLIED =
+            "Applied user overrides for space [{}]: policy settings present={}, {} filter id(s) attached";
+    public static final String W_LOG_USER_OVERRIDES_FILTER_UNREADABLE =
+            "Stored filter [{}] could not be parsed and was skipped; it will not be restored: {}";
+    public static final String W_LOG_USER_OVERRIDES_POLICY_MISSING =
+            "No policy found for space [{}] while applying user overrides. The registry is durable, so the"
+                    + " next synchronization will apply them.";
+    public static final String W_LOG_USER_OVERRIDES_FILTER_RECORD_FAILED =
+            "Failed to record filter [{}] in the user overrides registry. The filter itself is fine, but"
+                    + " it will not survive the next content rebuild of the standard space: {}";
     public static final String E_LOG_USER_OVERRIDES_READ_FAILED =
             "Failed to read stored integration enabled overrides for consumer [{}]; aborting snapshot"
                     + " so user decisions are not lost: {}";
@@ -572,6 +590,22 @@ public class Constants {
     public static final String INDEX_CVES = ".wazuh-threatintel-vulnerabilities";
     public static final String INDEX_FILTERS = "wazuh-threatintel-filters";
 
+    /**
+     * Document id of the single user-overrides registry document, stored in {@link #INDEX_POLICIES}.
+     *
+     * <p>That document deliberately carries no {@code space} field: the pre-snapshot wipe selects by
+     * {@code space.name}, so leaving it out is what keeps the registry from deleting itself, and what
+     * makes the plan-change reindex carry it into the new physical index.
+     */
+    public static final String USER_OVERRIDES_DOC_ID = "wazuh-user-overrides";
+
+    /**
+     * How many times a user-overrides registry write is retried on a version conflict before giving
+     * up. The registry is one shared document, so concurrent writers are serialized optimistically:
+     * each conflict re-reads and re-applies, and this bounds the loop.
+     */
+    public static final int MAX_USER_OVERRIDES_UPDATE_ATTEMPTS = 3;
+
     // Consumer types
     public static final String CONSUMER_TYPE_VULNERABILITIES = "cti:catalog:consumer:vulnerabilities";
     public static final String CONSUMER_TYPE_IOCS = "cti:catalog:consumer:iocs";
@@ -609,6 +643,15 @@ public class Constants {
     public static final String KEY_ENABLED = "enabled";
     public static final String KEY_USER_ENABLED = "user_enabled";
     public static final String KEY_CTI_ENABLED = "cti_enabled";
+    public static final String KEY_INDEX_UNCLASSIFIED_EVENTS = "index_unclassified_events";
+    public static final String KEY_INDEX_DISCARDED_EVENTS = "index_discarded_events";
+
+    // User overrides registry keys
+    public static final String KEY_USER_OVERRIDES = "user_overrides";
+    public static final String KEY_POLICY_SETTINGS = "policy";
+    public static final String KEY_ENRICHMENTS_REMOVED = "removed";
+    public static final String KEY_ENRICHMENTS_ADDED = "added";
+    public static final String KEY_STORED_FILTERS = "filters";
     public static final String KEY_MODE = "mode";
     public static final String KEY_DETECTOR = "detector";
     public static final String KEY_SOURCE = "source";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -607,13 +607,8 @@ public class Constants {
     public static final String KEY_MODIFIED = "modified";
     public static final String KEY_OFFSET = "offset";
     public static final String KEY_ENABLED = "enabled";
-
-    /** Document field holding the user's explicit enabled choice. Absent means never set. */
     public static final String KEY_USER_ENABLED = "user_enabled";
-
-    /** Document field holding the enabled state published by CTI. */
     public static final String KEY_CTI_ENABLED = "cti_enabled";
-
     public static final String KEY_MODE = "mode";
     public static final String KEY_DETECTOR = "detector";
     public static final String KEY_SOURCE = "source";

--- a/plugins/content-manager/src/main/resources/mappings/cti-integrations-mappings.json
+++ b/plugins/content-manager/src/main/resources/mappings/cti-integrations-mappings.json
@@ -44,6 +44,12 @@
         "enabled": {
           "type": "boolean"
         },
+        "user_enabled": {
+          "type": "boolean"
+        },
+        "cti_enabled": {
+          "type": "boolean"
+        },
         "mode": {
           "type": "keyword"
         },

--- a/plugins/content-manager/src/main/resources/mappings/cti-policies-mappings.json
+++ b/plugins/content-manager/src/main/resources/mappings/cti-policies-mappings.json
@@ -84,6 +84,10 @@
           }
         }
       }
+    },
+    "user_overrides": {
+      "type": "object",
+      "enabled": false
     }
   }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerRestTestCase.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerRestTestCase.java
@@ -649,7 +649,7 @@ public abstract class ContentManagerRestTestCase extends OpenSearchRestTestCase 
                 {
                     "resource": {
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "metadata": {
                             "title": "%s",
                             "author": "Wazuh Inc.",

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.apache.lucene.search.TotalHits;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
@@ -30,11 +31,16 @@ import org.opensearch.action.get.MultiGetRequest;
 import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.breaker.CircuitBreakingException;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.Client;
 import org.junit.After;
@@ -43,7 +49,9 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.wazuh.contentmanager.cti.catalog.model.Operation;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -737,5 +745,58 @@ public class ContentIndexTests extends OpenSearchTestCase {
 
         verify(this.client, times(2)).get(any(GetRequest.class));
         verify(this.client).index(any(IndexRequest.class));
+    }
+
+    /**
+     * Stubs {@code client.search} to return three hits: {@code suricata} with {@code
+     * user_enabled=true}, {@code docker} with {@code user_enabled=false}, and {@code o365} with no
+     * {@code user_enabled} field at all (proving absent fields are skipped, not defaulted).
+     */
+    private void stubIntegrationOverrideSearch() {
+        SearchHit suricataHit =
+                new SearchHit(1, "suricata-id", Collections.emptyMap(), Collections.emptyMap());
+        suricataHit.sourceRef(
+                new BytesArray(
+                        "{\"document\":{\"metadata\":{\"title\":\"suricata\"},\"user_enabled\":true}}"));
+
+        SearchHit dockerHit =
+                new SearchHit(2, "docker-id", Collections.emptyMap(), Collections.emptyMap());
+        dockerHit.sourceRef(
+                new BytesArray(
+                        "{\"document\":{\"metadata\":{\"title\":\"docker\"},\"user_enabled\":false}}"));
+
+        SearchHit o365Hit = new SearchHit(3, "o365-id", Collections.emptyMap(), Collections.emptyMap());
+        o365Hit.sourceRef(new BytesArray("{\"document\":{\"metadata\":{\"title\":\"o365\"}}}"));
+
+        SearchHit[] hits = new SearchHit[] {suricataHit, dockerHit, o365Hit};
+        SearchResponse response = mock(SearchResponse.class);
+        when(response.getHits())
+                .thenReturn(
+                        new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f));
+
+        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
+        searchFuture.onResponse(response);
+        when(this.client.search(any(SearchRequest.class))).thenReturn(searchFuture);
+    }
+
+    /** {@code fetchBooleanFieldByTitle} maps each hit's title to its boolean field value. */
+    public void testFetchBooleanFieldByTitleMapsTitlesToValues() throws Exception {
+        this.stubIntegrationOverrideSearch();
+
+        Map<String, Boolean> overrides =
+                this.contentIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
+
+        assertEquals(2, overrides.size());
+        assertTrue(overrides.get("suricata"));
+        assertFalse(overrides.get("docker"));
+    }
+
+    /** Documents without the requested field must be omitted, not defaulted to false. */
+    public void testFetchBooleanFieldByTitleSkipsDocumentsWithoutTheField() throws Exception {
+        this.stubIntegrationOverrideSearch();
+
+        Map<String, Boolean> overrides =
+                this.contentIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
+        assertFalse(overrides.containsKey("o365"));
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
@@ -18,6 +18,7 @@ package com.wazuh.contentmanager.cti.catalog.index;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
@@ -78,6 +79,7 @@ public class ContentIndexTests extends OpenSearchTestCase {
 
     private static final String INDEX_NAME = ".test-index";
     private static final String MAPPINGS_PATH = "/mappings/test-mapping.json";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Before
     @Override
@@ -600,6 +602,102 @@ public class ContentIndexTests extends OpenSearchTestCase {
         Assert.assertEquals(101L, result);
         verify(this.client).multiGet(any(MultiGetRequest.class));
         verify(this.client, times(0)).bulk(any(BulkRequest.class));
+    }
+
+    /**
+     * Drives {@code batchUpdate} for a single integration document through the mocked client and
+     * returns the captured indexed source as an {@link ObjectNode}. Modeled on {@link
+     * #testBatchUpdate_MultiGetAndBulk()}.
+     *
+     * @param stored the currently stored root document (as returned by multiGet).
+     * @param operations the patch operations to apply.
+     * @return the processed document that was indexed.
+     */
+    private ObjectNode applyPatchForIntegration(ObjectNode stored, List<Operation> operations)
+            throws Exception {
+        ContentIndex integrationsIndex =
+                new ContentIndex(this.client, Constants.INDEX_INTEGRATIONS, MAPPINGS_PATH);
+
+        GetResponse getResp = mock(GetResponse.class);
+        when(getResp.isExists()).thenReturn(true);
+        when(getResp.getSourceAsString()).thenReturn(stored.toString());
+
+        MultiGetItemResponse item = mock(MultiGetItemResponse.class);
+        when(item.isFailed()).thenReturn(false);
+        when(item.getResponse()).thenReturn(getResp);
+
+        MultiGetResponse mgetResponse = mock(MultiGetResponse.class);
+        when(mgetResponse.getResponses()).thenReturn(new MultiGetItemResponse[] {item});
+
+        PlainActionFuture<MultiGetResponse> mgetFuture = PlainActionFuture.newFuture();
+        mgetFuture.onResponse(mgetResponse);
+        when(this.client.multiGet(any(MultiGetRequest.class))).thenReturn(mgetFuture);
+
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        when(bulkResponse.hasFailures()).thenReturn(false);
+
+        PlainActionFuture<BulkResponse> bulkFuture = PlainActionFuture.newFuture();
+        bulkFuture.onResponse(bulkResponse);
+        ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        when(this.client.bulk(bulkCaptor.capture())).thenReturn(bulkFuture);
+
+        List<ContentIndex.UpdateTask> tasks =
+                List.of(new ContentIndex.UpdateTask("integration-1", operations, 1L));
+
+        integrationsIndex.batchUpdate(tasks);
+
+        BulkRequest bulkRequest = bulkCaptor.getValue();
+        IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
+        return (ObjectNode) MAPPER.readTree(indexRequest.source().utf8ToString());
+    }
+
+    /** A CTI patch that flips its own value must not defeat the user's stored choice. */
+    public void testIntegrationPatchKeepsUserOverride() throws Exception {
+        ObjectNode stored = MAPPER.createObjectNode();
+        ObjectNode document = MAPPER.createObjectNode();
+        document.put(Constants.KEY_ENABLED, false);
+        document.put(Constants.KEY_USER_ENABLED, true);
+        document.put(Constants.KEY_CTI_ENABLED, false);
+        stored.set(Constants.KEY_DOCUMENT, document);
+
+        ObjectNode result =
+                applyPatchForIntegration(
+                        stored, List.of(new Operation("replace", "/document/cti_enabled", null, Boolean.TRUE)));
+
+        JsonNode resultDocument = result.get(Constants.KEY_DOCUMENT);
+        assertTrue(resultDocument.get(Constants.KEY_CTI_ENABLED).asBoolean());
+        assertTrue(resultDocument.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertTrue(resultDocument.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** With no user override, CTI's new value becomes the effective one. */
+    public void testIntegrationPatchFollowsCtiWithoutOverride() throws Exception {
+        ObjectNode stored = MAPPER.createObjectNode();
+        ObjectNode document = MAPPER.createObjectNode();
+        document.put(Constants.KEY_ENABLED, false);
+        document.put(Constants.KEY_CTI_ENABLED, false);
+        stored.set(Constants.KEY_DOCUMENT, document);
+
+        ObjectNode result =
+                applyPatchForIntegration(
+                        stored, List.of(new Operation("replace", "/document/cti_enabled", null, Boolean.TRUE)));
+
+        assertTrue(result.get(Constants.KEY_DOCUMENT).get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** Transition: CTI still writes enabled directly, and the user's override still wins. */
+    public void testIntegrationPatchDuringTransitionKeepsUserOverride() throws Exception {
+        ObjectNode stored = MAPPER.createObjectNode();
+        ObjectNode document = MAPPER.createObjectNode();
+        document.put(Constants.KEY_ENABLED, true);
+        document.put(Constants.KEY_USER_ENABLED, true);
+        stored.set(Constants.KEY_DOCUMENT, document);
+
+        ObjectNode result =
+                applyPatchForIntegration(
+                        stored, List.of(new Operation("replace", "/document/enabled", null, Boolean.FALSE)));
+
+        assertTrue(result.get(Constants.KEY_DOCUMENT).get(Constants.KEY_ENABLED).asBoolean());
     }
 
     /** Test that update retries on CircuitBreakingException from GET and succeeds. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
@@ -62,6 +62,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -748,25 +749,24 @@ public class ContentIndexTests extends OpenSearchTestCase {
     }
 
     /**
-     * Stubs {@code client.search} to return three hits: {@code suricata} with {@code
-     * user_enabled=true}, {@code docker} with {@code user_enabled=false}, and {@code o365} with no
-     * {@code user_enabled} field at all (proving absent fields are skipped, not defaulted).
+     * Stubs the asynchronous {@code client.search} to return three hits: {@code suricata-id} with
+     * {@code user_enabled=true}, {@code docker-id} with {@code user_enabled=false}, and {@code
+     * o365-id} with no {@code user_enabled} field at all (proving absent fields are skipped, not
+     * defaulted).
      */
     private void stubIntegrationOverrideSearch() {
         SearchHit suricataHit =
                 new SearchHit(1, "suricata-id", Collections.emptyMap(), Collections.emptyMap());
         suricataHit.sourceRef(
-                new BytesArray(
-                        "{\"document\":{\"metadata\":{\"title\":\"suricata\"},\"user_enabled\":true}}"));
+                new BytesArray("{\"document\":{\"id\":\"suricata-id\",\"user_enabled\":true}}"));
 
         SearchHit dockerHit =
                 new SearchHit(2, "docker-id", Collections.emptyMap(), Collections.emptyMap());
         dockerHit.sourceRef(
-                new BytesArray(
-                        "{\"document\":{\"metadata\":{\"title\":\"docker\"},\"user_enabled\":false}}"));
+                new BytesArray("{\"document\":{\"id\":\"docker-id\",\"user_enabled\":false}}"));
 
         SearchHit o365Hit = new SearchHit(3, "o365-id", Collections.emptyMap(), Collections.emptyMap());
-        o365Hit.sourceRef(new BytesArray("{\"document\":{\"metadata\":{\"title\":\"o365\"}}}"));
+        o365Hit.sourceRef(new BytesArray("{\"document\":{\"id\":\"o365-id\"}}"));
 
         SearchHit[] hits = new SearchHit[] {suricataHit, dockerHit, o365Hit};
         SearchResponse response = mock(SearchResponse.class);
@@ -774,29 +774,35 @@ public class ContentIndexTests extends OpenSearchTestCase {
                 .thenReturn(
                         new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f));
 
-        PlainActionFuture<SearchResponse> searchFuture = PlainActionFuture.newFuture();
-        searchFuture.onResponse(response);
-        when(this.client.search(any(SearchRequest.class))).thenReturn(searchFuture);
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<SearchResponse>>getArgument(1).onResponse(response);
+                            return null;
+                        })
+                .when(this.client)
+                .search(any(SearchRequest.class), any());
     }
 
-    /** {@code fetchBooleanFieldByTitle} maps each hit's title to its boolean field value. */
-    public void testFetchBooleanFieldByTitleMapsTitlesToValues() throws Exception {
+    /** {@code fetchBooleanFieldById} maps each hit's document id to its boolean field value. */
+    public void testFetchBooleanFieldByIdMapsIdsToValues() throws Exception {
         this.stubIntegrationOverrideSearch();
 
-        Map<String, Boolean> overrides =
-                this.contentIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
+        PlainActionFuture<Map<String, Boolean>> future = PlainActionFuture.newFuture();
+        this.contentIndex.fetchBooleanFieldById("standard", Constants.KEY_USER_ENABLED, future);
+        Map<String, Boolean> overrides = future.actionGet();
 
         assertEquals(2, overrides.size());
-        assertTrue(overrides.get("suricata"));
-        assertFalse(overrides.get("docker"));
+        assertTrue(overrides.get("suricata-id"));
+        assertFalse(overrides.get("docker-id"));
     }
 
     /** Documents without the requested field must be omitted, not defaulted to false. */
-    public void testFetchBooleanFieldByTitleSkipsDocumentsWithoutTheField() throws Exception {
+    public void testFetchBooleanFieldByIdSkipsDocumentsWithoutTheField() throws Exception {
         this.stubIntegrationOverrideSearch();
 
-        Map<String, Boolean> overrides =
-                this.contentIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
-        assertFalse(overrides.containsKey("o365"));
+        PlainActionFuture<Map<String, Boolean>> future = PlainActionFuture.newFuture();
+        this.contentIndex.fetchBooleanFieldById("standard", Constants.KEY_USER_ENABLED, future);
+
+        assertFalse(future.actionGet().containsKey("o365-id"));
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/IntegrationEnabledResolverTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/IntegrationEnabledResolverTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import com.wazuh.contentmanager.utils.Constants;
+
+public class IntegrationEnabledResolverTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ObjectNode document(Boolean enabled, Boolean userEnabled, Boolean ctiEnabled) {
+        ObjectNode node = MAPPER.createObjectNode();
+        if (enabled != null) node.put(Constants.KEY_ENABLED, enabled);
+        if (userEnabled != null) node.put(Constants.KEY_USER_ENABLED, userEnabled);
+        if (ctiEnabled != null) node.put(Constants.KEY_CTI_ENABLED, ctiEnabled);
+        return node;
+    }
+
+    public void testHasUserOverrideFalseWhenAbsent() {
+        assertFalse(IntegrationEnabledResolver.hasUserOverride(document(true, null, true)));
+    }
+
+    /** A false override is a real override: presence, not truthiness, decides. */
+    public void testHasUserOverrideTrueWhenExplicitlyFalse() {
+        assertTrue(IntegrationEnabledResolver.hasUserOverride(document(true, false, true)));
+    }
+
+    public void testHasUserOverrideFalseWhenNullNode() {
+        ObjectNode node = document(true, null, true);
+        node.putNull(Constants.KEY_USER_ENABLED);
+        assertFalse(IntegrationEnabledResolver.hasUserOverride(node));
+    }
+
+    public void testHasUserOverrideFalseWhenDocumentIsNull() {
+        assertFalse(IntegrationEnabledResolver.hasUserOverride(null));
+    }
+
+    public void testResolveAppliesUserOverrideOverCtiValue() {
+        ObjectNode node = document(true, false, true);
+        IntegrationEnabledResolver.resolve(node);
+        assertFalse(node.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    public void testResolveFallsBackToCtiValue() {
+        ObjectNode node = document(true, null, false);
+        IntegrationEnabledResolver.resolve(node);
+        assertFalse(node.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** Transition path: CTI has not shipped cti_enabled yet, so enabled must be left alone. */
+    public void testResolveLeavesEnabledUntouchedWhenNeitherFieldIsPresent() {
+        ObjectNode node = document(true, null, null);
+        IntegrationEnabledResolver.resolve(node);
+        assertTrue(node.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** Transition path with an override: the user still wins. */
+    public void testResolveAppliesUserOverrideWithoutCtiValue() {
+        ObjectNode node = document(false, true, null);
+        IntegrationEnabledResolver.resolve(node);
+        assertTrue(node.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    public void testResolveIsIdempotent() {
+        ObjectNode node = document(true, false, true);
+        IntegrationEnabledResolver.resolve(node);
+        IntegrationEnabledResolver.resolve(node);
+        assertFalse(node.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    public void testCarryOverUserOverrideAppliesPreviousValue() {
+        ObjectNode node = document(true, null, true);
+        IntegrationEnabledResolver.carryOverUserOverride(node, Boolean.FALSE);
+        assertTrue(node.has(Constants.KEY_USER_ENABLED));
+        assertFalse(node.get(Constants.KEY_USER_ENABLED).asBoolean());
+    }
+
+    public void testCarryOverUserOverrideNoOpWhenPreviousIsNull() {
+        ObjectNode node = document(true, null, true);
+        IntegrationEnabledResolver.carryOverUserOverride(node, null);
+        assertFalse(node.has(Constants.KEY_USER_ENABLED));
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/PoliciesMappingTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/PoliciesMappingTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.InputStream;
+
+import com.wazuh.contentmanager.utils.Constants;
+
+/** Unit tests for the policies index mapping, which also hosts the user-overrides registry. */
+public class PoliciesMappingTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonNode policiesMapping() throws Exception {
+        try (InputStream stream =
+                PoliciesMappingTests.class.getResourceAsStream(Constants.MAPPING_POLICIES)) {
+            assertNotNull("mapping resource " + Constants.MAPPING_POLICIES + " not found", stream);
+            return MAPPER.readTree(stream);
+        }
+    }
+
+    /**
+     * The registry subtree must be declared with indexing disabled.
+     *
+     * <p>This mapping is {@code dynamic: "true"}, so an undeclared subtree would auto-map every field
+     * of every stored filter into the policies index. Two filters whose documents disagree on a
+     * field's type would then make the write fail outright.
+     */
+    public void testUserOverridesSubtreeIsNotIndexed() throws Exception {
+        JsonNode subtree = policiesMapping().path("properties").path(Constants.KEY_USER_OVERRIDES);
+
+        assertFalse("user_overrides must be declared", subtree.isMissingNode());
+        assertEquals("object", subtree.path("type").asText());
+        assertFalse(
+                "user_overrides must not be indexed, or stored filters would pollute this mapping",
+                subtree.path("enabled").asBoolean(true));
+    }
+
+    /**
+     * The registry is a sibling of {@code space}, not nested inside {@code document}, so that the
+     * document-level hash and the space-scoped queries never see it.
+     */
+    public void testUserOverridesIsATopLevelField() throws Exception {
+        JsonNode properties = policiesMapping().path("properties");
+
+        assertTrue(properties.has(Constants.KEY_USER_OVERRIDES));
+        assertFalse(
+                "user_overrides must not live under 'document'",
+                properties
+                        .path(Constants.KEY_DOCUMENT)
+                        .path("properties")
+                        .has(Constants.KEY_USER_OVERRIDES));
+    }
+
+    /**
+     * The policy's {@code filters} array holds plain document ids. The apply step appends restored
+     * filter ids to it as strings, so a change to this type would silently break that.
+     */
+    public void testPolicyFiltersHoldKeywordIds() throws Exception {
+        JsonNode filters =
+                policiesMapping()
+                        .path("properties")
+                        .path(Constants.KEY_DOCUMENT)
+                        .path("properties")
+                        .path(Constants.KEY_FILTERS);
+
+        assertEquals("keyword", filters.path("type").asText());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/UserOverridesTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/UserOverridesTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Set;
+
+import com.wazuh.contentmanager.utils.Constants;
+
+/** Unit tests for {@link UserOverrides}. */
+public class UserOverridesTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** A removal sticks, and enrichments CTI adds later still come through. */
+    public void testEnrichmentDeltaRemovesAndLetsNewCtiValuesThrough() {
+        UserOverrides.EnrichmentDelta delta =
+                new UserOverrides.EnrichmentDelta(Set.of("geo"), Set.of());
+
+        List<String> result = delta.applyTo(List.of("geo", "connection", "url_full"));
+        assertEquals(List.of("connection", "url_full"), result);
+
+        // CTI ships a new enrichment: the user who removed "geo" still receives it.
+        List<String> withNewValue = delta.applyTo(List.of("geo", "connection", "url_full", "asn"));
+        assertEquals(List.of("connection", "url_full", "asn"), withNewValue);
+    }
+
+    /** An addition survives even when CTI stops publishing it. */
+    public void testEnrichmentDeltaKeepsUserAdditions() {
+        UserOverrides.EnrichmentDelta delta =
+                new UserOverrides.EnrichmentDelta(Set.of(), Set.of("custom_one"));
+
+        assertEquals(List.of("connection", "custom_one"), delta.applyTo(List.of("connection")));
+    }
+
+    /** An empty delta leaves CTI's list untouched. */
+    public void testEmptyEnrichmentDeltaIsIdentity() {
+        UserOverrides.EnrichmentDelta delta = new UserOverrides.EnrichmentDelta(Set.of(), Set.of());
+
+        assertEquals(List.of("geo", "connection"), delta.applyTo(List.of("geo", "connection")));
+    }
+
+    /**
+     * What is written can be read back unchanged, and a setting the user never decided stays absent.
+     */
+    public void testRoundTripThroughRegistryNode() {
+        ObjectNode root = MAPPER.createObjectNode();
+
+        UserOverrides original =
+                new UserOverrides(
+                        new UserOverrides.PolicySettings(
+                                Boolean.FALSE,
+                                Boolean.TRUE,
+                                null,
+                                new UserOverrides.EnrichmentDelta(Set.of("geo"), Set.of())),
+                        List.of(new UserOverrides.StoredFilter("filter-id", "{\"document\":{}}")));
+
+        original.writeInto(root, "standard");
+        UserOverrides read = UserOverrides.forSpace(root, "standard");
+
+        assertEquals(Boolean.FALSE, read.getPolicy().getEnabled());
+        assertEquals(Boolean.TRUE, read.getPolicy().getIndexUnclassifiedEvents());
+        assertNull(
+                "a setting the user never decided must stay absent, not become false",
+                read.getPolicy().getIndexDiscardedEvents());
+        assertEquals(Set.of("geo"), read.getPolicy().getEnrichments().getRemoved());
+        assertEquals(1, read.getFilters().size());
+        assertEquals("filter-id", read.getFilters().get(0).getId());
+        assertEquals("{\"document\":{}}", read.getFilters().get(0).getDocument());
+    }
+
+    /** An unknown space reads as empty rather than throwing. */
+    public void testUnknownSpaceReadsAsEmpty() {
+        UserOverrides read = UserOverrides.forSpace(MAPPER.createObjectNode(), "standard");
+
+        assertNull(read.getPolicy());
+        assertTrue(read.getFilters().isEmpty());
+    }
+
+    /** A missing registry reads as empty: a cluster that never stored an override is not an error. */
+    public void testNullRegistryReadsAsEmpty() {
+        UserOverrides read = UserOverrides.forSpace(null, "standard");
+
+        assertNull(read.getPolicy());
+        assertTrue(read.getFilters().isEmpty());
+    }
+
+    /**
+     * Writing one space must not disturb another. The registry holds every space in a single
+     * document, so a per-space write that clobbered its siblings would lose overrides silently.
+     */
+    public void testWritingOneSpaceLeavesAnotherIntact() {
+        ObjectNode root = MAPPER.createObjectNode();
+
+        new UserOverrides(
+                        new UserOverrides.PolicySettings(Boolean.FALSE, null, null, null),
+                        List.of(new UserOverrides.StoredFilter("draft-filter", "{}")))
+                .writeInto(root, "draft");
+        new UserOverrides(new UserOverrides.PolicySettings(Boolean.TRUE, null, null, null), List.of())
+                .writeInto(root, "standard");
+
+        assertEquals(Boolean.FALSE, UserOverrides.forSpace(root, "draft").getPolicy().getEnabled());
+        assertEquals(1, UserOverrides.forSpace(root, "draft").getFilters().size());
+        assertEquals(Boolean.TRUE, UserOverrides.forSpace(root, "standard").getPolicy().getEnabled());
+    }
+
+    /**
+     * The written node must not contain a {@code space} field. The pre-snapshot wipe selects by
+     * {@code space.name}, so a registry that carried one would delete itself on the next sync.
+     */
+    public void testWrittenNodeCarriesNoSpaceField() {
+        ObjectNode root = MAPPER.createObjectNode();
+
+        new UserOverrides(
+                        new UserOverrides.PolicySettings(Boolean.FALSE, null, null, null),
+                        List.of(new UserOverrides.StoredFilter("f1", "{}")))
+                .writeInto(root, "standard");
+
+        assertFalse(root.toString().contains("\"" + Constants.KEY_SPACE + "\""));
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
@@ -42,12 +42,15 @@ import org.opensearch.transport.client.Client;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
+import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -55,12 +58,15 @@ import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -521,5 +527,50 @@ public class ConsumerIocServiceTests extends OpenSearchTestCase {
                 "type_hashes should be empty when no documents exist",
                 0,
                 root.get(Constants.KEY_TYPE_HASHES).size());
+    }
+
+    /**
+     * The user's integration enabled overrides live in the very documents the wipe deletes, so the
+     * capture has to happen first. Reading afterwards searches an emptied index, yields an empty map
+     * indistinguishable from "the user never chose anything", and silently rebuilds every integration
+     * with CTI's values — the bug this guards against, reproduced on a live cluster.
+     *
+     * <p>What is asserted is the ordering, not merely that both steps ran.
+     */
+    public void testCaptureOverridesThenWipe_capturesBeforeClearing() throws Exception {
+        SnapshotServiceImpl snapshotService = mock(SnapshotServiceImpl.class);
+        ContentIndex integrations = mock(ContentIndex.class);
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put(Constants.KEY_INTEGRATION, integrations);
+
+        boolean proceed =
+                this.service.captureOverridesThenWipe(
+                        snapshotService, indicesMap, "cti:catalog:consumer:iocs");
+
+        assertTrue("the wipe should have been attempted", proceed);
+        InOrder order = inOrder(snapshotService, integrations);
+        order.verify(snapshotService).captureUserOverrides();
+        order.verify(integrations).clear();
+    }
+
+    /**
+     * A failed override read must abort before anything is deleted. An unreadable map cannot be told
+     * apart from "no overrides", so proceeding would wipe the indices and repopulate them from CTI,
+     * destroying every user choice. Aborting first leaves the index intact for the next sync cycle.
+     */
+    public void testCaptureOverridesThenWipe_abortsWithoutDeletingWhenCaptureFails()
+            throws Exception {
+        SnapshotServiceImpl snapshotService = mock(SnapshotServiceImpl.class);
+        doThrow(new IOException("all shards failed")).when(snapshotService).captureUserOverrides();
+        ContentIndex integrations = mock(ContentIndex.class);
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put(Constants.KEY_INTEGRATION, integrations);
+
+        boolean proceed =
+                this.service.captureOverridesThenWipe(
+                        snapshotService, indicesMap, "cti:catalog:consumer:iocs");
+
+        assertFalse("the sync must abort when the overrides cannot be read", proceed);
+        verify(integrations, never()).clear();
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
@@ -42,15 +42,12 @@ import org.opensearch.transport.client.Client;
 import org.junit.After;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
-import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -58,15 +55,12 @@ import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -527,50 +521,5 @@ public class ConsumerIocServiceTests extends OpenSearchTestCase {
                 "type_hashes should be empty when no documents exist",
                 0,
                 root.get(Constants.KEY_TYPE_HASHES).size());
-    }
-
-    /**
-     * The user's integration enabled overrides live in the very documents the wipe deletes, so the
-     * capture has to happen first. Reading afterwards searches an emptied index, yields an empty map
-     * indistinguishable from "the user never chose anything", and silently rebuilds every integration
-     * with CTI's values — the bug this guards against, reproduced on a live cluster.
-     *
-     * <p>What is asserted is the ordering, not merely that both steps ran.
-     */
-    public void testCaptureOverridesThenWipe_capturesBeforeClearing() throws Exception {
-        SnapshotServiceImpl snapshotService = mock(SnapshotServiceImpl.class);
-        ContentIndex integrations = mock(ContentIndex.class);
-        Map<String, ContentIndex> indicesMap = new HashMap<>();
-        indicesMap.put(Constants.KEY_INTEGRATION, integrations);
-
-        boolean proceed =
-                this.service.captureOverridesThenWipe(
-                        snapshotService, indicesMap, "cti:catalog:consumer:iocs");
-
-        assertTrue("the wipe should have been attempted", proceed);
-        InOrder order = inOrder(snapshotService, integrations);
-        order.verify(snapshotService).captureUserOverrides();
-        order.verify(integrations).clear();
-    }
-
-    /**
-     * A failed override read must abort before anything is deleted. An unreadable map cannot be told
-     * apart from "no overrides", so proceeding would wipe the indices and repopulate them from CTI,
-     * destroying every user choice. Aborting first leaves the index intact for the next sync cycle.
-     */
-    public void testCaptureOverridesThenWipe_abortsWithoutDeletingWhenCaptureFails()
-            throws Exception {
-        SnapshotServiceImpl snapshotService = mock(SnapshotServiceImpl.class);
-        doThrow(new IOException("all shards failed")).when(snapshotService).captureUserOverrides();
-        ContentIndex integrations = mock(ContentIndex.class);
-        Map<String, ContentIndex> indicesMap = new HashMap<>();
-        indicesMap.put(Constants.KEY_INTEGRATION, integrations);
-
-        boolean proceed =
-                this.service.captureOverridesThenWipe(
-                        snapshotService, indicesMap, "cti:catalog:consumer:iocs");
-
-        assertFalse("the sync must abort when the overrides cannot be read", proceed);
-        verify(integrations, never()).clear();
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
@@ -24,6 +24,7 @@ import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.test.OpenSearchTestCase;
@@ -37,6 +38,7 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.model.LocalConsumer;
@@ -47,7 +49,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -81,6 +85,129 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
             this.closeable.close();
         }
         super.tearDown();
+    }
+
+    // --- User overrides registry -------------------------------------------------------------
+
+    /**
+     * Wires a {@link SpaceService} whose async calls answer immediately, recording the order in which
+     * the interesting ones happen. Without this the real service would sit on {@code awaitResult}'s
+     * 60-second timeout for every call.
+     */
+    private SpaceService stubSpaceServiceRecording(List<String> order) {
+        SpaceService spaceService = mock(SpaceService.class);
+
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Void>>getArgument(0).onResponse(null);
+                            return null;
+                        })
+                .when(spaceService)
+                .initializeDefaultSpaces(any());
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<Map<String, Map<String, Object>>>>getArgument(3)
+                                    .onResponse(Collections.emptyMap());
+                            return null;
+                        })
+                .when(spaceService)
+                .getResourcesBySpace(any(), any(), any(), any());
+        doAnswer(
+                        invocation -> {
+                            order.add("hash");
+                            invocation
+                                    .<ActionListener<Set<String>>>getArgument(1)
+                                    .onResponse(Collections.emptySet());
+                            return null;
+                        })
+                .when(spaceService)
+                .calculateAndUpdate(any(), any());
+        doAnswer(
+                        invocation -> {
+                            order.add("engine");
+                            invocation
+                                    .<ActionListener<JsonNode>>getArgument(1)
+                                    .onResponse(new ObjectMapper().createObjectNode());
+                            return null;
+                        })
+                .when(spaceService)
+                .buildEnginePayload(any(), any());
+
+        return spaceService;
+    }
+
+    /** A {@link UserOverridesService} whose apply succeeds, recording when it ran. */
+    private UserOverridesService stubOverridesServiceRecording(List<String> order) {
+        UserOverridesService overridesService = mock(UserOverridesService.class);
+        doAnswer(
+                        invocation -> {
+                            order.add("apply");
+                            invocation.<ActionListener<Void>>getArgument(1).onResponse(null);
+                            return null;
+                        })
+                .when(overridesService)
+                .apply(any(), any());
+        return overridesService;
+    }
+
+    /**
+     * The overrides must be re-applied before the space hash is recalculated and before the space is
+     * loaded into the engine, so both see the merged values rather than CTI's raw ones.
+     */
+    public void testUserOverridesAreAppliedBeforeTheHashAndTheEngineLoad() {
+        List<String> order = new java.util.ArrayList<>();
+        this.synchronizer.setSpaceService(stubSpaceServiceRecording(order));
+        this.synchronizer.setUserOverridesService(stubOverridesServiceRecording(order));
+
+        this.synchronizer.onSyncComplete(true);
+
+        Assert.assertEquals("the overrides must be applied first", "apply", order.get(0));
+        Assert.assertTrue(
+                "the space hash must be recalculated after the merge",
+                order.indexOf("apply") < order.indexOf("hash"));
+        Assert.assertTrue(
+                "the engine must be loaded after the merge",
+                order.indexOf("apply") < order.indexOf("engine"));
+    }
+
+    /**
+     * A failure to apply the overrides is logged and the synchronization continues. The registry is
+     * durable, so the next sync retries; aborting here would leave the space half-built.
+     */
+    public void testSyncContinuesWhenApplyingOverridesFails() {
+        List<String> order = new java.util.ArrayList<>();
+        SpaceService spaceService = stubSpaceServiceRecording(order);
+        UserOverridesService overridesService = mock(UserOverridesService.class);
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<Void>>getArgument(1)
+                                    .onFailure(new java.io.IOException("registry unavailable"));
+                            return null;
+                        })
+                .when(overridesService)
+                .apply(any(), any());
+
+        this.synchronizer.setSpaceService(spaceService);
+        this.synchronizer.setUserOverridesService(overridesService);
+
+        this.synchronizer.onSyncComplete(true);
+
+        verify(spaceService).calculateAndUpdate(any(), any());
+        Assert.assertTrue("the sync must still recalculate the hash", order.contains("hash"));
+    }
+
+    /** A sync that changed nothing must not touch the registry. */
+    public void testNothingIsAppliedWhenTheSyncChangedNothing() {
+        List<String> order = new java.util.ArrayList<>();
+        UserOverridesService overridesService = stubOverridesServiceRecording(order);
+        this.synchronizer.setSpaceService(stubSpaceServiceRecording(order));
+        this.synchronizer.setUserOverridesService(overridesService);
+
+        this.synchronizer.onSyncComplete(false);
+
+        verify(overridesService, never()).apply(any(), any());
     }
 
     /** Tests that getMappings returns the expected index mappings. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -53,12 +53,14 @@ import com.wazuh.contentmanager.cti.catalog.model.RemoteConsumer;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -1274,5 +1276,154 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         Assert.assertFalse("Temp file should be cleaned up", Files.exists(zipPath));
         Assert.assertNull(
                 "stablePath should be null for default constructor", this.snapshotService.getStablePath());
+    }
+
+    /**
+     * Builds a fresh {@link SnapshotServiceImpl} wired to a single mock "integration" {@link
+     * ContentIndex}, feeds one NDJSON integration line through the snapshot path, and returns the
+     * captured indexed source. Kept isolated from the shared {@link #snapshotService}/{@link
+     * #contentIndexMock} so stubbing {@code fetchBooleanFieldByTitle} here cannot leak into other
+     * tests, which never register an "integration" entry in their {@code indicesMap}.
+     *
+     * @param title the integration's {@code document.metadata.title}.
+     * @param ctiEnabled the {@code document.cti_enabled} value CTI publishes in this snapshot line.
+     * @param overrides the title-to-user_enabled map {@code fetchBooleanFieldByTitle} should return,
+     *     simulating the live pre-swap state read through the alias.
+     * @return the processed {@code document} wrapper that was indexed.
+     */
+    private ObjectNode runSnapshotForSingleIntegration(
+            String title, boolean ctiEnabled, Map<String, Boolean> overrides) throws Exception {
+        ContentIndex integrationsIndex = mock(ContentIndex.class);
+        when(integrationsIndex.processPayload(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
+        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
+                .thenReturn(overrides);
+
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
+
+        SnapshotServiceImpl service =
+                new SnapshotServiceImpl(
+                        "cti:catalog:consumer:ruleset", indicesMap, this.consumersIndex, this.environment);
+        service.setSnapshotClient(this.snapshotClient);
+        this.mockT0ConsumerDoc();
+
+        String url = "http://example.com/integration-" + title + ".zip";
+        when(this.remoteConsumer.getSnapshotLink()).thenReturn(url);
+        when(this.remoteConsumer.getSnapshotOffset()).thenReturn(1L);
+
+        // spotless:off
+        String jsonContent =
+                "{\"name\": \"" + title + "-id\", \"offset\": 1, \"payload\": {\"type\": \"integration\", "
+                        + "\"document\": {\"id\": \"" + title + "-id\", "
+                        + "\"metadata\": {\"title\": \"" + title + "\"}, "
+                        + "\"cti_enabled\": " + ctiEnabled + "}}}";
+        // spotless:on
+        Path zipPath = this.createZipFileWithContent("integration-" + title + ".json", jsonContent);
+        when(this.snapshotClient.downloadFile(url)).thenReturn(zipPath);
+
+        boolean success = service.initialize(this.remoteConsumer);
+        Assert.assertTrue("Snapshot init should succeed for [" + title + "]", success);
+
+        ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(integrationsIndex, atLeastOnce()).executeBulk(bulkCaptor.capture());
+        BulkRequest bulkRequest = bulkCaptor.getValue();
+        IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
+        return (ObjectNode) this.plain.readTree(indexRequest.source().utf8ToString());
+    }
+
+    /** A CTI resync/plan-change must not clobber a live user override matched by title. */
+    public void testSnapshotReappliesUserOverrideByTitle() throws Exception {
+        ObjectNode indexed =
+                runSnapshotForSingleIntegration("suricata", false, Map.of("suricata", true));
+
+        JsonNode document = indexed.get(Constants.KEY_DOCUMENT);
+        assertTrue(document.get(Constants.KEY_ENABLED).asBoolean());
+        assertTrue(document.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertFalse(document.get(Constants.KEY_CTI_ENABLED).asBoolean());
+    }
+
+    /** With no stored override for the title, the rebuilt document just follows CTI. */
+    public void testSnapshotFollowsCtiWhenNoOverrideExists() throws Exception {
+        ObjectNode indexed = runSnapshotForSingleIntegration("docker", false, Map.of());
+
+        JsonNode document = indexed.get(Constants.KEY_DOCUMENT);
+        assertFalse(document.get(Constants.KEY_ENABLED).asBoolean());
+        assertFalse(document.has(Constants.KEY_USER_ENABLED));
+    }
+
+    /**
+     * Builds a fresh {@link SnapshotServiceImpl} wired to a single mock "integration" {@link
+     * ContentIndex} and drives it through {@code initialize(Path, JsonNode)} — the local/stable
+     * snapshot rollback path used by {@code AbstractConsumerService} when the remote feed is
+     * unreachable (lines 708 and 774). That path clears the live indices before repopulating them
+     * from the local zip, so the override must be captured before {@code clear()} runs. Mirrors
+     * {@link #runSnapshotForSingleIntegration} but for the local-zip entry point.
+     *
+     * @param title the integration's {@code document.metadata.title}.
+     * @param ctiEnabled the {@code document.cti_enabled} value CTI publishes in this snapshot line.
+     * @param overrides the title-to-user_enabled map {@code fetchBooleanFieldByTitle} should return,
+     *     simulating the live pre-clear state read through the alias.
+     * @return the processed {@code document} wrapper that was indexed.
+     */
+    private ObjectNode runLocalSnapshotForSingleIntegration(
+            String title, boolean ctiEnabled, Map<String, Boolean> overrides) throws Exception {
+        ContentIndex integrationsIndex = mock(ContentIndex.class);
+        when(integrationsIndex.processPayload(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
+        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
+                .thenReturn(overrides);
+
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
+
+        SnapshotServiceImpl service =
+                new SnapshotServiceImpl(
+                        "cti:catalog:consumer:ruleset", indicesMap, this.consumersIndex, this.environment);
+        this.mockT0ConsumerDoc();
+
+        // spotless:off
+        String jsonContent =
+                "{\"name\": \"" + title + "-id\", \"offset\": 1, \"payload\": {\"type\": \"integration\", "
+                        + "\"document\": {\"id\": \"" + title + "-id\", "
+                        + "\"metadata\": {\"title\": \"" + title + "\"}, "
+                        + "\"cti_enabled\": " + ctiEnabled + "}}}";
+        // spotless:on
+        Path localZip =
+                this.createZipFileWithContent("local-integration-" + title + ".json", jsonContent);
+
+        boolean success = service.initialize(localZip, null);
+        Assert.assertTrue("Local snapshot init should succeed for [" + title + "]", success);
+
+        // The override must have been read BEFORE clear() wiped the live index.
+        InOrder order = inOrder(integrationsIndex);
+        order
+                .verify(integrationsIndex)
+                .fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
+        order.verify(integrationsIndex).clear();
+
+        ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(integrationsIndex, atLeastOnce()).executeBulk(bulkCaptor.capture());
+        BulkRequest bulkRequest = bulkCaptor.getValue();
+        IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
+        return (ObjectNode) this.plain.readTree(indexRequest.source().utf8ToString());
+    }
+
+    /**
+     * The local/stable snapshot rollback path (remote feed unreachable, falling back to the last good
+     * local zip) must also re-apply a live user override matched by title — it clears and repopulates
+     * the same integrations index as a full resync, so it is the same bug on a fourth path if the
+     * override isn't captured first.
+     */
+    public void testLocalSnapshotRollbackReappliesUserOverrideByTitle() throws Exception {
+        ObjectNode indexed =
+                runLocalSnapshotForSingleIntegration("suricata", false, Map.of("suricata", true));
+
+        JsonNode document = indexed.get(Constants.KEY_DOCUMENT);
+        assertTrue(document.get(Constants.KEY_ENABLED).asBoolean());
+        assertTrue(document.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertFalse(document.get(Constants.KEY_CTI_ENABLED).asBoolean());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -63,6 +63,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -1330,6 +1331,76 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         BulkRequest bulkRequest = bulkCaptor.getValue();
         IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
         return (ObjectNode) this.plain.readTree(indexRequest.source().utf8ToString());
+    }
+
+    /**
+     * Regression test for the reinitialisation path.
+     *
+     * <p>{@code AbstractConsumerService} deletes every standard-space document <b>before</b> calling
+     * {@code initialize}, so by the time {@code initialize} runs the overrides are already gone from
+     * the index. The fix is for that caller to invoke {@link
+     * SnapshotServiceImpl#captureUserOverrides()} while the documents still exist, and for {@code
+     * initialize} not to re-read afterwards.
+     *
+     * <p>This reproduces exactly that sequence: the first read (the caller's explicit capture) sees
+     * the override, every later read sees an emptied index. Before the fix, {@code initialize}
+     * re-read unconditionally, replaced the captured map with the empty one, and the user's choice
+     * was silently overwritten with CTI's value — the original bug, verified live on a real cluster.
+     */
+    public void testInitializeKeepsOverridesCapturedBeforeTheIndicesWereWiped() throws Exception {
+        ContentIndex integrationsIndex = mock(ContentIndex.class);
+        when(integrationsIndex.processPayloadToString(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0).toString());
+        when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
+        // First read: the live index, still holding the user's choice. Every read after that: the
+        // index as the caller left it once it deleted the standard-space documents.
+        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
+                .thenReturn(Map.of("suricata", true))
+                .thenReturn(Map.of());
+
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
+
+        SnapshotServiceImpl service =
+                new SnapshotServiceImpl(
+                        "cti:catalog:consumer:ruleset", indicesMap, this.consumersIndex, this.environment);
+        service.setSnapshotClient(this.snapshotClient);
+        this.mockT0ConsumerDoc();
+
+        String url = "http://example.com/integration-suricata.zip";
+        when(this.remoteConsumer.getSnapshotLink()).thenReturn(url);
+        when(this.remoteConsumer.getSnapshotOffset()).thenReturn(1L);
+
+        // spotless:off
+        String jsonContent =
+                "{\"name\": \"suricata-id\", \"offset\": 1, \"payload\": {\"type\": \"integration\", "
+                        + "\"document\": {\"id\": \"suricata-id\", "
+                        + "\"metadata\": {\"title\": \"suricata\"}, "
+                        + "\"cti_enabled\": false}}}";
+        // spotless:on
+        Path zipPath = this.createZipFileWithContent("integration-suricata.json", jsonContent);
+        when(this.snapshotClient.downloadFile(url)).thenReturn(zipPath);
+
+        // The caller captures while the documents still exist, then wipes, then initialises.
+        service.captureUserOverrides();
+        Assert.assertTrue(service.initialize(this.remoteConsumer));
+
+        // Exactly one read: initialize must not go back to an index the caller already emptied.
+        verify(integrationsIndex, times(1))
+                .fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
+
+        ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        verify(integrationsIndex, atLeastOnce()).executeBulk(bulkCaptor.capture());
+        IndexRequest indexRequest = (IndexRequest) bulkCaptor.getValue().requests().get(0);
+        JsonNode document =
+                this.plain.readTree(indexRequest.source().utf8ToString()).get(Constants.KEY_DOCUMENT);
+
+        assertTrue(
+                "the captured override must survive the wipe",
+                document.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertTrue(
+                "enabled must be derived from the override, not from CTI",
+                document.get(Constants.KEY_ENABLED).asBoolean());
     }
 
     /** A CTI resync/plan-change must not clobber a live user override matched by title. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.After;
@@ -41,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -59,7 +61,9 @@ import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -1279,16 +1283,49 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
     }
 
     /**
+     * Stubs the asynchronous override read on a mock integrations index to answer with the given map.
+     *
+     * @param integrationsIndex the mock to stub.
+     * @param overrides the document-id-to-user_enabled map the read should return.
+     */
+    private void stubOverrideRead(ContentIndex integrationsIndex, Map<String, Boolean> overrides) {
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Map<String, Boolean>>>getArgument(2).onResponse(overrides);
+                            return null;
+                        })
+                .when(integrationsIndex)
+                .fetchBooleanFieldById(eq("standard"), eq(Constants.KEY_USER_ENABLED), any());
+    }
+
+    /**
+     * Stubs the asynchronous override read to fail, so the caller sees the failure through {@link
+     * ActionListener#onFailure} rather than as a thrown exception.
+     *
+     * @param integrationsIndex the mock to stub.
+     * @param failure the exception the read should report.
+     */
+    private void stubOverrideReadFailure(ContentIndex integrationsIndex, Exception failure) {
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Map<String, Boolean>>>getArgument(2).onFailure(failure);
+                            return null;
+                        })
+                .when(integrationsIndex)
+                .fetchBooleanFieldById(eq("standard"), eq(Constants.KEY_USER_ENABLED), any());
+    }
+
+    /**
      * Builds a fresh {@link SnapshotServiceImpl} wired to a single mock "integration" {@link
      * ContentIndex}, feeds one NDJSON integration line through the snapshot path, and returns the
      * captured indexed source. Kept isolated from the shared {@link #snapshotService}/{@link
-     * #contentIndexMock} so stubbing {@code fetchBooleanFieldByTitle} here cannot leak into other
-     * tests, which never register an "integration" entry in their {@code indicesMap}.
+     * #contentIndexMock} so stubbing {@code fetchBooleanFieldById} here cannot leak into other tests,
+     * which never register an "integration" entry in their {@code indicesMap}.
      *
      * @param title the integration's {@code document.metadata.title}.
      * @param ctiEnabled the {@code document.cti_enabled} value CTI publishes in this snapshot line.
-     * @param overrides the title-to-user_enabled map {@code fetchBooleanFieldByTitle} should return,
-     *     simulating the live pre-swap state read through the alias.
+     * @param overrides the document-id-to-user_enabled map {@code fetchBooleanFieldById} should
+     *     return, simulating the state stored before the indices were rebuilt.
      * @return the processed {@code document} wrapper that was indexed.
      */
     private ObjectNode runSnapshotForSingleIntegration(
@@ -1297,8 +1334,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         when(integrationsIndex.processPayloadToString(any(JsonNode.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0).toString());
         when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
-        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
-                .thenReturn(overrides);
+        this.stubOverrideRead(integrationsIndex, overrides);
 
         Map<String, ContentIndex> indicesMap = new HashMap<>();
         indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
@@ -1354,9 +1390,16 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
         // First read: the live index, still holding the user's choice. Every read after that: the
         // index as the caller left it once it deleted the standard-space documents.
-        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
-                .thenReturn(Map.of("suricata", true))
-                .thenReturn(Map.of());
+        AtomicBoolean firstRead = new AtomicBoolean(true);
+        doAnswer(
+                        invocation -> {
+                            Map<String, Boolean> answer =
+                                    firstRead.getAndSet(false) ? Map.of("suricata-id", true) : Map.of();
+                            invocation.<ActionListener<Map<String, Boolean>>>getArgument(2).onResponse(answer);
+                            return null;
+                        })
+                .when(integrationsIndex)
+                .fetchBooleanFieldById(eq("standard"), eq(Constants.KEY_USER_ENABLED), any());
 
         Map<String, ContentIndex> indicesMap = new HashMap<>();
         indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
@@ -1387,7 +1430,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
 
         // Exactly one read: initialize must not go back to an index the caller already emptied.
         verify(integrationsIndex, times(1))
-                .fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
+                .fetchBooleanFieldById(eq("standard"), eq(Constants.KEY_USER_ENABLED), any());
 
         ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
         verify(integrationsIndex, atLeastOnce()).executeBulk(bulkCaptor.capture());
@@ -1403,10 +1446,10 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
                 document.get(Constants.KEY_ENABLED).asBoolean());
     }
 
-    /** A CTI resync/plan-change must not clobber a live user override matched by title. */
-    public void testSnapshotReappliesUserOverrideByTitle() throws Exception {
+    /** A CTI resync must not clobber a stored user override matched by document id. */
+    public void testSnapshotReappliesUserOverrideById() throws Exception {
         ObjectNode indexed =
-                runSnapshotForSingleIntegration("suricata", false, Map.of("suricata", true));
+                runSnapshotForSingleIntegration("suricata", false, Map.of("suricata-id", true));
 
         JsonNode document = indexed.get(Constants.KEY_DOCUMENT);
         assertTrue(document.get(Constants.KEY_ENABLED).asBoolean());
@@ -1433,8 +1476,8 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
      *
      * @param title the integration's {@code document.metadata.title}.
      * @param ctiEnabled the {@code document.cti_enabled} value CTI publishes in this snapshot line.
-     * @param overrides the title-to-user_enabled map {@code fetchBooleanFieldByTitle} should return,
-     *     simulating the live pre-clear state read through the alias.
+     * @param overrides the document-id-to-user_enabled map {@code fetchBooleanFieldById} should
+     *     return, simulating the state stored before {@code clear()} ran.
      * @return the processed {@code document} wrapper that was indexed.
      */
     private ObjectNode runLocalSnapshotForSingleIntegration(
@@ -1443,8 +1486,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         when(integrationsIndex.processPayloadToString(any(JsonNode.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0).toString());
         when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
-        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
-                .thenReturn(overrides);
+        this.stubOverrideRead(integrationsIndex, overrides);
 
         Map<String, ContentIndex> indicesMap = new HashMap<>();
         indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
@@ -1471,7 +1513,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         InOrder order = inOrder(integrationsIndex);
         order
                 .verify(integrationsIndex)
-                .fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED);
+                .fetchBooleanFieldById(eq("standard"), eq(Constants.KEY_USER_ENABLED), any());
         order.verify(integrationsIndex).clear();
 
         ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -1483,13 +1525,13 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
 
     /**
      * The local/stable snapshot rollback path (remote feed unreachable, falling back to the last good
-     * local zip) must also re-apply a live user override matched by title — it clears and repopulates
-     * the same integrations index as a full resync, so it is the same bug on a fourth path if the
-     * override isn't captured first.
+     * local zip) must also re-apply a stored user override matched by document id — it clears and
+     * repopulates the same integrations index as a full resync, so it is the same bug on another path
+     * if the override isn't captured first.
      */
-    public void testLocalSnapshotRollbackReappliesUserOverrideByTitle() throws Exception {
+    public void testLocalSnapshotRollbackReappliesUserOverrideById() throws Exception {
         ObjectNode indexed =
-                runLocalSnapshotForSingleIntegration("suricata", false, Map.of("suricata", true));
+                runLocalSnapshotForSingleIntegration("suricata", false, Map.of("suricata-id", true));
 
         JsonNode document = indexed.get(Constants.KEY_DOCUMENT);
         assertTrue(document.get(Constants.KEY_ENABLED).asBoolean());
@@ -1513,8 +1555,7 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         when(integrationsIndex.processPayloadToString(any(JsonNode.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0).toString());
         when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
-        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
-                .thenThrow(new IOException("search timeout"));
+        this.stubOverrideReadFailure(integrationsIndex, new IOException("search timeout"));
 
         Map<String, ContentIndex> indicesMap = new HashMap<>();
         indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
@@ -1561,8 +1602,8 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         when(integrationsIndex.processPayloadToString(any(JsonNode.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0).toString());
         when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
-        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
-                .thenThrow(new IOException("Failed to execute phase [query], all shards failed"));
+        this.stubOverrideReadFailure(
+                integrationsIndex, new IOException("Failed to execute phase [query], all shards failed"));
 
         Map<String, ContentIndex> indicesMap = new HashMap<>();
         indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -1426,4 +1426,95 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         assertTrue(document.get(Constants.KEY_USER_ENABLED).asBoolean());
         assertFalse(document.get(Constants.KEY_CTI_ENABLED).asBoolean());
     }
+
+    /**
+     * If reading the stored user overrides fails (e.g. a search timeout, or a cluster-level search
+     * failure such as "Failed to execute phase [query], all shards failed"), the remote snapshot must
+     * ABORT rather than proceed with an empty override map. An empty map is indistinguishable from
+     * "the user never set any override", so proceeding would silently rebuild every integration with
+     * CTI's values and permanently lose every user override — exactly the data loss this feature
+     * exists to prevent.
+     */
+    public void testInitialize_AbortsWhenUserOverrideReadFails() throws Exception {
+        ContentIndex integrationsIndex = mock(ContentIndex.class);
+        // Stubbed exactly like the passing-path tests (e.g. runSnapshotForSingleIntegration) so that,
+        // if the abort did NOT happen, the snapshot would run to completion and this test would fail
+        // for the right reason instead of being masked by an unrelated NPE from an unstubbed mock.
+        when(integrationsIndex.processPayload(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
+        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
+                .thenThrow(new IOException("search timeout"));
+
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
+
+        SnapshotServiceImpl service =
+                new SnapshotServiceImpl(
+                        "cti:catalog:consumer:ruleset", indicesMap, this.consumersIndex, this.environment);
+        service.setSnapshotClient(this.snapshotClient);
+        this.mockT0ConsumerDoc();
+
+        String url = "http://example.com/integration-abort.zip";
+        when(this.remoteConsumer.getSnapshotLink()).thenReturn(url);
+        when(this.remoteConsumer.getSnapshotOffset()).thenReturn(1L);
+
+        Path zipPath =
+                this.createZipFileWithContent(
+                        "integration-abort.json",
+                        "{\"name\": \"abort-id\", \"offset\": 1, \"payload\": {\"type\": \"integration\", "
+                                + "\"document\": {\"id\": \"abort-id\", \"metadata\": {\"title\": \"abort\"}, "
+                                + "\"cti_enabled\": true}}}");
+        when(this.snapshotClient.downloadFile(url)).thenReturn(zipPath);
+
+        boolean success = service.initialize(this.remoteConsumer);
+
+        Assert.assertFalse(
+                "Snapshot must abort when the user-override read fails, not proceed as if there were no"
+                        + " overrides",
+                success);
+        verify(integrationsIndex, never()).executeBulk(any(BulkRequest.class));
+        verify(this.consumersIndex, never()).setConsumer(any(LocalConsumer.class));
+    }
+
+    /**
+     * Same failure, but through the local/stable snapshot path used on plan changes and rollbacks
+     * (remote feed unreachable). The read happens before {@code ContentIndex#clear}, so aborting here
+     * must leave the live integrations index untouched — verified by asserting {@code clear()} is
+     * never invoked.
+     */
+    public void testInitializeFromPath_AbortsWhenUserOverrideReadFails() throws Exception {
+        ContentIndex integrationsIndex = mock(ContentIndex.class);
+        // Stubbed exactly like the passing-path tests so that, if the abort did NOT happen, the
+        // snapshot would run to completion (and the assertFalse below would fail for the right
+        // reason instead of being masked by an unrelated NPE from an unstubbed mock).
+        when(integrationsIndex.processPayload(any(JsonNode.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(integrationsIndex.getWriteIndex()).thenReturn(Constants.INDEX_INTEGRATIONS);
+        when(integrationsIndex.fetchBooleanFieldByTitle("standard", Constants.KEY_USER_ENABLED))
+                .thenThrow(new IOException("Failed to execute phase [query], all shards failed"));
+
+        Map<String, ContentIndex> indicesMap = new HashMap<>();
+        indicesMap.put(Constants.KEY_INTEGRATION, integrationsIndex);
+
+        SnapshotServiceImpl service =
+                new SnapshotServiceImpl(
+                        "cti:catalog:consumer:ruleset", indicesMap, this.consumersIndex, this.environment);
+        this.mockT0ConsumerDoc();
+
+        String jsonContent =
+                "{\"name\": \"abort-id\", \"offset\": 1, \"payload\": {\"type\": \"integration\", "
+                        + "\"document\": {\"id\": \"abort-id\", \"metadata\": {\"title\": \"abort\"}, "
+                        + "\"cti_enabled\": true}}}";
+        Path localZip = this.createZipFileWithContent("local-integration-abort.json", jsonContent);
+
+        boolean success = service.initialize(localZip, null);
+
+        Assert.assertFalse(
+                "Local snapshot must abort when the user-override read fails, not proceed as if there"
+                        + " were no overrides",
+                success);
+        verify(integrationsIndex, never()).clear();
+        verify(integrationsIndex, never()).executeBulk(any(BulkRequest.class));
+    }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SpaceServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SpaceServiceTests.java
@@ -39,6 +39,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -152,6 +154,50 @@ public class SpaceServiceTests extends OpenSearchTestCase {
         verify(this.client).search(any(SearchRequest.class), any());
         // No bulk update should be performed when there are no policies
         verify(this.client, never()).bulk(any(), any());
+    }
+
+    /**
+     * The policy scan must only pick up actual policies, which are the documents carrying {@code
+     * space.name}.
+     *
+     * <p>The user-overrides registry also lives in the policies index and deliberately has no {@code
+     * space.name}. Without this filter it fell through the space check in {@code processHitsAsync} --
+     * which only skips a hit when {@code space} is present -- and had a meaningless {@code
+     * space.hash} written into it on every recalculation.
+     */
+    public void testCalculateAndUpdateOnlyScansDocumentsThatAreActuallyPolicies() {
+        when(this.client.admin()).thenReturn(this.adminClient);
+        when(this.adminClient.indices()).thenReturn(this.indicesAdminClient);
+        when(this.indicesExistsResponse.isExists()).thenReturn(true);
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<IndicesExistsResponse>>getArgument(1)
+                                    .onResponse(this.indicesExistsResponse);
+                            return null;
+                        })
+                .when(this.indicesAdminClient)
+                .exists(any(IndicesExistsRequest.class), any());
+
+        when(this.searchResponse.getHits()).thenReturn(SearchHits.empty());
+        ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<SearchResponse>>getArgument(1)
+                                    .onResponse(this.searchResponse);
+                            return null;
+                        })
+                .when(this.client)
+                .search(captor.capture(), any());
+
+        this.policyHashService.calculateAndUpdate(
+                List.of(Space.STANDARD.toString()), ActionListener.wrap(r -> {}, e -> {}));
+
+        String query = captor.getValue().source().query().toString();
+        assertTrue(
+                "the scan must require space.name, or non-policy documents are processed as policies",
+                query.contains(Constants.Q_SPACE_NAME) && query.contains("exists"));
     }
 
     /** Tests that calculateAndUpdate handles exceptions gracefully without propagating them. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/UserOverridesServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/UserOverridesServiceTests.java
@@ -1,0 +1,630 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.Client;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.wazuh.contentmanager.cti.catalog.model.UserOverrides;
+import com.wazuh.contentmanager.utils.Constants;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Unit tests for {@link UserOverridesService}. */
+public class UserOverridesServiceTests extends OpenSearchTestCase {
+
+    private Client client;
+    private SpaceService spaceService;
+    private UserOverridesService service;
+
+    @Before
+    public void setUpService() {
+        this.client = mock(Client.class);
+        this.spaceService = mock(SpaceService.class);
+        this.service = new UserOverridesService(this.client, this.spaceService);
+    }
+
+    /** Stubs the registry GET as absent. */
+    private void stubRegistryMissing() {
+        GetResponse missing = mock(GetResponse.class);
+        when(missing.isExists()).thenReturn(false);
+        stubGet(missing);
+    }
+
+    /** Stubs the registry GET as present, with the given source and concurrency metadata. */
+    private void stubRegistryPresent(String source, long seqNo, long primaryTerm) {
+        GetResponse present = mock(GetResponse.class);
+        when(present.isExists()).thenReturn(true);
+        when(present.getSourceAsString()).thenReturn(source);
+        when(present.getSeqNo()).thenReturn(seqNo);
+        when(present.getPrimaryTerm()).thenReturn(primaryTerm);
+        stubGet(present);
+    }
+
+    private void stubGet(GetResponse response) {
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<GetResponse>>getArgument(1).onResponse(response);
+                            return null;
+                        })
+                .when(this.client)
+                .get(any(GetRequest.class), any());
+    }
+
+    /** Stubs a successful index call, capturing the request. */
+    private void stubIndexSucceeding(ArgumentCaptor<IndexRequest> captor) {
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<IndexResponse>>getArgument(1)
+                                    .onResponse(mock(IndexResponse.class));
+                            return null;
+                        })
+                .when(this.client)
+                .index(captor.capture(), any());
+    }
+
+    /** A mutator that pins {@code enabled} and leaves the filters alone. */
+    private static UserOverrides pinEnabled(UserOverrides current) {
+        return new UserOverrides(
+                new UserOverrides.PolicySettings(Boolean.FALSE, null, null, null), current.getFilters());
+    }
+
+    /** A cluster that has never stored an override reads as empty, not as an error. */
+    public void testReadReturnsEmptyWhenTheRegistryDoesNotExist() {
+        stubRegistryMissing();
+
+        PlainActionFuture<UserOverrides> future = PlainActionFuture.newFuture();
+        this.service.read("standard", future);
+
+        UserOverrides overrides = future.actionGet();
+        assertNull(overrides.getPolicy());
+        assertTrue(overrides.getFilters().isEmpty());
+    }
+
+    /** Reading returns only the requested space's overrides. */
+    public void testReadReturnsOnlyTheRequestedSpace() {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"policy\":{\"enabled\":false}},"
+                        + "\"draft\":{\"policy\":{\"enabled\":true}}}}",
+                4L,
+                1L);
+
+        PlainActionFuture<UserOverrides> future = PlainActionFuture.newFuture();
+        this.service.read("standard", future);
+
+        assertEquals(Boolean.FALSE, future.actionGet().getPolicy().getEnabled());
+    }
+
+    /**
+     * The written document must not carry a {@code space} field, and must land on the reserved id.
+     * The pre-snapshot wipe selects by {@code space.name}, so adding one would make the registry
+     * delete itself on the next sync.
+     */
+    public void testUpdateWritesADocumentWithoutASpaceField() {
+        stubRegistryMissing();
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        stubIndexSucceeding(captor);
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.update("standard", UserOverridesServiceTests::pinEnabled, future);
+        future.actionGet();
+
+        String written = captor.getValue().source().utf8ToString();
+        assertFalse("the registry must not carry a space field", written.contains("\"space\""));
+        assertTrue(written.contains("\"user_overrides\""));
+        assertEquals(Constants.USER_OVERRIDES_DOC_ID, captor.getValue().id());
+        assertEquals(Constants.INDEX_POLICIES, captor.getValue().index());
+    }
+
+    /**
+     * The first write uses {@code opType=CREATE}, so two callers racing to create the registry cannot
+     * both succeed with one silently overwriting the other.
+     */
+    public void testFirstWriteUsesCreateOpType() {
+        stubRegistryMissing();
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        stubIndexSucceeding(captor);
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.update("standard", UserOverridesServiceTests::pinEnabled, future);
+        future.actionGet();
+
+        assertEquals(DocWriteRequest.OpType.CREATE, captor.getValue().opType());
+    }
+
+    /**
+     * A write against an existing registry carries the sequence number and primary term read from the
+     * GET, so a concurrent writer's change cannot be lost.
+     */
+    public void testUpdateOfAnExistingRegistryUsesOptimisticConcurrency() {
+        stubRegistryPresent("{\"user_overrides\":{}}", 7L, 3L);
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        stubIndexSucceeding(captor);
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.update("standard", UserOverridesServiceTests::pinEnabled, future);
+        future.actionGet();
+
+        assertEquals(7L, captor.getValue().ifSeqNo());
+        assertEquals(3L, captor.getValue().ifPrimaryTerm());
+    }
+
+    /**
+     * A version conflict re-reads and retries, rather than dropping the user's change. This is what
+     * replaces a mutex: the read-modify-write is repeated against the winner's document.
+     */
+    public void testUpdateRetriesOnVersionConflict() {
+        stubRegistryPresent("{\"user_overrides\":{}}", 7L, 3L);
+
+        AtomicInteger attempts = new AtomicInteger();
+        doAnswer(
+                        invocation -> {
+                            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+                            if (attempts.incrementAndGet() == 1) {
+                                listener.onFailure(
+                                        new VersionConflictEngineException(
+                                                new ShardId(Constants.INDEX_POLICIES, "_na_", 0), "conflict", "reason"));
+                            } else {
+                                listener.onResponse(mock(IndexResponse.class));
+                            }
+                            return null;
+                        })
+                .when(this.client)
+                .index(any(IndexRequest.class), any());
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.update("standard", UserOverridesServiceTests::pinEnabled, future);
+        future.actionGet();
+
+        assertEquals("the write must be retried once", 2, attempts.get());
+        // The retry must re-read, not reuse the stale document.
+        verify(this.client, times(2)).get(any(GetRequest.class), any());
+    }
+
+    /** Retries are bounded: a permanently conflicting document fails instead of looping forever. */
+    public void testUpdateGivesUpAfterTheRetryLimit() {
+        stubRegistryPresent("{\"user_overrides\":{}}", 7L, 3L);
+
+        AtomicInteger attempts = new AtomicInteger();
+        doAnswer(
+                        invocation -> {
+                            attempts.incrementAndGet();
+                            invocation
+                                    .<ActionListener<IndexResponse>>getArgument(1)
+                                    .onFailure(
+                                            new VersionConflictEngineException(
+                                                    new ShardId(Constants.INDEX_POLICIES, "_na_", 0), "conflict", "reason"));
+                            return null;
+                        })
+                .when(this.client)
+                .index(any(IndexRequest.class), any());
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.update("standard", UserOverridesServiceTests::pinEnabled, future);
+
+        expectThrows(VersionConflictEngineException.class, future::actionGet);
+        assertEquals(Constants.MAX_USER_OVERRIDES_UPDATE_ATTEMPTS, attempts.get());
+    }
+
+    /**
+     * Updating one space must leave the others untouched. The registry is a single shared document,
+     * so a write that rebuilt it from scratch would silently discard the other spaces.
+     */
+    public void testUpdateLeavesOtherSpacesUntouched() {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"draft\":{\"policy\":{\"enabled\":true},"
+                        + "\"filters\":[{\"id\":\"d1\",\"document\":\"{}\"}]}}}",
+                2L,
+                1L);
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        stubIndexSucceeding(captor);
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.update("standard", UserOverridesServiceTests::pinEnabled, future);
+        future.actionGet();
+
+        String written = captor.getValue().source().utf8ToString();
+        assertTrue("the draft space must survive", written.contains("\"draft\""));
+        assertTrue("its stored filter must survive", written.contains("\"d1\""));
+        assertTrue(written.contains("\"standard\""));
+    }
+
+    /** The mutator receives the overrides currently stored, not an empty instance. */
+    public void testMutatorSeesTheStoredOverrides() {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"filters\":"
+                        + "[{\"id\":\"existing\",\"document\":\"{}\"}]}}}",
+                5L,
+                1L);
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        stubIndexSucceeding(captor);
+
+        List<String> seen = new ArrayList<>();
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.update(
+                "standard",
+                current -> {
+                    current.getFilters().forEach(filter -> seen.add(filter.getId()));
+                    return new UserOverrides(
+                            new UserOverrides.PolicySettings(
+                                    null, null, null, new UserOverrides.EnrichmentDelta(Set.of("geo"), Set.of())),
+                            current.getFilters());
+                },
+                future);
+        future.actionGet();
+
+        assertEquals(List.of("existing"), seen);
+        assertTrue(captor.getValue().source().utf8ToString().contains("\"existing\""));
+    }
+
+    // --- Filter mutators ---------------------------------------------------------------------
+
+    /** Storing a filter adds it, keeping the policy settings the user had already saved. */
+    public void testStoreFilterAddsItAndKeepsThePolicySettings() {
+        UserOverrides current =
+                new UserOverrides(
+                        new UserOverrides.PolicySettings(Boolean.FALSE, null, null, null), new ArrayList<>());
+
+        UserOverrides result =
+                UserOverridesService.storeFilter("f1", "{\"document\":{\"name\":\"filter/a/0\"}}")
+                        .apply(current);
+
+        assertEquals(1, result.getFilters().size());
+        assertEquals("f1", result.getFilters().get(0).getId());
+        assertTrue(result.getFilters().get(0).getDocument().contains("filter/a/0"));
+        assertEquals(
+                "storing a filter must not drop the policy settings",
+                Boolean.FALSE,
+                result.getPolicy().getEnabled());
+    }
+
+    /** Storing the same id twice refreshes the copy instead of duplicating the entry. */
+    public void testStoreFilterRefreshesAnExistingEntry() {
+        UserOverrides current =
+                new UserOverrides(
+                        null, new ArrayList<>(List.of(new UserOverrides.StoredFilter("f1", "{\"old\":true}"))));
+
+        UserOverrides result = UserOverridesService.storeFilter("f1", "{\"new\":true}").apply(current);
+
+        assertEquals(1, result.getFilters().size());
+        assertEquals("{\"new\":true}", result.getFilters().get(0).getDocument());
+    }
+
+    /** Storing one filter leaves the others alone. */
+    public void testStoreFilterKeepsTheOtherFilters() {
+        UserOverrides current =
+                new UserOverrides(
+                        null, new ArrayList<>(List.of(new UserOverrides.StoredFilter("f1", "{}"))));
+
+        UserOverrides result = UserOverridesService.storeFilter("f2", "{}").apply(current);
+
+        assertEquals(2, result.getFilters().size());
+    }
+
+    /** Removing a filter prunes only that one, and keeps the policy settings. */
+    public void testRemoveFilterPrunesOnlyTheMatchingEntry() {
+        UserOverrides current =
+                new UserOverrides(
+                        new UserOverrides.PolicySettings(Boolean.TRUE, null, null, null),
+                        new ArrayList<>(
+                                List.of(
+                                        new UserOverrides.StoredFilter("f1", "{}"),
+                                        new UserOverrides.StoredFilter("f2", "{}"))));
+
+        UserOverrides result = UserOverridesService.removeFilter("f1").apply(current);
+
+        assertEquals(1, result.getFilters().size());
+        assertEquals("f2", result.getFilters().get(0).getId());
+        assertEquals(Boolean.TRUE, result.getPolicy().getEnabled());
+    }
+
+    /** Removing a filter that was never stored is a no-op, not an error. */
+    public void testRemoveFilterOfAnUnknownIdIsANoOp() {
+        UserOverrides current =
+                new UserOverrides(
+                        null, new ArrayList<>(List.of(new UserOverrides.StoredFilter("f1", "{}"))));
+
+        UserOverrides result = UserOverridesService.removeFilter("nope").apply(current);
+
+        assertEquals(1, result.getFilters().size());
+    }
+
+    /** The mutators must not modify the instance they are given. */
+    public void testFilterMutatorsDoNotMutateTheirInput() {
+        List<UserOverrides.StoredFilter> original =
+                new ArrayList<>(List.of(new UserOverrides.StoredFilter("f1", "{}")));
+        UserOverrides current = new UserOverrides(null, original);
+
+        UserOverridesService.storeFilter("f2", "{}").apply(current);
+        UserOverridesService.removeFilter("f1").apply(current);
+
+        assertEquals("the input list must be untouched", 1, original.size());
+        assertEquals("f1", original.get(0).getId());
+    }
+
+    // --- apply -------------------------------------------------------------------------------
+
+    /** Stubs the rebuilt policy that {@code apply} merges into, and its real document id. */
+    private void stubRebuiltPolicy(String source) throws Exception {
+        Map<String, Object> policyMap =
+                new ObjectMapper().readValue(source, new TypeReference<Map<String, Object>>() {});
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Map<String, Object>>>getArgument(1).onResponse(policyMap);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(any(), any());
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<String>>getArgument(3).onResponse("real-policy-id");
+                            return null;
+                        })
+                .when(this.spaceService)
+                .findDocumentIdAsync(any(), any(), any(), any());
+    }
+
+    private void stubBulkSucceeding(ArgumentCaptor<BulkRequest> captor) {
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<BulkResponse>>getArgument(1)
+                                    .onResponse(mock(BulkResponse.class));
+                            return null;
+                        })
+                .when(this.client)
+                .bulk(captor.capture(), any());
+    }
+
+    /** Runs apply against the stubs and returns the policy document that was written back. */
+    private String applyAndCaptureWrittenPolicy() {
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        stubIndexSucceeding(captor);
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.apply("standard", future);
+        future.actionGet();
+
+        return captor.getValue().source().utf8ToString();
+    }
+
+    /** An empty registry means nothing to do: no writes at all. */
+    public void testApplyDoesNothingWhenTheRegistryIsEmpty() {
+        stubRegistryMissing();
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.apply("standard", future);
+        future.actionGet();
+
+        verify(this.client, never()).index(any(IndexRequest.class), any());
+        verify(this.client, never()).bulk(any(BulkRequest.class), any());
+        verify(this.spaceService, never()).getPolicy(any(), any());
+    }
+
+    /**
+     * The user's booleans are written over CTI's, and the enrichment delta is resolved against the
+     * list CTI just published rather than against a stored copy.
+     */
+    public void testApplyOverwritesTheSettingsAndResolvesTheEnrichmentDelta() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"policy\":{\"enabled\":false,"
+                        + "\"enrichments\":{\"removed\":[\"geo\"],\"added\":[]}},\"filters\":[]}}}",
+                1L,
+                1L);
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enabled\":true,\"index_unclassified_events\":true,"
+                        + "\"enrichments\":[\"geo\",\"connection\",\"asn\"],\"filters\":[]},"
+                        + "\"hash\":{\"sha256\":\"stale\"},\"space\":{\"name\":\"standard\"},\"offset\":640}");
+
+        String written = applyAndCaptureWrittenPolicy();
+
+        assertTrue("the user's choice must win", written.contains("\"enabled\":false"));
+        assertFalse("the removed enrichment must be gone", written.contains("\"geo\""));
+        assertTrue("CTI's other enrichments must stay", written.contains("\"connection\""));
+        assertTrue("an enrichment CTI added later must come through", written.contains("\"asn\""));
+    }
+
+    /** A setting the user never decided is left exactly as CTI published it. */
+    public void testApplyLeavesUndecidedSettingsAsCtiPublishedThem() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"policy\":{\"enabled\":false},\"filters\":[]}}}",
+                1L,
+                1L);
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enabled\":true,\"index_unclassified_events\":true,"
+                        + "\"index_discarded_events\":true,\"enrichments\":[],\"filters\":[]},"
+                        + "\"hash\":{\"sha256\":\"x\"},\"space\":{\"name\":\"standard\"}}");
+
+        String written = applyAndCaptureWrittenPolicy();
+
+        assertTrue(written.contains("\"enabled\":false"));
+        assertTrue(
+                "index_unclassified_events was never decided by the user",
+                written.contains("\"index_unclassified_events\":true"));
+        assertTrue(
+                "index_discarded_events was never decided by the user",
+                written.contains("\"index_discarded_events\":true"));
+    }
+
+    /** The policy write carries a freshly computed hash, not the one the rebuild left. */
+    public void testApplyRecomputesThePolicyHash() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"policy\":{\"enabled\":false},\"filters\":[]}}}",
+                1L,
+                1L);
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enabled\":true,\"enrichments\":[],\"filters\":[]},"
+                        + "\"hash\":{\"sha256\":\"stale\"},\"space\":{\"name\":\"standard\"}}");
+
+        String written = applyAndCaptureWrittenPolicy();
+
+        assertFalse("the stale hash must not survive", written.contains("stale"));
+        assertTrue(written.contains("\"sha256\""));
+    }
+
+    /** A stored filter is recreated under its original id, and its id attached to the policy. */
+    public void testApplyRestoresAStoredFilterAndAttachesItsId() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"filters\":"
+                        + "[{\"id\":\"f1\",\"document\":\"{\\\"document\\\":{\\\"name\\\":\\\"filter/a/0\\\"}}\"}]}}}",
+                1L,
+                1L);
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enrichments\":[],\"filters\":[]},"
+                        + "\"hash\":{\"sha256\":\"x\"},\"space\":{\"name\":\"standard\"}}");
+        ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        stubBulkSucceeding(bulkCaptor);
+
+        String written = applyAndCaptureWrittenPolicy();
+
+        assertEquals("one filter must be recreated", 1, bulkCaptor.getValue().numberOfActions());
+        assertEquals("f1", bulkCaptor.getValue().requests().get(0).id());
+        assertEquals(Constants.INDEX_FILTERS, bulkCaptor.getValue().requests().get(0).index());
+        assertTrue("the policy must reference the restored filter", written.contains("\"f1\""));
+    }
+
+    /** Applying twice must not duplicate a filter id in the policy's array. */
+    public void testApplyIsIdempotentForTheFilterArray() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"filters\":"
+                        + "[{\"id\":\"f1\",\"document\":\"{\\\"document\\\":{}}\"}]}}}",
+                1L,
+                1L);
+        // The policy already lists f1, as it would after a previous apply.
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enrichments\":[],\"filters\":[\"f1\"]},"
+                        + "\"hash\":{\"sha256\":\"x\"},\"space\":{\"name\":\"standard\"}}");
+        stubBulkSucceeding(ArgumentCaptor.forClass(BulkRequest.class));
+
+        String written = applyAndCaptureWrittenPolicy();
+
+        assertEquals("f1 must appear exactly once", 1, written.split("\"f1\"", -1).length - 1);
+    }
+
+    /** An unparseable stored filter is skipped, and the rest are still restored. */
+    public void testApplySkipsAnUnparseableStoredFilter() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"filters\":"
+                        + "[{\"id\":\"bad\",\"document\":\"not json\"},"
+                        + "{\"id\":\"good\",\"document\":\"{\\\"document\\\":{}}\"}]}}}",
+                1L,
+                1L);
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enrichments\":[],\"filters\":[]},"
+                        + "\"hash\":{\"sha256\":\"x\"},\"space\":{\"name\":\"standard\"}}");
+        ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        stubBulkSucceeding(bulkCaptor);
+
+        String written = applyAndCaptureWrittenPolicy();
+
+        assertEquals("only the parseable one is restored", 1, bulkCaptor.getValue().numberOfActions());
+        assertEquals("good", bulkCaptor.getValue().requests().get(0).id());
+        assertTrue(written.contains("\"good\""));
+        assertFalse(written.contains("\"bad\""));
+    }
+
+    /**
+     * A missing policy is not an error. The registry is durable, so the next sync applies the
+     * overrides; failing here would abort a sync for something that self-heals.
+     */
+    public void testApplyDoesNothingWhenThePolicyIsMissing() {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"policy\":{\"enabled\":false},\"filters\":[]}}}",
+                1L,
+                1L);
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Map<String, Object>>>getArgument(1).onResponse(null);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(any(), any());
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.apply("standard", future);
+        future.actionGet();
+
+        verify(this.client, never()).index(any(IndexRequest.class), any());
+    }
+
+    /** The restored policy is written under the real document id, not the logical one. */
+    public void testApplyWritesUnderTheRealDocumentId() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"policy\":{\"enabled\":false},\"filters\":[]}}}",
+                1L,
+                1L);
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enrichments\":[],\"filters\":[]},"
+                        + "\"hash\":{\"sha256\":\"x\"},\"space\":{\"name\":\"standard\"}}");
+
+        ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
+        stubIndexSucceeding(captor);
+
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        this.service.apply("standard", future);
+        future.actionGet();
+
+        assertEquals("real-policy-id", captor.getValue().id());
+        assertEquals(Constants.INDEX_POLICIES, captor.getValue().index());
+    }
+
+    /** The space and offset the rebuild wrote must survive the merge untouched. */
+    public void testApplyPreservesTheSpaceAndOffset() throws Exception {
+        stubRegistryPresent(
+                "{\"user_overrides\":{\"standard\":{\"policy\":{\"enabled\":false},\"filters\":[]}}}",
+                1L,
+                1L);
+        stubRebuiltPolicy(
+                "{\"document\":{\"id\":\"p1\",\"enrichments\":[],\"filters\":[]},"
+                        + "\"hash\":{\"sha256\":\"x\"},\"space\":{\"name\":\"standard\"},\"offset\":640}");
+
+        String written = applyAndCaptureWrittenPolicy();
+
+        assertTrue(written.contains("\"space\""));
+        assertTrue(written.contains("\"standard\""));
+        assertTrue(written.contains("640"));
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
@@ -17,6 +17,7 @@
 package com.wazuh.contentmanager.rest.it;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.wazuh.contentmanager.ContentManagerRestTestCase;
+import com.wazuh.contentmanager.cti.catalog.index.IntegrationEnabledResolver;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -801,13 +803,15 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
-     * Toggle {@code enabled} on a user-managed integration living in the standard space.
+     * Toggle {@code enabled} on a user-managed integration living in the standard space, by sending
+     * {@code user_enabled} (the only field the client is allowed to change in that space).
      *
      * <p>Verifies:
      *
      * <ul>
      *   <li>Response status code is 200 OK.
-     *   <li>The stored {@code enabled} flag reflects the new value.
+     *   <li>The stored {@code user_enabled} field records the user's decision.
+     *   <li>The stored {@code enabled} flag, derived from it, reflects the new value.
      *   <li>The document stays in the standard space and keeps its {@code user-managed} mode.
      * </ul>
      *
@@ -829,7 +833,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": false,
+                        "user_enabled": false,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -847,6 +851,9 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
         assertNotNull("Standard integration should still exist", source);
         JsonNode document = source.path(Constants.KEY_DOCUMENT);
         assertFalse(
+                "user_enabled should record the requested value",
+                document.path(Constants.KEY_USER_ENABLED).asBoolean());
+        assertFalse(
                 "enabled should have been toggled to false",
                 document.path(Constants.KEY_ENABLED).asBoolean());
         assertEquals(
@@ -856,9 +863,9 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
-     * Update a user-managed integration in the standard space, changing {@code enabled} together with
-     * other fields. Only {@code enabled} must take effect; every other field is preserved from the
-     * stored document.
+     * Update a user-managed integration in the standard space, changing {@code user_enabled} together
+     * with other fields. Only {@code user_enabled} must take effect; every other field is preserved
+     * from the stored document.
      *
      * <p>Verifies: Response status code is 200 OK, {@code enabled} changed, and {@code category} /
      * {@code metadata.title} are unchanged.
@@ -881,7 +888,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://example.com"]
                         },
                         "category": "changed-category",
-                        "enabled": false,
+                        "user_enabled": false,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -951,7 +958,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
     }
 
     /**
-     * Toggling {@code enabled} on a standard user-managed integration succeeds and leaves the
+     * Toggling {@code user_enabled} on a standard user-managed integration succeeds and leaves the
      * CTI-owned, immutable {@code document.detector} block untouched. (The SAP detector is toggled
      * out-of-band; that side effect is verified on a full stack, not here, since these tests run
      * against a mocked Security Analytics service.)
@@ -969,7 +976,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                 this.makeRequest(
                         "PUT",
                         PluginSettings.INTEGRATIONS_URI + "/" + integrationId,
-                        "{\"resource\":{\"enabled\":false}}");
+                        "{\"resource\":{\"user_enabled\":false}}");
         assertEquals(RestStatus.OK.getStatus(), this.getStatusCode(disable));
 
         JsonNode doc =
@@ -985,7 +992,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                 this.makeRequest(
                         "PUT",
                         PluginSettings.INTEGRATIONS_URI + "/" + integrationId,
-                        "{\"resource\":{\"enabled\":true}}");
+                        "{\"resource\":{\"user_enabled\":true}}");
         assertEquals(RestStatus.OK.getStatus(), this.getStatusCode(enable));
 
         doc =
@@ -995,6 +1002,152 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
         assertTrue(
                 "document.detector is immutable and must stay as indexed (true)",
                 doc.path(Constants.KEY_DETECTOR).path(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /**
+     * Exercises the REST update path end to end — the client sends {@code user_enabled} and the
+     * stored document comes back with the derived {@code enabled} — then applies the same {@link
+     * IntegrationEnabledResolver} calls the snapshot pipeline uses, to confirm the override is
+     * carried onto a document republished under a new {@code document.id} with an unchanged title.
+     *
+     * <p>This does NOT drive the CTI snapshot pipeline, which is not reachable from this REST-only
+     * harness; that path is covered by {@code SnapshotServiceImplTests}.
+     *
+     * <p>Verifies:
+     *
+     * <ul>
+     *   <li>PUT with {@code user_enabled=true} sets both {@code user_enabled} and the derived {@code
+     *       enabled} to {@code true} on the original document.
+     *   <li>After carrying that override onto a document with a different id but the same title, and
+     *       {@code cti_enabled=false}, the effective {@code enabled} still tracks the user's choice
+     *       (true), not the freshly published CTI value (false).
+     * </ul>
+     *
+     * @throws IOException On request or response parsing failure.
+     */
+    public void testStandardUserManagedOverrideSurvivesDocumentIdChange() throws IOException {
+        // 1. Seed a standard user-managed integration with enabled=false, cti_enabled=false.
+        String title = "test-standard-survives-reindex";
+        String originalId = this.indexIntegrationWithCtiEnabled(title, false, false);
+
+        // 2. PUT user_enabled=true through the API (the only field mutable in the standard space).
+        Response response =
+                this.makeRequest(
+                        "PUT",
+                        PluginSettings.INTEGRATIONS_URI + "/" + originalId,
+                        "{\"resource\":{\"user_enabled\":true}}");
+        assertEquals(RestStatus.OK.getStatus(), this.getStatusCode(response));
+
+        // 3. Assert the stored document now has enabled=true AND user_enabled=true.
+        JsonNode originalDocument =
+                this.getResourceByDocumentId(Constants.INDEX_INTEGRATIONS, originalId, "standard")
+                        .path(Constants.KEY_DOCUMENT);
+        assertTrue(
+                "user_enabled should record the user's decision",
+                originalDocument.path(Constants.KEY_USER_ENABLED).asBoolean());
+        assertTrue(
+                "enabled should be derived from user_enabled",
+                originalDocument.path(Constants.KEY_ENABLED).asBoolean());
+        boolean storedOverride = originalDocument.path(Constants.KEY_USER_ENABLED).asBoolean();
+
+        // 4. Re-index the same document from a simulated CTI payload carrying cti_enabled=false,
+        // same title, DIFFERENT document.id, to mimic a plan change. This drives the exact same
+        // production functions SnapshotServiceImpl uses to carry a stored override across a
+        // full resync: IntegrationEnabledResolver.carryOverUserOverride() + .resolve().
+        String newId = UUID.randomUUID().toString();
+        // spotless:off
+        String ctiPayload = """
+                {
+                    "document": {
+                        "id": "%s",
+                        "category": "cloud-services",
+                        "cti_enabled": false,
+                        "mode": "user-managed",
+                        "decoders": [],
+                        "kvdbs": [],
+                        "rules": [],
+                        "metadata": {
+                            "title": "%s",
+                            "author": "Wazuh Inc.",
+                            "description": "Republished by CTI under a new id.",
+                            "documentation": "doc",
+                            "references": ["https://wazuh.com"]
+                        }
+                    },
+                    "hash": {"sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
+                    "space": {"name": "standard"}
+                }
+                """;
+        // spotless:on
+        ctiPayload = String.format(java.util.Locale.ROOT, ctiPayload, newId, title);
+
+        ObjectNode ctiRoot = (ObjectNode) MAPPER.readTree(ctiPayload);
+        ObjectNode ctiDocument = (ObjectNode) ctiRoot.get(Constants.KEY_DOCUMENT);
+        IntegrationEnabledResolver.carryOverUserOverride(ctiDocument, storedOverride);
+        IntegrationEnabledResolver.resolve(ctiDocument);
+
+        this.makeRequest(
+                "PUT",
+                Constants.INDEX_INTEGRATIONS + "/_doc/" + newId + "?refresh=true",
+                ctiRoot.toString());
+
+        // 5. Assert the result: enabled=true, user_enabled=true, cti_enabled=false.
+        JsonNode reindexedDocument =
+                this.getResourceByDocumentId(Constants.INDEX_INTEGRATIONS, newId, "standard")
+                        .path(Constants.KEY_DOCUMENT);
+        assertTrue(
+                "user_enabled must survive the reindex under the new id",
+                reindexedDocument.path(Constants.KEY_USER_ENABLED).asBoolean());
+        assertTrue(
+                "enabled must keep tracking the carried-over user override, not the fresh cti_enabled",
+                reindexedDocument.path(Constants.KEY_ENABLED).asBoolean());
+        assertFalse(
+                "cti_enabled should still reflect what CTI just published",
+                reindexedDocument.path(Constants.KEY_CTI_ENABLED).asBoolean());
+    }
+
+    /**
+     * Indexes a standard, user-managed integration that carries both {@code enabled} and {@code
+     * cti_enabled}, but no {@code user_enabled} (mirroring an integration CTI has published but the
+     * user has never touched).
+     *
+     * @param title the integration title.
+     * @param enabled the initial {@code document.enabled} value.
+     * @param ctiEnabled the initial {@code document.cti_enabled} value.
+     * @return the generated integration ID.
+     * @throws IOException On request or response parsing failure.
+     */
+    private String indexIntegrationWithCtiEnabled(String title, boolean enabled, boolean ctiEnabled)
+            throws IOException {
+        String id = UUID.randomUUID().toString();
+        // spotless:off
+        String doc = """
+                {
+                    "document": {
+                        "id": "%s",
+                        "category": "cloud-services",
+                        "enabled": %s,
+                        "cti_enabled": %s,
+                        "mode": "user-managed",
+                        "decoders": [],
+                        "kvdbs": [],
+                        "rules": [],
+                        "metadata": {
+                            "title": "%s",
+                            "author": "Wazuh Inc.",
+                            "description": "Integration indexed by the test suite.",
+                            "documentation": "doc",
+                            "references": ["https://wazuh.com"]
+                        }
+                    },
+                    "hash": {"sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
+                    "space": {"name": "standard"}
+                }
+                """;
+        // spotless:on
+        doc = String.format(java.util.Locale.ROOT, doc, id, enabled, ctiEnabled, title);
+        this.makeRequest("PUT", Constants.INDEX_INTEGRATIONS + "/_doc/" + id + "?refresh=true", doc);
+        return id;
     }
 
     /**

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
@@ -17,7 +17,6 @@
 package com.wazuh.contentmanager.rest.it;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
@@ -29,7 +28,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.wazuh.contentmanager.ContentManagerRestTestCase;
-import com.wazuh.contentmanager.cti.catalog.index.IntegrationEnabledResolver;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -1002,108 +1000,6 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
         assertTrue(
                 "document.detector is immutable and must stay as indexed (true)",
                 doc.path(Constants.KEY_DETECTOR).path(Constants.KEY_ENABLED).asBoolean());
-    }
-
-    /**
-     * Exercises the REST update path end to end — the client sends {@code user_enabled} and the
-     * stored document comes back with the derived {@code enabled} — then applies the same {@link
-     * IntegrationEnabledResolver} calls the snapshot pipeline uses, to confirm the override is
-     * carried onto a document republished under a new {@code document.id} with an unchanged title.
-     *
-     * <p>This does NOT drive the CTI snapshot pipeline, which is not reachable from this REST-only
-     * harness; that path is covered by {@code SnapshotServiceImplTests}.
-     *
-     * <p>Verifies:
-     *
-     * <ul>
-     *   <li>PUT with {@code user_enabled=true} sets both {@code user_enabled} and the derived {@code
-     *       enabled} to {@code true} on the original document.
-     *   <li>After carrying that override onto a document with a different id but the same title, and
-     *       {@code cti_enabled=false}, the effective {@code enabled} still tracks the user's choice
-     *       (true), not the freshly published CTI value (false).
-     * </ul>
-     *
-     * @throws IOException On request or response parsing failure.
-     */
-    public void testStandardUserManagedOverrideSurvivesDocumentIdChange() throws IOException {
-        // 1. Seed a standard user-managed integration with enabled=false, cti_enabled=false.
-        String title = "test-standard-survives-reindex";
-        String originalId = this.indexIntegrationWithCtiEnabled(title, false, false);
-
-        // 2. PUT user_enabled=true through the API (the only field mutable in the standard space).
-        Response response =
-                this.makeRequest(
-                        "PUT",
-                        PluginSettings.INTEGRATIONS_URI + "/" + originalId,
-                        "{\"resource\":{\"user_enabled\":true}}");
-        assertEquals(RestStatus.OK.getStatus(), this.getStatusCode(response));
-
-        // 3. Assert the stored document now has enabled=true AND user_enabled=true.
-        JsonNode originalDocument =
-                this.getResourceByDocumentId(Constants.INDEX_INTEGRATIONS, originalId, "standard")
-                        .path(Constants.KEY_DOCUMENT);
-        assertTrue(
-                "user_enabled should record the user's decision",
-                originalDocument.path(Constants.KEY_USER_ENABLED).asBoolean());
-        assertTrue(
-                "enabled should be derived from user_enabled",
-                originalDocument.path(Constants.KEY_ENABLED).asBoolean());
-        boolean storedOverride = originalDocument.path(Constants.KEY_USER_ENABLED).asBoolean();
-
-        // 4. Re-index the same document from a simulated CTI payload carrying cti_enabled=false,
-        // same title, DIFFERENT document.id, to mimic a plan change. This drives the exact same
-        // production functions SnapshotServiceImpl uses to carry a stored override across a
-        // full resync: IntegrationEnabledResolver.carryOverUserOverride() + .resolve().
-        String newId = UUID.randomUUID().toString();
-        // spotless:off
-        String ctiPayload = """
-                {
-                    "document": {
-                        "id": "%s",
-                        "category": "cloud-services",
-                        "cti_enabled": false,
-                        "mode": "user-managed",
-                        "decoders": [],
-                        "kvdbs": [],
-                        "rules": [],
-                        "metadata": {
-                            "title": "%s",
-                            "author": "Wazuh Inc.",
-                            "description": "Republished by CTI under a new id.",
-                            "documentation": "doc",
-                            "references": ["https://wazuh.com"]
-                        }
-                    },
-                    "hash": {"sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
-                    "space": {"name": "standard"}
-                }
-                """;
-        // spotless:on
-        ctiPayload = String.format(java.util.Locale.ROOT, ctiPayload, newId, title);
-
-        ObjectNode ctiRoot = (ObjectNode) MAPPER.readTree(ctiPayload);
-        ObjectNode ctiDocument = (ObjectNode) ctiRoot.get(Constants.KEY_DOCUMENT);
-        IntegrationEnabledResolver.carryOverUserOverride(ctiDocument, storedOverride);
-        IntegrationEnabledResolver.resolve(ctiDocument);
-
-        this.makeRequest(
-                "PUT",
-                Constants.INDEX_INTEGRATIONS + "/_doc/" + newId + "?refresh=true",
-                ctiRoot.toString());
-
-        // 5. Assert the result: enabled=true, user_enabled=true, cti_enabled=false.
-        JsonNode reindexedDocument =
-                this.getResourceByDocumentId(Constants.INDEX_INTEGRATIONS, newId, "standard")
-                        .path(Constants.KEY_DOCUMENT);
-        assertTrue(
-                "user_enabled must survive the reindex under the new id",
-                reindexedDocument.path(Constants.KEY_USER_ENABLED).asBoolean());
-        assertTrue(
-                "enabled must keep tracking the carried-over user override, not the fresh cti_enabled",
-                reindexedDocument.path(Constants.KEY_ENABLED).asBoolean());
-        assertFalse(
-                "cti_enabled should still reflect what CTI just published",
-                reindexedDocument.path(Constants.KEY_CTI_ENABLED).asBoolean());
     }
 
     /**

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/IntegrationCUDIT.java
@@ -114,7 +114,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                 {
                     "resource": {
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "metadata": {
                             "title": "test-integration-malformed-date",
                             "author": "Wazuh Inc.",
@@ -160,7 +160,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": true
+                        "user_enabled": true
                     }
                 }
                 """;
@@ -188,7 +188,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "author": "Wazuh Inc."
                         },
                         "category": "cloud-services",
-                        "enabled": true
+                        "user_enabled": true
                     }
                 }
                 """;
@@ -216,7 +216,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "title": "test-integration-no-author"
                         },
                         "category": "cloud-services",
-                        "enabled": true
+                        "user_enabled": true
                     }
                 }
                 """;
@@ -244,7 +244,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "title": "test-integration-no-cat",
                             "author": "Wazuh Inc."
                         },
-                        "enabled": true
+                        "user_enabled": true
                     }
                 }
                 """;
@@ -279,7 +279,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": true
+                        "user_enabled": true
                     }
                 }
                 """;
@@ -359,7 +359,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -414,7 +414,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -449,7 +449,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": []
                         },
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -487,7 +487,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": []
                         },
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -559,7 +559,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -717,7 +717,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": false,
+                        "user_enabled": false,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []
@@ -761,7 +761,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": true,
+                        "user_enabled": true,
                         "mode": "protected",
                         "rules": [],
                         "decoders": [],
@@ -938,7 +938,7 @@ public class IntegrationCUDIT extends ContentManagerRestTestCase {
                             "references": ["https://wazuh.com"]
                         },
                         "category": "cloud-services",
-                        "enabled": false,
+                        "user_enabled": false,
                         "rules": [],
                         "decoders": [],
                         "kvdbs": []

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/FilterOverrideRecorderTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/FilterOverrideRecorderTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.model.UserOverrides;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/** Unit tests for {@link FilterOverrideRecorder}. */
+public class FilterOverrideRecorderTests extends OpenSearchTestCase {
+
+    private UserOverridesService overridesService;
+    private AtomicInteger onDoneCalls;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.overridesService = mock(UserOverridesService.class);
+        this.onDoneCalls = new AtomicInteger();
+    }
+
+    /** Makes the registry write succeed. */
+    private void stubRegistrySucceeding() {
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Void>>getArgument(2).onResponse(null);
+                            return null;
+                        })
+                .when(this.overridesService)
+                .update(any(), any(), any());
+    }
+
+    private void record(String spaceName) {
+        FilterOverrideRecorder.record(
+                this.overridesService,
+                spaceName,
+                UserOverridesService.storeFilter("f1", "{}"),
+                "f1",
+                this.onDoneCalls::incrementAndGet);
+    }
+
+    /** A filter in the standard space is recorded, and the request is answered afterwards. */
+    public void testStandardSpaceIsRecorded() {
+        stubRegistrySucceeding();
+
+        record(Space.STANDARD.toString());
+
+        verify(this.overridesService).update(any(), any(), any());
+        assertEquals("the request must be answered", 1, this.onDoneCalls.get());
+    }
+
+    /**
+     * Every other space is skipped outright.
+     *
+     * <p>This is the guard that keeps a filter created in {@code draft} out of the standard registry.
+     * Without it, the next synchronization would recreate that filter in {@code standard} -- handing
+     * the user a resource in a space they never put it in.
+     */
+    public void testOtherSpacesAreNotRecorded() {
+        for (String space :
+                new String[] {Space.DRAFT.toString(), Space.TEST.toString(), Space.CUSTOM.toString()}) {
+            this.overridesService = mock(UserOverridesService.class);
+            this.onDoneCalls = new AtomicInteger();
+
+            record(space);
+
+            verifyNoInteractions(this.overridesService);
+            assertEquals(
+                    "the request must still be answered for space " + space, 1, this.onDoneCalls.get());
+        }
+    }
+
+    /**
+     * A registry failure must not fail the request. By the time this runs the filter has already been
+     * written and the space hash recalculated, so the user's request did succeed.
+     */
+    public void testTheRequestIsAnsweredWhenTheRegistryFails() {
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<Void>>getArgument(2)
+                                    .onFailure(new java.io.IOException("registry unavailable"));
+                            return null;
+                        })
+                .when(this.overridesService)
+                .update(any(), any(), any());
+
+        record(Space.STANDARD.toString());
+
+        assertEquals("a registry failure must not swallow the response", 1, this.onDoneCalls.get());
+    }
+
+    /** The response is sent exactly once, never twice. */
+    public void testTheRequestIsAnsweredExactlyOnce() {
+        stubRegistrySucceeding();
+
+        record(Space.STANDARD.toString());
+
+        assertEquals(1, this.onDoneCalls.get());
+    }
+
+    /**
+     * The mutator handed to the registry is the one the caller passed, applied to the stored state.
+     */
+    public void testTheCallersMutatorIsTheOneApplied() {
+        stubRegistrySucceeding();
+        org.mockito.ArgumentCaptor<java.util.function.UnaryOperator<UserOverrides>> captor =
+                org.mockito.ArgumentCaptor.forClass(java.util.function.UnaryOperator.class);
+
+        FilterOverrideRecorder.record(
+                this.overridesService,
+                Space.STANDARD.toString(),
+                UserOverridesService.removeFilter("f1"),
+                "f1",
+                this.onDoneCalls::incrementAndGet);
+
+        verify(this.overridesService).update(any(), captor.capture(), any());
+
+        UserOverrides current =
+                new UserOverrides(
+                        null, new ArrayList<>(java.util.List.of(new UserOverrides.StoredFilter("f1", "{}"))));
+        assertTrue(
+                "the recorder must not substitute the caller's mutator",
+                captor.getValue().apply(current).getFilters().isEmpty());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateFilterActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateFilterActionTests.java
@@ -50,6 +50,7 @@ import java.nio.charset.StandardCharsets;
 
 import com.wazuh.contentmanager.action.ContentCreateRequest;
 import com.wazuh.contentmanager.action.ContentResponse;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
@@ -68,6 +69,7 @@ public class TransportCreateFilterActionTests extends OpenSearchTestCase {
                     + "\"author\":{\"name\":\"Wazuh\",\"email\":\"info@wazuh.com\"}}}}";
 
     private Client client;
+    private UserOverridesService overridesService;
     private TransportCreateFilterAction action;
 
     @Before
@@ -89,9 +91,24 @@ public class TransportCreateFilterActionTests extends OpenSearchTestCase {
                 .when(threadPool)
                 .schedule(any(Runnable.class), any(TimeValue.class), anyString());
         when(transportService.getThreadPool()).thenReturn(threadPool);
+        this.overridesService = mock(UserOverridesService.class);
         this.action =
                 new TransportCreateFilterAction(
-                        transportService, mock(ActionFilters.class), this.client, mock(EngineService.class));
+                        transportService,
+                        mock(ActionFilters.class),
+                        this.client,
+                        mock(EngineService.class),
+                        this.overridesService);
+
+        // Recording an override succeeds by default, so the tests that predate the registry are
+        // unaffected by it.
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Void>>getArgument(2).onResponse(null);
+                            return null;
+                        })
+                .when(this.overridesService)
+                .update(any(), any(), any(ActionListener.class));
     }
 
     @After

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationActionTests.java
@@ -134,4 +134,74 @@ public class TransportUpdateIntegrationActionTests extends OpenSearchTestCase {
 
         assertTrue(payload.get(Constants.KEY_ENABLED).asBoolean());
     }
+
+    /** Stored draft document: fully editable, no CTI value. */
+    private ObjectNode storedDraftDocument() {
+        ObjectNode document = MAPPER.createObjectNode();
+        document.put(Constants.KEY_ID, ID);
+        document.put(Constants.KEY_ENABLED, false);
+        document.put(Constants.KEY_MODE, "user-managed");
+        document.put(Constants.KEY_CATEGORY, "other");
+        document.set(Constants.KEY_METADATA, MAPPER.createObjectNode().put("title", "my-integration"));
+
+        ObjectNode wrapper = MAPPER.createObjectNode();
+        wrapper.set(Constants.KEY_DOCUMENT, document);
+        wrapper.set(Constants.KEY_SPACE, MAPPER.createObjectNode().put("name", "draft"));
+        return wrapper;
+    }
+
+    public void testDraftPutStoresUserChoiceAndDerivesEnabled() {
+        ObjectNode payload = MAPPER.createObjectNode();
+        payload.put(Constants.KEY_ID, ID);
+        payload.put(Constants.KEY_CATEGORY, "other");
+        payload.put(Constants.KEY_USER_ENABLED, true);
+        payload.set(Constants.KEY_METADATA, MAPPER.createObjectNode().put("title", "my-integration"));
+
+        this.action.preserveMetadata(indexReturning(storedDraftDocument()), ID, payload, Space.DRAFT);
+
+        assertTrue(payload.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertTrue(payload.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** A false choice is a real decision in draft too. */
+    public void testDraftPutStoresFalseChoice() {
+        ObjectNode payload = MAPPER.createObjectNode();
+        payload.put(Constants.KEY_ID, ID);
+        payload.put(Constants.KEY_CATEGORY, "other");
+        payload.put(Constants.KEY_USER_ENABLED, false);
+        payload.set(Constants.KEY_METADATA, MAPPER.createObjectNode().put("title", "my-integration"));
+
+        this.action.preserveMetadata(indexReturning(storedDraftDocument()), ID, payload, Space.DRAFT);
+
+        assertFalse(payload.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertFalse(payload.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** On draft, an 'enabled' sent by the client must not win over the derivation. */
+    public void testDraftEnabledSentByClientIsIgnored() {
+        ObjectNode payload = MAPPER.createObjectNode();
+        payload.put(Constants.KEY_ID, ID);
+        payload.put(Constants.KEY_CATEGORY, "other");
+        payload.put(Constants.KEY_USER_ENABLED, true);
+        payload.put(Constants.KEY_ENABLED, false);
+        payload.set(Constants.KEY_METADATA, MAPPER.createObjectNode().put("title", "my-integration"));
+
+        this.action.preserveMetadata(indexReturning(storedDraftDocument()), ID, payload, Space.DRAFT);
+
+        assertTrue(payload.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** A client cannot forge cti_enabled in draft either. */
+    public void testDraftInjectedCtiEnabledIsStripped() {
+        ObjectNode payload = MAPPER.createObjectNode();
+        payload.put(Constants.KEY_ID, ID);
+        payload.put(Constants.KEY_CATEGORY, "other");
+        payload.put(Constants.KEY_USER_ENABLED, true);
+        payload.put(Constants.KEY_CTI_ENABLED, true);
+        payload.set(Constants.KEY_METADATA, MAPPER.createObjectNode().put("title", "my-integration"));
+
+        this.action.preserveMetadata(indexReturning(storedDraftDocument()), ID, payload, Space.DRAFT);
+
+        assertFalse(payload.has(Constants.KEY_CTI_ENABLED));
+    }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdateIntegrationActionTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+import org.junit.Before;
+
+import com.wazuh.contentmanager.cti.catalog.index.ContentIndex;
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.engine.service.EngineService;
+import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TransportUpdateIntegrationActionTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String ID = "61dbde65-f36c-4aa0-aac2-36ac259d4dd5";
+
+    private TransportUpdateIntegrationAction action;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        PluginSettings.getInstance(
+                Settings.builder().put("plugins.content_manager.engine.mock", true).build());
+        this.action =
+                new TransportUpdateIntegrationAction(
+                        mock(TransportService.class),
+                        mock(ActionFilters.class),
+                        mock(Client.class),
+                        mock(EngineService.class));
+    }
+
+    /** Stored document as CTI published it: disabled, no user decision yet. */
+    private ObjectNode storedDocument() {
+        ObjectNode document = MAPPER.createObjectNode();
+        document.put(Constants.KEY_ID, ID);
+        document.put(Constants.KEY_ENABLED, false);
+        document.put(Constants.KEY_CTI_ENABLED, false);
+        document.put(Constants.KEY_MODE, "user-managed");
+        document.set(Constants.KEY_METADATA, MAPPER.createObjectNode().put("title", "suricata"));
+
+        ObjectNode wrapper = MAPPER.createObjectNode();
+        wrapper.set(Constants.KEY_DOCUMENT, document);
+        wrapper.set(Constants.KEY_SPACE, MAPPER.createObjectNode().put("name", "standard"));
+        return wrapper;
+    }
+
+    private ContentIndex indexReturning(JsonNode stored) {
+        ContentIndex index = mock(ContentIndex.class);
+        when(index.getDocument(ID)).thenReturn(stored);
+        return index;
+    }
+
+    /** A standard-space request carries the user's decision in user_enabled. */
+    private ObjectNode request(boolean userEnabled) {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put(Constants.KEY_ID, ID);
+        node.put(Constants.KEY_USER_ENABLED, userEnabled);
+        return node;
+    }
+
+    public void testStandardPutStoresUserChoiceAndResolvesEnabled() {
+        ObjectNode payload = request(true);
+        assertNull(
+                this.action.preserveMetadata(
+                        indexReturning(storedDocument()), ID, payload, Space.STANDARD));
+        assertTrue(payload.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertTrue(payload.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    /** Disabling is a decision too, and must be recorded as such. */
+    public void testStandardPutStoresFalseChoice() {
+        ObjectNode stored = storedDocument();
+        ((ObjectNode) stored.get(Constants.KEY_DOCUMENT)).put(Constants.KEY_ENABLED, true);
+        ((ObjectNode) stored.get(Constants.KEY_DOCUMENT)).put(Constants.KEY_CTI_ENABLED, true);
+
+        ObjectNode payload = request(false);
+        this.action.preserveMetadata(indexReturning(stored), ID, payload, Space.STANDARD);
+
+        assertTrue(payload.has(Constants.KEY_USER_ENABLED));
+        assertFalse(payload.get(Constants.KEY_USER_ENABLED).asBoolean());
+        assertFalse(payload.get(Constants.KEY_ENABLED).asBoolean());
+    }
+
+    public void testStandardPutPreservesCtiValue() {
+        ObjectNode payload = request(true);
+        this.action.preserveMetadata(indexReturning(storedDocument()), ID, payload, Space.STANDARD);
+        assertFalse(payload.get(Constants.KEY_CTI_ENABLED).asBoolean());
+    }
+
+    /** A client cannot forge CTI's value. */
+    public void testInjectedCtiEnabledIsIgnored() {
+        ObjectNode payload = request(true);
+        payload.put(Constants.KEY_CTI_ENABLED, true);
+
+        this.action.preserveMetadata(indexReturning(storedDocument()), ID, payload, Space.STANDARD);
+
+        assertFalse(payload.get(Constants.KEY_CTI_ENABLED).asBoolean());
+    }
+
+    /** On standard, enabled is derived — a value sent by the client must not win. */
+    public void testEnabledSentByClientIsIgnoredOnStandard() {
+        ObjectNode payload = request(true);
+        payload.put(Constants.KEY_ENABLED, false);
+
+        this.action.preserveMetadata(indexReturning(storedDocument()), ID, payload, Space.STANDARD);
+
+        assertTrue(payload.get(Constants.KEY_ENABLED).asBoolean());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyActionTests.java
@@ -37,12 +37,16 @@ import org.junit.Before;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.action.UpdatePolicyRequest;
+import com.wazuh.contentmanager.cti.catalog.model.UserOverrides;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
+import com.wazuh.contentmanager.cti.catalog.service.UserOverridesService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
@@ -52,6 +56,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +73,7 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
 
     private Client client;
     private SpaceService spaceService;
+    private UserOverridesService overridesService;
     private TransportUpdatePolicyAction action;
     private IndexResponse indexResponse;
 
@@ -81,6 +87,7 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
 
         this.client = mock(Client.class);
         this.spaceService = mock(SpaceService.class);
+        this.overridesService = mock(UserOverridesService.class);
         EngineService engineService = mock(EngineService.class);
         this.indexResponse = mock(IndexResponse.class);
 
@@ -90,7 +97,19 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
                         mock(ActionFilters.class),
                         this.spaceService,
                         engineService,
-                        this.client);
+                        this.client,
+                        this.overridesService);
+
+        // Recording an override succeeds by default, so the tests that predate the registry are
+        // unaffected by it.
+        doAnswer(
+                        invocation -> {
+                            ActionListener<Void> l = invocation.getArgument(2);
+                            l.onResponse(null);
+                            return null;
+                        })
+                .when(this.overridesService)
+                .update(any(), any(), any(ActionListener.class));
 
         when(this.spaceService.getKnownEnrichmentTypes()).thenReturn(Collections.emptySet());
         when(this.indexResponse.getId()).thenReturn("draft-doc-id");
@@ -257,5 +276,188 @@ public class TransportUpdatePolicyActionTests extends OpenSearchTestCase {
                 "'date' should always be preserved from the existing document",
                 EXISTING_CREATION_DATE,
                 metadata.path(Constants.KEY_DATE).asText());
+    }
+
+    // --- User overrides registry -------------------------------------------------------------
+
+    private static final List<String> CTI_ENRICHMENTS =
+            List.of(
+                    "geo", "connection", "url_full", "url_domain", "hash_md5", "hash_sha1", "hash_sha256");
+
+    /** Stubs {@code getPolicy()} with a standard policy holding the given enrichments. */
+    @SuppressWarnings("unchecked")
+    private void stubStandardPolicy(List<String> storedEnrichments) {
+        Map<String, Object> policy = currentDraftPolicy();
+        Map<String, Object> document = (Map<String, Object>) policy.get(Constants.KEY_DOCUMENT);
+        document.put(Constants.KEY_ENRICHMENTS, storedEnrichments);
+
+        // Any enrichment absent from this set is rejected with 400 before the merge runs.
+        when(this.spaceService.getKnownEnrichmentTypes()).thenReturn(Set.copyOf(CTI_ENRICHMENTS));
+
+        doAnswer(
+                        invocation -> {
+                            ActionListener<Map<String, Object>> l = invocation.getArgument(1);
+                            l.onResponse(policy);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(any(), any(ActionListener.class));
+    }
+
+    /** A standard-space update body carrying exactly the given enrichments. */
+    private static String standardUpdateBody(List<String> enrichments) {
+        String quoted =
+                enrichments.stream().map(e -> "\"" + e + "\"").reduce((a, b) -> a + ", " + b).orElse("");
+        return "{"
+                + "\"type\": \"policy\","
+                + "\"resource\": {"
+                + "\"root_decoder\": \"\","
+                + "\"integrations\": [],"
+                + "\"filters\": [],"
+                + "\"enrichments\": ["
+                + quoted
+                + "],"
+                + "\"enabled\": true,"
+                + "\"index_unclassified_events\": true,"
+                + "\"index_discarded_events\": false,"
+                + "\"metadata\": {"
+                + "\"title\": \"Existing policy\","
+                + "\"author\": \"Wazuh Inc.\","
+                + "\"description\": \"Existing description\","
+                + "\"documentation\": \"\","
+                + "\"references\": []"
+                + "}"
+                + "}"
+                + "}";
+    }
+
+    /** Runs a standard-space update and returns the mutator handed to the registry. */
+    @SuppressWarnings("unchecked")
+    private UnaryOperator<UserOverrides> captureRecordedMutator(List<String> incomingEnrichments) {
+        this.action.doExecute(
+                mock(Task.class),
+                new UpdatePolicyRequest("standard", standardUpdateBody(incomingEnrichments)),
+                mock(ActionListener.class));
+
+        ArgumentCaptor<UnaryOperator<UserOverrides>> captor =
+                ArgumentCaptor.forClass(UnaryOperator.class);
+        verify(this.overridesService).update(any(), captor.capture(), any(ActionListener.class));
+        return captor.getValue();
+    }
+
+    /**
+     * Saving the standard policy records all four settings, and the enrichment change is stored as a
+     * delta so enrichments CTI publishes later still reach this user.
+     */
+    public void testStandardUpdateRecordsAllFourSettingsAndAnEnrichmentDelta() {
+        stubStandardPolicy(CTI_ENRICHMENTS);
+
+        // The client sends six of the seven, dropping "geo".
+        List<String> incoming =
+                List.of("connection", "url_full", "url_domain", "hash_md5", "hash_sha1", "hash_sha256");
+        UserOverrides recorded =
+                captureRecordedMutator(incoming)
+                        .apply(new UserOverrides(null, new java.util.ArrayList<>()));
+
+        Assert.assertEquals(Boolean.TRUE, recorded.getPolicy().getEnabled());
+        Assert.assertEquals(Boolean.TRUE, recorded.getPolicy().getIndexUnclassifiedEvents());
+        Assert.assertEquals(Boolean.FALSE, recorded.getPolicy().getIndexDiscardedEvents());
+        Assert.assertEquals(Set.of("geo"), recorded.getPolicy().getEnrichments().getRemoved());
+        Assert.assertTrue(recorded.getPolicy().getEnrichments().getAdded().isEmpty());
+    }
+
+    /**
+     * Re-adding an enrichment the user had previously removed clears the removal, so the same value
+     * does not stay suppressed forever.
+     */
+    public void testReAddingAPreviouslyRemovedEnrichmentClearsTheRemoval() {
+        // The stored policy is the result of the first save: six enrichments, no "geo".
+        List<String> withoutGeo =
+                List.of("connection", "url_full", "url_domain", "hash_md5", "hash_sha1", "hash_sha256");
+        stubStandardPolicy(withoutGeo);
+
+        UserOverrides priorState =
+                new UserOverrides(
+                        new UserOverrides.PolicySettings(
+                                Boolean.TRUE,
+                                Boolean.TRUE,
+                                Boolean.FALSE,
+                                new UserOverrides.EnrichmentDelta(Set.of("geo"), Set.of())),
+                        new java.util.ArrayList<>());
+
+        // The user re-checks "geo": the body carries all seven again.
+        UserOverrides recorded = captureRecordedMutator(CTI_ENRICHMENTS).apply(priorState);
+
+        Assert.assertTrue(
+                "the removal must be cleared",
+                recorded.getPolicy().getEnrichments().getRemoved().isEmpty());
+        Assert.assertEquals(Set.of("geo"), recorded.getPolicy().getEnrichments().getAdded());
+    }
+
+    /** The filters already stored in the registry survive a policy save untouched. */
+    public void testRecordingPolicySettingsKeepsTheStoredFilters() {
+        stubStandardPolicy(CTI_ENRICHMENTS);
+
+        UserOverrides priorState =
+                new UserOverrides(
+                        null,
+                        new java.util.ArrayList<>(
+                                List.of(new UserOverrides.StoredFilter("f1", "{\"document\":{}}"))));
+
+        UserOverrides recorded = captureRecordedMutator(CTI_ENRICHMENTS).apply(priorState);
+
+        Assert.assertEquals(1, recorded.getFilters().size());
+        Assert.assertEquals("f1", recorded.getFilters().get(0).getId());
+    }
+
+    /** A draft-space update records nothing: draft is never rebuilt from CTI. */
+    @SuppressWarnings("unchecked")
+    public void testDraftUpdateDoesNotTouchTheRegistry() {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<Map<String, Object>> l = invocation.getArgument(1);
+                            l.onResponse(currentDraftPolicy());
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getPolicy(any(), any(ActionListener.class));
+
+        this.action.doExecute(
+                mock(Task.class),
+                new UpdatePolicyRequest("draft", draftUpdateBody(null)),
+                mock(ActionListener.class));
+
+        verify(this.overridesService, never()).update(any(), any(), any(ActionListener.class));
+    }
+
+    /**
+     * A registry write failure must not fail the user's update: the policy has already been indexed,
+     * so the request succeeded. The failure is logged and the response stays OK.
+     */
+    @SuppressWarnings("unchecked")
+    public void testUpdateStillSucceedsWhenRecordingFails() {
+        stubStandardPolicy(CTI_ENRICHMENTS);
+        doAnswer(
+                        invocation -> {
+                            ActionListener<Void> l = invocation.getArgument(2);
+                            l.onFailure(new RuntimeException("registry unavailable"));
+                            return null;
+                        })
+                .when(this.overridesService)
+                .update(any(), any(), any(ActionListener.class));
+
+        ActionListener<MessageStatusResponse> listener = mock(ActionListener.class);
+        this.action.doExecute(
+                mock(Task.class),
+                new UpdatePolicyRequest("standard", standardUpdateBody(CTI_ENRICHMENTS)),
+                listener);
+
+        verify(listener)
+                .onResponse(
+                        argThat(
+                                response -> {
+                                    Assert.assertEquals(RestStatus.OK, response.getStatus());
+                                    return true;
+                                }));
     }
 }

--- a/tests/content-manager/lib/payloads.py
+++ b/tests/content-manager/lib/payloads.py
@@ -37,7 +37,7 @@ def make_integration(
                 "documentation": documentation,
             },
             "category": category,
-            "enabled": enabled,
+            "user_enabled": enabled,
         }
     }
 
@@ -58,7 +58,7 @@ def integration_update(stored_document, **overrides):
             "documentation": meta.get("documentation", ""),
         },
         "category": stored_document.get("category", "other"),
-        "enabled": stored_document.get("enabled", True),
+        "user_enabled": stored_document.get("user_enabled", True),
         "rules": stored_document.get("rules", []),
         "decoders": stored_document.get("decoders", []),
         "kvdbs": stored_document.get("kvdbs", []),

--- a/tests/content-manager/test_resources_lifecycle.py
+++ b/tests/content-manager/test_resources_lifecycle.py
@@ -30,6 +30,8 @@ class TestIntegrationLifecycle:
         A.assert_hash_present(source)
         # Integrations created through the API are always user-managed.
         assert source["document"]["mode"] == "user-managed", source["document"]
+        # Integrations created through the API carry no user override yet.
+        assert "user_enabled" not in source["document"], source["document"]
         A.assert_listed_in_draft_policy(client, "integrations", iid)
         A.assert_space_hash_changed(before, A.space_hash(client, C.SPACE_DRAFT))
 
@@ -56,6 +58,44 @@ class TestIntegrationLifecycle:
         assert updated["metadata"]["description"] == "updated description"
         # The mode is server-managed and preserved across updates.
         assert updated["mode"] == "user-managed", updated
+
+    def test_update_standard_space_toggles_user_enabled(self, client):
+        """Standard-space integrations only accept ``user_enabled``; ``enabled`` is
+        derived from it. The API never creates integrations in 'standard' (that's CTI's
+        job), so the starting document is seeded directly, the same way CTI content
+        lands in the index.
+        """
+        iid = str(uuid.uuid4())
+        doc = {
+            "document": {
+                "id": iid,
+                "category": "other",
+                "enabled": False,
+                "cti_enabled": False,
+                "mode": "user-managed",
+                "decoders": [],
+                "kvdbs": [],
+                "rules": [],
+                "metadata": {
+                    "title": f"ct-standard-{iid[:8]}",
+                    "author": "Wazuh Inc.",
+                    "description": "Seeded directly to simulate CTI content.",
+                    "documentation": "docs",
+                    "references": ["https://wazuh.com"],
+                },
+            },
+            "hash": {"sha256": "0" * 64},
+            "space": {"name": C.SPACE_STANDARD},
+        }
+        seed = client.put(f"/{C.INDEX_INTEGRATIONS}/_doc/{iid}", json=doc, params={"refresh": "true"})
+        assert seed.status_code in (200, 201), seed.text
+
+        resp = client.put(f"{C.INTEGRATIONS}/{iid}", json={"resource": {"user_enabled": True}})
+        assert resp.status_code == 200, resp.text
+
+        updated = client.get_doc_in_space(C.INDEX_INTEGRATIONS, iid, C.SPACE_STANDARD)["document"]
+        # Toggling enabled records the user's decision.
+        assert updated["user_enabled"] == updated["enabled"], updated
 
     def test_update_rejects_dependency_add(self, client, integration):
         source = client.get_doc(C.INDEX_INTEGRATIONS, integration["id"])["document"]

--- a/tests/content-manager/test_resources_lifecycle.py
+++ b/tests/content-manager/test_resources_lifecycle.py
@@ -30,8 +30,10 @@ class TestIntegrationLifecycle:
         A.assert_hash_present(source)
         # Integrations created through the API are always user-managed.
         assert source["document"]["mode"] == "user-managed", source["document"]
-        # Integrations created through the API carry no user override yet.
-        assert "user_enabled" not in source["document"], source["document"]
+        # 'user_enabled' defaults to the requested value (True here), and 'enabled'
+        # is derived from it.
+        assert source["document"]["user_enabled"] is True, source["document"]
+        assert source["document"]["enabled"] is True, source["document"]
         A.assert_listed_in_draft_policy(client, "integrations", iid)
         A.assert_space_hash_changed(before, A.space_hash(client, C.SPACE_DRAFT))
 


### PR DESCRIPTION
## Description

A user's enable/disable choice on a `standard`/`user-managed` integration was lost whenever content arrived from CTI, because `document.enabled` had two writers  , CTI on every content update, and the user through `PUT /integrations/{id}` , and the last write won.

Closes #1403

## Proposed Changes

Each field gets a single writer:

| Field | Written by | Meaning |
| --- | --- | --- |
| `document.cti_enabled` | CTI | the state CTI publishes |
| `document.user_enabled` | Content Manager | the user's explicit choice; **absent** means never set |
| `document.enabled` | Content Manager | the effective state, resolved as `user_enabled ?? cti_enabled` |

The rule lives in one class, `IntegrationEnabledResolver`, and runs at ingest and on update — never on read. Once the user sets a value, it wins over every later CTI update.

It is applied on all five paths that rebuild integration documents: incremental CTI patches, full resynchronisation, subscription plan change (shadow index swap), rollback to a local/stable snapshot, and a failed override read (which now aborts the snapshot instead of silently rebuilding every integration with CTI's values).

Overrides are matched by `document.metadata.title`, not `document.id`, because CTI reassigns the document id between catalog generations.

**API change:** the client now sends `user_enabled` instead of `enabled` when creating or updating an integration. `enabled` is derived and no longer accepted from a request body; neither is `cti_enabled`. On create, `user_enabled` is optional and defaults to `true`, exactly as `enabled` did.

### Results and Evidence

Validated on a live cluster, with every request and response recorded here:
**[Validation comment](https://github.com/wazuh/wazuh-indexer-plugins/pull/1411#issuecomment-5120377948)**

It covers the nine scenarios end to end — the toggle and the request contract,
a full CTI resynchronisation, the rollback to the stable snapshot, a plan change
where CTI reassigns every `document.id`, and create/update/promotion across
`draft`, `test` and `custom`. Seven of them are automated by the script attached
to that comment; the two that touch the host firewall and the cluster's
subscription come with copy-paste runbooks.

### Artifacts Affected

None.

### Configuration Changes

None. Two boolean fields are added to the `wazuh-threatintel-integrations` mapping; they apply on the next index creation, and until then are stored but not queryable, with no behaviour change.

### Documentation Updates

`openapi.yml`, `docs/dev/plugins/content-manager.md` (new "Integration `enabled` resolution" section) and `CHANGELOG.md`.

### Tests Introduced

`IntegrationEnabledResolverTests` (11) and `TransportUpdateIntegrationActionTests` (9) are new; 5 added to `ContentIndexTests`, 6 to `SnapshotServiceImplTests` and 2 to `ConsumerIocServiceTests`, plus REST coverage in `IntegrationCUDIT` and `test_resources_lifecycle.py`. Every new test was verified to fail without the corresponding production change.

The three in `ConsumerIocServiceTests` and `SnapshotServiceImplTests` that guard the capture ordering deserve a mention: they assert that the overrides are read **before** the standard space is wiped, and that a failed read aborts without deleting anything. A unit test on `initialize()` alone cannot catch that — the wipe happens in the caller — which is exactly how the first version of this fix passed its tests and still lost every override on a live cluster.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)

### Notes for reviewers

- **Must land with the dashboard change** ([wazuh-dashboard-security-analytics#426](https://github.com/wazuh/wazuh-dashboard-security-analytics/pull/426)). Until the dashboard sends `user_enabled`, the toggle returns `400`.
