### PR TITLE
Reload standard space into the engine after content changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 - [BUG] Missing threat-intel indices [(#1362)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1362)
 - Update the Content Manager OpenAPI (`openapi.yml`) to match the current API [(#1353)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1353)
 - [BUG] Vulnerability Detection empty for all agents after a transient snapshot bootstrap failure [(#1383)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1383)
+- [BUG] Log test does not use manually enabled integrations [(#1410)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1410)
 
 ## Prior versions
 - []()

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -205,7 +205,7 @@ public class ContentManagerPlugin extends Plugin
         if (PluginSettings.getInstance().isEngineMockEnabled()) {
             this.engine = new MockEngineService();
         } else {
-            this.engine = new EngineServiceImpl();
+            this.engine = new EngineServiceImpl(this.threadPool);
         }
 
         // Initialize CatalogSyncJob

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/engine/service/EngineService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/engine/service/EngineService.java
@@ -18,6 +18,8 @@ package com.wazuh.contentmanager.engine.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.opensearch.core.action.ActionListener;
+
 import com.wazuh.contentmanager.rest.model.RestResponse;
 
 public interface EngineService {
@@ -27,6 +29,15 @@ public interface EngineService {
     RestResponse validate(JsonNode resource);
 
     RestResponse promote(JsonNode policy);
+
+    /**
+     * Asynchronous variant of {@link #promote(JsonNode)} that offloads the blocking socket I/O to a
+     * background thread. Use this from transport-thread callbacks where blocking is not permitted.
+     *
+     * @param policy the Engine payload to promote.
+     * @param listener receives the {@link RestResponse} on success, or the exception on failure.
+     */
+    void promoteAsync(JsonNode policy, ActionListener<RestResponse> listener);
 
     RestResponse validateResource(String type, JsonNode resource);
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/engine/service/EngineServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/engine/service/EngineServiceImpl.java
@@ -20,6 +20,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.threadpool.ThreadPool;
+
 import com.wazuh.contentmanager.engine.client.EngineSocketClient;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.utils.Constants;
@@ -36,21 +39,27 @@ public class EngineServiceImpl implements EngineService {
 
     private final EngineSocketClient socket;
     private final ObjectMapper mapper;
+    private final ThreadPool threadPool;
 
-    /** Default constructor. */
-    public EngineServiceImpl() {
-        this.socket = new EngineSocketClient();
-        this.mapper = new ObjectMapper();
+    /**
+     * Production constructor.
+     *
+     * @param threadPool used by {@link #promoteAsync} to offload blocking socket I/O.
+     */
+    public EngineServiceImpl(ThreadPool threadPool) {
+        this(new EngineSocketClient(), threadPool);
     }
 
     /**
-     * Parametrized constructor
+     * Test constructor.
      *
      * @param socket instance of {@link EngineSocketClient}
+     * @param threadPool used by {@link #promoteAsync} to offload blocking socket I/O.
      */
-    public EngineServiceImpl(EngineSocketClient socket) {
+    public EngineServiceImpl(EngineSocketClient socket, ThreadPool threadPool) {
         this.socket = socket;
         this.mapper = new ObjectMapper();
+        this.threadPool = threadPool;
     }
 
     @Override
@@ -66,6 +75,20 @@ public class EngineServiceImpl implements EngineService {
     @Override
     public RestResponse promote(JsonNode policy) {
         return this.socket.sendRequest(PROMOTE, POST.name(), policy);
+    }
+
+    @Override
+    public void promoteAsync(JsonNode policy, ActionListener<RestResponse> listener) {
+        this.threadPool
+                .generic()
+                .execute(
+                        () -> {
+                            try {
+                                listener.onResponse(promote(policy));
+                            } catch (Exception e) {
+                                listener.onFailure(e);
+                            }
+                        });
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportCreateActionSpaces.java
@@ -403,6 +403,8 @@ public abstract class AbstractTransportCreateActionSpaces
                                                                 List.of(spaceName),
                                                                 ActionListener.wrap(
                                                                         changed -> {
+                                                                            TransportActionHelper.reloadStandardSpaceIntoEngine(
+                                                                                    this.engine, spaceService, changed);
                                                                             log.info(
                                                                                     Constants.I_LOG_SUCCESS,
                                                                                     "Created",

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportDeleteActionSpaces.java
@@ -241,6 +241,8 @@ public abstract class AbstractTransportDeleteActionSpaces
                                     List.of(spaceName),
                                     ActionListener.wrap(
                                             changed -> {
+                                                TransportActionHelper.reloadStandardSpaceIntoEngine(
+                                                        this.engine, spaceService, changed);
                                                 log.info(Constants.I_LOG_SUCCESS, "Deleted", this.getResourceType(), id);
                                                 respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
                                             },

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/AbstractTransportUpdateActionSpaces.java
@@ -333,6 +333,8 @@ public abstract class AbstractTransportUpdateActionSpaces
                                         List.of(spaceName),
                                         ActionListener.wrap(
                                                 changed -> {
+                                                    TransportActionHelper.reloadStandardSpaceIntoEngine(
+                                                            this.engine, spaceService, changed);
                                                     log.info(Constants.I_LOG_SUCCESS, "Updated", this.getResourceType(), id);
                                                     respond(listener, new RestResponse(id, RestStatus.OK.getStatus()));
                                                 },

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
@@ -116,21 +116,23 @@ public final class TransportActionHelper {
         spaceService.buildEnginePayload(
                 Space.STANDARD.toString(),
                 ActionListener.wrap(
-                        payload -> {
-                            try {
-                                RestResponse response = engine.promote(payload);
-                                if (response.getStatus() == RestStatus.OK.getStatus()) {
-                                    log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
-                                } else {
-                                    log.warn(
-                                            Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
-                                            response.getStatus(),
-                                            response.getMessage());
-                                }
-                            } catch (Exception e) {
-                                log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage());
-                            }
-                        },
+                        payload ->
+                                engine.promoteAsync(
+                                        payload,
+                                        ActionListener.wrap(
+                                                response -> {
+                                                    if (response.getStatus() == RestStatus.OK.getStatus()) {
+                                                        log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
+                                                    } else {
+                                                        log.warn(
+                                                                Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
+                                                                response.getStatus(),
+                                                                response.getMessage());
+                                                    }
+                                                },
+                                                e ->
+                                                        log.error(
+                                                                Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage()))),
                         e -> log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage())));
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportActionHelper.java
@@ -28,8 +28,11 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.transport.client.Client;
 
 import java.util.Objects;
+import java.util.Set;
 
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
+import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -80,6 +83,55 @@ public final class TransportActionHelper {
                                                 RestStatus.BAD_REQUEST.getStatus()));
                             }
                         }));
+    }
+
+    /**
+     * Reloads the standard space into the Engine when a mutation changed that space's hash.
+     *
+     * <p>The Engine holds its own copy of the standard policy and resolves asset selection from it,
+     * for both the production router and the log test endpoint. Content mutations only write to the
+     * OpenSearch indices, so without this reload the Engine keeps serving the snapshot it received at
+     * the last full load and changes such as toggling an integration's {@code enabled} flag never
+     * reach log test.
+     *
+     * <p>Fire-and-forget: the reload runs asynchronously and failures are only logged. The mutation
+     * that triggered it has already been persisted, so it must not be reported as failed.
+     *
+     * @param engine the Engine service; a {@code null} value is logged and skipped.
+     * @param spaceService used to build the Engine payload for the standard space.
+     * @param changedSpaces the spaces whose hash changed, as reported by {@link
+     *     SpaceService#calculateAndUpdate}. The reload is skipped unless it contains the standard
+     *     space.
+     */
+    public static void reloadStandardSpaceIntoEngine(
+            EngineService engine, SpaceService spaceService, Set<String> changedSpaces) {
+        if (changedSpaces == null || !changedSpaces.contains(Space.STANDARD.toString())) {
+            return;
+        }
+        if (engine == null) {
+            log.warn(Constants.E_LOG_ENGINE_IS_NULL);
+            return;
+        }
+
+        spaceService.buildEnginePayload(
+                Space.STANDARD.toString(),
+                ActionListener.wrap(
+                        payload -> {
+                            try {
+                                RestResponse response = engine.promote(payload);
+                                if (response.getStatus() == RestStatus.OK.getStatus()) {
+                                    log.info(Constants.I_LOG_ENGINE_STANDARD_LOADED);
+                                } else {
+                                    log.warn(
+                                            Constants.W_LOG_ENGINE_STANDARD_LOAD_STATUS,
+                                            response.getStatus(),
+                                            response.getMessage());
+                                }
+                            } catch (Exception e) {
+                                log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage());
+                            }
+                        },
+                        e -> log.error(Constants.E_LOG_ENGINE_STANDARD_LOAD_FAILED, e.getMessage())));
     }
 
     /** Walks the exception cause chain looking for an OpenSearchSecurityException. */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportUpdatePolicyAction.java
@@ -349,9 +349,8 @@ public class TransportUpdatePolicyAction
                 List.of(spaceName),
                 ActionListener.wrap(
                         changedSpaces -> {
-                            if (changedSpaces.contains(Space.STANDARD.toString())) {
-                                this.loadStandardSpaceIntoEngine();
-                            }
+                            TransportActionHelper.reloadStandardSpaceIntoEngine(
+                                    this.engineService, this.spaceService, changedSpaces);
                             listener.onResponse(new MessageStatusResponse(policyId, RestStatus.OK));
                         },
                         e -> respondWithError(listener, e)));
@@ -460,32 +459,6 @@ public class TransportUpdatePolicyAction
         ObjectNode policyNode = mapper.valueToTree(incomingPolicy);
         Resource.nestMetadataFields(policyNode);
         return policyNode;
-    }
-
-    private void loadStandardSpaceIntoEngine() {
-        if (this.engineService == null) {
-            log.warn(Constants.E_LOG_ENGINE_IS_NULL);
-            return;
-        }
-        this.spaceService.buildEnginePayload(
-                Space.STANDARD.toString(),
-                ActionListener.wrap(
-                        payload -> {
-                            try {
-                                RestResponse response = this.engineService.promote(payload);
-                                if (response.getStatus() == RestStatus.OK.getStatus()) {
-                                    log.info("Engine load for standard space completed successfully.");
-                                } else {
-                                    log.warn(
-                                            "Engine load for standard space returned status [{}]: {}",
-                                            response.getStatus(),
-                                            response.getMessage());
-                                }
-                            } catch (Exception e) {
-                                log.error("Failed to load standard space into Engine: {}", e.getMessage());
-                            }
-                        },
-                        e -> log.error("Failed to load standard space into Engine: {}", e.getMessage())));
     }
 
     private void respondWithError(ActionListener<MessageStatusResponse> listener, Exception e) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockEngineService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockEngineService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 
 import com.wazuh.contentmanager.engine.service.EngineService;
@@ -55,6 +56,11 @@ public class MockEngineService implements EngineService {
     public RestResponse promote(JsonNode policy) {
         log.debug("MockEngineService.promote called");
         return new RestResponse("OK", RestStatus.OK.getStatus());
+    }
+
+    @Override
+    public void promoteAsync(JsonNode policy, ActionListener<RestResponse> listener) {
+        listener.onResponse(promote(policy));
     }
 
     @Override

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/engine/service/EngineServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/engine/service/EngineServiceImplTests.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
 import org.junit.Before;
 
 import com.wazuh.contentmanager.engine.client.EngineSocketClient;
@@ -49,7 +50,8 @@ public class EngineServiceImplTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.socket = mock(EngineSocketClient.class);
-        this.engine = new EngineServiceImpl(this.socket);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        this.engine = new EngineServiceImpl(this.socket, threadPool);
     }
 
     /** Tests the logtest operation for a successful (200) response. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link TransportActionHelper#reloadStandardSpaceIntoEngine}, the hook that keeps
@@ -79,15 +78,42 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
                 .buildEnginePayload(eq(Space.STANDARD.toString()), any(ActionListener.class));
     }
 
+    /** Stubs {@link EngineService#promoteAsync} to invoke its listener with the given response. */
+    @SuppressWarnings("unchecked")
+    private void stubPromoteAsync(RestResponse response) {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<RestResponse> listener =
+                                    (ActionListener<RestResponse>) invocation.getArguments()[1];
+                            listener.onResponse(response);
+                            return null;
+                        })
+                .when(this.engine)
+                .promoteAsync(any(JsonNode.class), any(ActionListener.class));
+    }
+
+    /** Stubs {@link EngineService#promoteAsync} to invoke its listener with a failure. */
+    @SuppressWarnings("unchecked")
+    private void stubPromoteAsyncFailure(Exception exception) {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<RestResponse> listener =
+                                    (ActionListener<RestResponse>) invocation.getArguments()[1];
+                            listener.onFailure(exception);
+                            return null;
+                        })
+                .when(this.engine)
+                .promoteAsync(any(JsonNode.class), any(ActionListener.class));
+    }
+
     public void testPromotesStandardSpaceWhenItsHashChanged() {
         stubPayloadBuild();
-        when(this.engine.promote(any(JsonNode.class)))
-                .thenReturn(new RestResponse("OK", RestStatus.OK.getStatus()));
+        stubPromoteAsync(new RestResponse("OK", RestStatus.OK.getStatus()));
 
         TransportActionHelper.reloadStandardSpaceIntoEngine(
                 this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
 
-        verify(this.engine).promote(this.payload);
+        verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
 
     public void testSkipsReloadWhenStandardSpaceUnchanged() {
@@ -126,24 +152,22 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
      */
     public void testTolerantOfEngineRejection() {
         stubPayloadBuild();
-        when(this.engine.promote(any(JsonNode.class)))
-                .thenReturn(new RestResponse("rejected", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+        stubPromoteAsync(new RestResponse("rejected", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
 
         TransportActionHelper.reloadStandardSpaceIntoEngine(
                 this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
 
-        verify(this.engine).promote(this.payload);
+        verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
 
     public void testTolerantOfEngineFailure() {
         stubPayloadBuild();
-        when(this.engine.promote(any(JsonNode.class)))
-                .thenThrow(new RuntimeException("socket unavailable"));
+        stubPromoteAsyncFailure(new RuntimeException("socket unavailable"));
 
         TransportActionHelper.reloadStandardSpaceIntoEngine(
                 this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
 
-        verify(this.engine).promote(this.payload);
+        verify(this.engine).promoteAsync(eq(this.payload), any(ActionListener.class));
     }
 
     /** A payload build failure is logged, and never reaches the Engine. */
@@ -162,6 +186,6 @@ public class TransportActionHelperTests extends OpenSearchTestCase {
         TransportActionHelper.reloadStandardSpaceIntoEngine(
                 this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
 
-        verify(this.engine, never()).promote(any(JsonNode.class));
+        verify(this.engine, never()).promoteAsync(any(JsonNode.class), any(ActionListener.class));
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportActionHelperTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.util.Set;
+
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
+import com.wazuh.contentmanager.engine.service.EngineService;
+import com.wazuh.contentmanager.rest.model.RestResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link TransportActionHelper#reloadStandardSpaceIntoEngine}, the hook that keeps
+ * the Engine's copy of the standard policy in sync after a content mutation. Without it the Engine
+ * serves the snapshot from its last full load, so changes such as toggling an integration's {@code
+ * enabled} flag never reach the log test endpoint.
+ */
+public class TransportActionHelperTests extends OpenSearchTestCase {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private SpaceService spaceService;
+    private EngineService engine;
+    private ObjectNode payload;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.spaceService = mock(SpaceService.class);
+        this.engine = mock(EngineService.class);
+        this.payload = MAPPER.createObjectNode();
+        this.payload.put("space", Space.STANDARD.toString());
+    }
+
+    /** Stubs {@link SpaceService#buildEnginePayload} to hand {@link #payload} to its listener. */
+    @SuppressWarnings("unchecked")
+    private void stubPayloadBuild() {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<JsonNode> listener =
+                                    (ActionListener<JsonNode>) invocation.getArguments()[1];
+                            listener.onResponse(this.payload);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .buildEnginePayload(eq(Space.STANDARD.toString()), any(ActionListener.class));
+    }
+
+    public void testPromotesStandardSpaceWhenItsHashChanged() {
+        stubPayloadBuild();
+        when(this.engine.promote(any(JsonNode.class)))
+                .thenReturn(new RestResponse("OK", RestStatus.OK.getStatus()));
+
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+
+        verify(this.engine).promote(this.payload);
+    }
+
+    public void testSkipsReloadWhenStandardSpaceUnchanged() {
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                this.engine, this.spaceService, Set.of(Space.DRAFT.toString()));
+
+        verifyNoInteractions(this.spaceService);
+        verifyNoInteractions(this.engine);
+    }
+
+    public void testSkipsReloadWhenNoSpaceChanged() {
+        TransportActionHelper.reloadStandardSpaceIntoEngine(this.engine, this.spaceService, Set.of());
+
+        verifyNoInteractions(this.spaceService);
+        verifyNoInteractions(this.engine);
+    }
+
+    public void testSkipsReloadWhenChangedSpacesIsNull() {
+        TransportActionHelper.reloadStandardSpaceIntoEngine(this.engine, this.spaceService, null);
+
+        verifyNoInteractions(this.spaceService);
+        verifyNoInteractions(this.engine);
+    }
+
+    /** A missing Engine must not build a payload, and must not fail the completed mutation. */
+    public void testToleratesMissingEngine() {
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                null, this.spaceService, Set.of(Space.STANDARD.toString()));
+
+        verifyNoInteractions(this.spaceService);
+    }
+
+    /**
+     * The mutation is already persisted by the time the reload runs, so an Engine that rejects or
+     * cannot be reached is logged, never rethrown.
+     */
+    public void testTolerantOfEngineRejection() {
+        stubPayloadBuild();
+        when(this.engine.promote(any(JsonNode.class)))
+                .thenReturn(new RestResponse("rejected", RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+
+        verify(this.engine).promote(this.payload);
+    }
+
+    public void testTolerantOfEngineFailure() {
+        stubPayloadBuild();
+        when(this.engine.promote(any(JsonNode.class)))
+                .thenThrow(new RuntimeException("socket unavailable"));
+
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+
+        verify(this.engine).promote(this.payload);
+    }
+
+    /** A payload build failure is logged, and never reaches the Engine. */
+    @SuppressWarnings("unchecked")
+    public void testTolerantOfPayloadBuildFailure() {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<JsonNode> listener =
+                                    (ActionListener<JsonNode>) invocation.getArguments()[1];
+                            listener.onFailure(new RuntimeException("standard policy missing"));
+                            return null;
+                        })
+                .when(this.spaceService)
+                .buildEnginePayload(eq(Space.STANDARD.toString()), any(ActionListener.class));
+
+        TransportActionHelper.reloadStandardSpaceIntoEngine(
+                this.engine, this.spaceService, Set.of(Space.STANDARD.toString()));
+
+        verify(this.engine, never()).promote(any(JsonNode.class));
+    }
+}


### PR DESCRIPTION
## Description
Enabling an integration that ships disabled by default (e.g. `clamav`) made standard ingestion decode its logs, but log test kept ignoring it. Toggling `enabled` wrote the document and recomputed the space hash without notifying the Engine, so the Engine kept resolving assets from the policy snapshot it received at its last full load — log test included. The gap self-healed on the next CTI sync, which is why default-enabled integrations never showed it.                                                                                                                                                                                                    

Closes #https://github.com/wazuh/wazuh-indexer-plugins/issues/1410

## Proposed Changes
- Add `TransportActionHelper.reloadStandardSpaceIntoEngine(engine, spaceService, changedSpaces)`: reloads the standard space via `buildEnginePayload` → `engine.promote` when that space's hash changed. Fire-and-forget — the mutation is already persisted, so failures are logged, never returned as an error.
- Call it from the create, update and delete `*ActionSpaces` abstracts, at the existing `calculateAndUpdate` listener that already received `changed` and discarded it.
- `TransportUpdatePolicyAction` uses the shared helper instead of its private copy, dropping four duplicated inline log strings in favour of the existing `Constants.*_ENGINE_STANDARD_*` keys.

Create and delete are in scope because filters are standard-space CRUD and carried the same staleness gap. Decoders, kvdbs and rules use the non-Spaces abstract, hardcoded to `DRAFT`.


### Results and Evidence
See: https://github.com/wazuh/wazuh-indexer-plugins/pull/1417#issuecomment-5122759276

### Artifacts Affected
**wazuh-indexer-plugins** (content-manager)

### Configuration Changes
N/A

### Documentation Updates
N/A

### Tests Introduced

 New `TransportActionHelperTests` — 8 cases:                                                                                                                                                                                      
                                                                                                                                                                                                                                   
  | Case | Asserts |                                                                                                                                                                                                               
  |---|---|                                                                                                                                                                                                                        
  | `testPromotesStandardSpaceWhenItsHashChanged` | `promote` called with the built payload |                                                                                                                                      
  | `testSkipsReloadWhenStandardSpaceUnchanged` | no Engine or SpaceService interaction |                                                                                                                                          
  | `testSkipsReloadWhenNoSpaceChanged` | no interaction on an empty changed set |                                                                                                                                                 
  | `testSkipsReloadWhenChangedSpacesIsNull` | no interaction on `null` |                                                                                                                                                          
  | `testToleratesMissingEngine` | null Engine skips before building a payload |                                                                                                                                                   
  | `testTolerantOfEngineRejection` | non-OK status logged, not rethrown |                                                                                                                                                         
  | `testTolerantOfEngineFailure` | `promote` throwing is logged, not rethrown |                                                                                                                                                   
  | `testTolerantOfPayloadBuildFailure` | build failure never reaches the Engine |

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
