### PR TITLE
Remove CM settings maximum values

### DIFF
--- a/docs/ref/modules/alerting/configuration.md
+++ b/docs/ref/modules/alerting/configuration.md
@@ -4,7 +4,7 @@ The Alerting plugin is configured through cluster settings under the `plugins.al
 
 ## Monitor settings
 
-- **`plugins.alerting.monitor.max_monitors`** (Integer, default `10`, range 0–10) — maximum number of monitors allowed per node.
+- **`plugins.alerting.monitor.max_monitors`** (Integer, default `10`, minimum `0`, no upper bound) — maximum number of monitors allowed per node.
 - **`plugins.alerting.monitor.max_triggers`** (Integer, default `10`, hard max `50`) — maximum number of triggers per monitor.
 - **`plugins.alerting.monitor.doc_level_monitor_shard_fetch_size`** (Integer, default `10000`) — number of documents fetched per shard for document-level monitors.
 - **`plugins.alerting.monitor.doc_level_monitor_fan_out_nodes`** (Integer, default `1000`) — maximum number of nodes to fan out document-level monitor queries to.

--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -20,11 +20,11 @@ The Content Manager plugin is configured through settings in `opensearch.yml`. A
 - **`plugins.content_manager.telemetry.enabled`** (Boolean, default `true`, dynamic) — enable or disable the daily Update check service ping.
 - **`plugins.content_manager.catalog.update_on_demand`** (Boolean, default `true`) — when `false`, on-demand content updates (`POST /update`) return `403 Forbidden` for every caller, regardless of role.
 - **`plugins.content_manager.catalog.policy_update.enabled`** (Boolean, default `true`) — when `false`, policy updates (`PUT /policy/{space}`) return `403 Forbidden` for every caller, regardless of role.
-- **`plugins.content_manager.max_integrations`** (Integer, default `100`, range 0–100, dynamic) — maximum number of integrations that can be created. Requests that would exceed this limit are rejected with HTTP 400.
-- **`plugins.content_manager.max_decoders`** (Integer, default `200`, range 0–200, dynamic) — maximum number of decoders that can be created. Requests that would exceed this limit are rejected with HTTP 400.
-- **`plugins.content_manager.max_rules`** (Integer, default `200`, range 0–200, dynamic) — maximum number of rules that can be created. Requests that would exceed this limit are rejected with HTTP 400.
-- **`plugins.content_manager.max_kvdbs`** (Integer, default `100`, range 0–100, dynamic) — maximum number of KVDBs that can be created. Requests that would exceed this limit are rejected with HTTP 400.
-- **`plugins.content_manager.max_filters`** (Integer, default `100`, range 0–100, dynamic) — maximum number of filters that can be created per space. Requests that would exceed this limit are rejected with HTTP 400.
+- **`plugins.content_manager.max_integrations`** (Integer, default `100`, minimum `0`, no upper bound, dynamic) — maximum number of integrations that can be created. Requests that would exceed this limit are rejected with HTTP 400.
+- **`plugins.content_manager.max_decoders`** (Integer, default `200`, minimum `0`, no upper bound, dynamic) — maximum number of decoders that can be created. Requests that would exceed this limit are rejected with HTTP 400.
+- **`plugins.content_manager.max_rules`** (Integer, default `200`, minimum `0`, no upper bound, dynamic) — maximum number of rules that can be created. Requests that would exceed this limit are rejected with HTTP 400.
+- **`plugins.content_manager.max_kvdbs`** (Integer, default `100`, minimum `0`, no upper bound, dynamic) — maximum number of KVDBs that can be created. Requests that would exceed this limit are rejected with HTTP 400.
+- **`plugins.content_manager.max_filters`** (Integer, default `100`, minimum `0`, no upper bound, dynamic) — maximum number of filters that can be created per space. Requests that would exceed this limit are rejected with HTTP 400.
 
 <!-- // ANCHOR_END: settings-table -->
 

--- a/docs/ref/modules/notifications/configuration.md
+++ b/docs/ref/modules/notifications/configuration.md
@@ -52,10 +52,10 @@ These settings control the plugin's general behavior.
 
 These settings cap how many notification configuration documents can exist, to bound resource usage. All are dynamic. Creation requests that would exceed a limit are rejected with HTTP 400; existing configurations are unaffected when a limit is lowered.
 
-- **`plugins.notifications.max_notification_configs`** (Integer, default `40`, range 0–40) — global cap on the total number of notification configuration documents of any type (channels, groups, senders, and active responses all count against this shared limit).
-- **`plugins.notifications.max_notification_groups`** (Integer, default `10`, range 0–10) — cap on the number of `email_group` configurations. Counts against, and in addition to, `max_notification_configs`.
-- **`plugins.notifications.max_notification_senders`** (Integer, default `5`, range 0–5) — cap on the number of `smtp_account` and `ses_account` configurations combined. Counts against, and in addition to, `max_notification_configs`.
-- **`plugins.notifications.max_active_responses`** (Integer, default `10`, range 0–10) — cap on the number of `active_response` configurations. Counts against, and in addition to, `max_notification_configs`.
+- **`plugins.notifications.max_notification_configs`** (Integer, default `40`, minimum `0`, no upper bound) — global cap on the total number of notification configuration documents of any type (channels, groups, senders, and active responses all count against this shared limit).
+- **`plugins.notifications.max_notification_groups`** (Integer, default `10`, minimum `0`, no upper bound) — cap on the number of `email_group` configurations. Counts against, and in addition to, `max_notification_configs`.
+- **`plugins.notifications.max_notification_senders`** (Integer, default `5`, minimum `0`, no upper bound) — cap on the number of `smtp_account` and `ses_account` configurations combined. Counts against, and in addition to, `max_notification_configs`.
+- **`plugins.notifications.max_active_responses`** (Integer, default `10`, minimum `0`, no upper bound) — cap on the number of `active_response` configurations. Counts against, and in addition to, `max_notification_configs`.
 
 > **Note:** These are separate from `opensearch.notifications.general.default_items_query_count` and other `general.*` settings above — they live under a distinct `plugins.notifications.*` prefix.
 

--- a/docs/ref/modules/reporting/index.md
+++ b/docs/ref/modules/reporting/index.md
@@ -19,7 +19,7 @@ For a walkthrough of configuring an email delivery channel and generating a repo
 
 The Reporting plugin is configured through cluster settings.
 
-- **`plugins.reports.max_report_definitions`** (Integer, default `50`, range 0–50, dynamic) — maximum number of report definitions allowed. Creation requests that would exceed this limit are rejected with HTTP 400. Existing report definitions are not affected when the limit is lowered.
+- **`plugins.reports.max_report_definitions`** (Integer, default `50`, minimum `0`, no upper bound, dynamic) — maximum number of report definitions allowed. Creation requests that would exceed this limit are rejected with HTTP 400. Existing report definitions are not affected when the limit is lowered.
 - **`opensearch.reports.general.operationTimeoutMs`** (Long, default `60000`, min `100`) — timeout in milliseconds for report generation operations.
 - **`opensearch.reports.general.defaultItemsQueryCount`** (Integer, default `100`, min `10`) — default number of items fetched per query when building report data.
 

--- a/docs/ref/modules/security-analytics/configuration.md
+++ b/docs/ref/modules/security-analytics/configuration.md
@@ -37,8 +37,8 @@ The Security Analytics plugin is configured through settings in `opensearch.yml`
 - **`plugins.security_analytics.finding_history_retention_period`** (Time, default `60d`) — retention period after which finding history indices are deleted.
 - **`plugins.security_analytics.index_timeout`** (Time, default `60s`) — timeout for Security Analytics index operations.
 - **`plugins.security_analytics.max_case_management_bulk_size`** (Integer, default `10`, range 0–100, dynamic) — maximum number of findings that can be updated in a single request to the [update findings](case-management.md#updating-findings) endpoint. Setting it to `0` disables the endpoint entirely.
-- **`plugins.security_analytics.max_detectors`** (Integer, default `10`, range 0–10, dynamic) — maximum number of user-created detectors (Content Manager detectors do not count).
-- **`plugins.security_analytics.max_rules_per_detector`** (Integer, default `50`, range 0–50, dynamic) — maximum number of rules (custom or pre-packaged) allowed in a single detector input. Requests that would exceed this limit are rejected with HTTP 400.
+- **`plugins.security_analytics.max_detectors`** (Integer, default `10`, minimum `0`, no upper bound, dynamic) — maximum number of user-created detectors (Content Manager detectors do not count).
+- **`plugins.security_analytics.max_rules_per_detector`** (Integer, default `50`, minimum `0`, no upper bound, dynamic) — maximum number of rules (custom or pre-packaged) allowed in a single detector input. Requests that would exceed this limit are rejected with HTTP 400.
 - **`plugins.security_analytics.mappings.default_schema`** (String, default `ecs`) — default field-mapping schema used to resolve a Sigma rule's raw field names to Wazuh Common Schema fields when a log type does not declare its own schema.
 
 <!-- // ANCHOR_END: settings-table -->

--- a/docs/ref/modules/security-analytics/index.md
+++ b/docs/ref/modules/security-analytics/index.md
@@ -15,7 +15,7 @@ When the restriction is violated, the API returns `400 Bad Request`.
 - **Max rules per detector** — each detector input can reference at most `plugins.security_analytics.max_rules_per_detector` rules (custom or pre-packaged), default `50`. Requests that exceed this limit are rejected with HTTP 400.
 - **Max detectors** — at most `plugins.security_analytics.max_detectors` user-created detectors are allowed, default `10`. Detectors created by the Content Manager plugin do not count towards this limit.
 
-Both limits are dynamic and enforced at the transport layer, applying to all detector creation and update paths, including inter-plugin calls from the Content Manager. See [Configuration](configuration.md) for the settings' full ranges.
+Both limits are dynamic and enforced at the transport layer, applying to all detector creation and update paths, including inter-plugin calls from the Content Manager. Both accept any value from `0` upwards; there is no hard-coded ceiling. See [Configuration](configuration.md) for details.
 
 ## Wazuh enriched findings
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -51,24 +51,19 @@ public class PluginSettings {
     /** Settings default values */
     private static final int DEFAULT_MAX_ITEMS_PER_BULK = 999;
 
-    private static final int MAXIMUM_MAX_INTEGRATIONS = 100;
-    public static final int DEFAULT_MAX_INTEGRATIONS = MAXIMUM_MAX_INTEGRATIONS;
+    public static final int DEFAULT_MAX_INTEGRATIONS = 100;
     private static final int MINIMUM_MAX_INTEGRATIONS = 0;
 
-    private static final int MAXIMUM_MAX_DECODERS = 200;
-    public static final int DEFAULT_MAX_DECODERS = MAXIMUM_MAX_DECODERS;
+    public static final int DEFAULT_MAX_DECODERS = 200;
     private static final int MINIMUM_MAX_DECODERS = 0;
 
-    private static final int MAXIMUM_MAX_RULES = 200;
-    public static final int DEFAULT_MAX_RULES = MAXIMUM_MAX_RULES;
+    public static final int DEFAULT_MAX_RULES = 200;
     private static final int MINIMUM_MAX_RULES = 0;
 
-    private static final int MAXIMUM_MAX_KVDBS = 100;
-    public static final int DEFAULT_MAX_KVDBS = MAXIMUM_MAX_KVDBS;
+    public static final int DEFAULT_MAX_KVDBS = 100;
     private static final int MINIMUM_MAX_KVDBS = 0;
 
-    private static final int MAXIMUM_MAX_FILTERS = 100;
-    public static final int DEFAULT_MAX_FILTERS = MAXIMUM_MAX_FILTERS;
+    public static final int DEFAULT_MAX_FILTERS = 100;
     private static final int MINIMUM_MAX_FILTERS = 0;
 
     private static final long DEFAULT_MAX_BULK_BYTES = 5L * 1024 * 1024;
@@ -274,7 +269,6 @@ public class PluginSettings {
                     "plugins.content_manager.max_integrations",
                     DEFAULT_MAX_INTEGRATIONS,
                     MINIMUM_MAX_INTEGRATIONS,
-                    MAXIMUM_MAX_INTEGRATIONS,
                     Setting.Property.NodeScope,
                     Setting.Property.Dynamic);
 
@@ -287,7 +281,6 @@ public class PluginSettings {
                     "plugins.content_manager.max_decoders",
                     DEFAULT_MAX_DECODERS,
                     MINIMUM_MAX_DECODERS,
-                    MAXIMUM_MAX_DECODERS,
                     Setting.Property.NodeScope,
                     Setting.Property.Dynamic);
 
@@ -300,7 +293,6 @@ public class PluginSettings {
                     "plugins.content_manager.max_rules",
                     DEFAULT_MAX_RULES,
                     MINIMUM_MAX_RULES,
-                    MAXIMUM_MAX_RULES,
                     Setting.Property.NodeScope,
                     Setting.Property.Dynamic);
 
@@ -313,7 +305,6 @@ public class PluginSettings {
                     "plugins.content_manager.max_kvdbs",
                     DEFAULT_MAX_KVDBS,
                     MINIMUM_MAX_KVDBS,
-                    MAXIMUM_MAX_KVDBS,
                     Setting.Property.NodeScope,
                     Setting.Property.Dynamic);
 
@@ -326,7 +317,6 @@ public class PluginSettings {
                     "plugins.content_manager.max_filters",
                     DEFAULT_MAX_FILTERS,
                     MINIMUM_MAX_FILTERS,
-                    MAXIMUM_MAX_FILTERS,
                     Setting.Property.NodeScope,
                     Setting.Property.Dynamic);
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
@@ -146,6 +146,91 @@ public class PluginSettingsTests extends OpenSearchTestCase {
         Assert.assertThrows(IllegalArgumentException.class, () -> PluginSettings.getInstance(settings));
     }
 
+    /** Tests that the resource limit settings fall back to their documented defaults. */
+    public void testResourceLimitDefaults() {
+        PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
+
+        Assert.assertEquals(100, pluginSettings.getMaxIntegrations());
+        Assert.assertEquals(200, pluginSettings.getMaxDecoders());
+        Assert.assertEquals(200, pluginSettings.getMaxRules());
+        Assert.assertEquals(100, pluginSettings.getMaxKvdbs());
+        Assert.assertEquals(100, pluginSettings.getMaxFilters());
+    }
+
+    /** Tests that the resource limit settings have no upper bound. */
+    public void testResourceLimitsHaveNoUpperBound() {
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.max_integrations", 100_000)
+                        .put("plugins.content_manager.max_decoders", 100_000)
+                        .put("plugins.content_manager.max_rules", 100_000)
+                        .put("plugins.content_manager.max_kvdbs", 100_000)
+                        .put("plugins.content_manager.max_filters", 100_000)
+                        .build();
+
+        PluginSettings pluginSettings = PluginSettings.getInstance(settings);
+
+        Assert.assertEquals(100_000, pluginSettings.getMaxIntegrations());
+        Assert.assertEquals(100_000, pluginSettings.getMaxDecoders());
+        Assert.assertEquals(100_000, pluginSettings.getMaxRules());
+        Assert.assertEquals(100_000, pluginSettings.getMaxKvdbs());
+        Assert.assertEquals(100_000, pluginSettings.getMaxFilters());
+    }
+
+    /** Tests that the resource limit settings accept Integer.MAX_VALUE. */
+    public void testResourceLimitsAcceptIntegerMaxValue() {
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.max_integrations", Integer.MAX_VALUE)
+                        .put("plugins.content_manager.max_decoders", Integer.MAX_VALUE)
+                        .put("plugins.content_manager.max_rules", Integer.MAX_VALUE)
+                        .put("plugins.content_manager.max_kvdbs", Integer.MAX_VALUE)
+                        .put("plugins.content_manager.max_filters", Integer.MAX_VALUE)
+                        .build();
+
+        PluginSettings pluginSettings = PluginSettings.getInstance(settings);
+
+        Assert.assertEquals(Integer.MAX_VALUE, pluginSettings.getMaxIntegrations());
+        Assert.assertEquals(Integer.MAX_VALUE, pluginSettings.getMaxDecoders());
+        Assert.assertEquals(Integer.MAX_VALUE, pluginSettings.getMaxRules());
+        Assert.assertEquals(Integer.MAX_VALUE, pluginSettings.getMaxKvdbs());
+        Assert.assertEquals(Integer.MAX_VALUE, pluginSettings.getMaxFilters());
+    }
+
+    /** Tests that the resource limit settings keep their zero floor. */
+    public void testResourceLimitsRejectNegativeValues() {
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        PluginSettings.MAX_DECODERS.get(
+                                Settings.builder().put("plugins.content_manager.max_decoders", -1).build()));
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        PluginSettings.MAX_FILTERS.get(
+                                Settings.builder().put("plugins.content_manager.max_filters", -1).build()));
+    }
+
+    /** Tests that zero is still a valid resource limit, blocking creation of that resource. */
+    public void testResourceLimitsAcceptZero() {
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.max_integrations", 0)
+                        .put("plugins.content_manager.max_decoders", 0)
+                        .put("plugins.content_manager.max_rules", 0)
+                        .put("plugins.content_manager.max_kvdbs", 0)
+                        .put("plugins.content_manager.max_filters", 0)
+                        .build();
+
+        PluginSettings pluginSettings = PluginSettings.getInstance(settings);
+
+        Assert.assertEquals(0, pluginSettings.getMaxIntegrations());
+        Assert.assertEquals(0, pluginSettings.getMaxDecoders());
+        Assert.assertEquals(0, pluginSettings.getMaxRules());
+        Assert.assertEquals(0, pluginSettings.getMaxKvdbs());
+        Assert.assertEquals(0, pluginSettings.getMaxFilters());
+    }
+
     /** Tests that getUserAgent returns the fallback value when no version has been set. */
     public void testGetUserAgentDefaultsToUnknown() {
         PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);


### PR DESCRIPTION
## Description

The five Content Manager resource limits (`max_integrations`, `max_decoders`, `max_rules`, `max_kvdbs`, `max_filters`) were declared with hard-coded upper bounds of `100`, `200`, `200`, `100` and `100`, and each bound doubled as its setting's default.
CTI team has hit this ceiling. This PR removes the ceilings, so the settings are fully customizable, leaving the defaults (`100`, `200`, `200`, `100`, `100`) and the minimums (`0`) untouched.

This PR also carries the documentation updates for the whole issue, since the settings reference for every indexer plugin lives in this repository.

Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1420 *(plugins side)*


## Proposed Changes

- Deleted the private `MAXIMUM_MAX_INTEGRATIONS`, `MAXIMUM_MAX_DECODERS`, `MAXIMUM_MAX_RULES`, `MAXIMUM_MAX_KVDBS` and `MAXIMUM_MAX_FILTERS` constants, and dropped the `max` argument from the five corresponding `Setting.intSetting` declarations.
- The `DEFAULT_MAX_*` constants are now literals (`100`, `200`, `200`, `100`, `100`) instead of aliases of the deleted maximums, so the defaults no longer move with ceilings that no longer exist.
- The `MINIMUM_MAX_*` constants (`0`) are kept and still passed to `Setting.intSetting`, so negative values remain rejected.
- Updated the settings reference documentation for all thirteen limits


### Results and Evidence

**Unit tests**: `PluginSettingsTests`, 28 tests, 0 failures, 0 errors (5 new, 23 pre-existing):

``` console
jorge@jorge-wazuh:~/wazuh/wazuh-indexer-plugins$ ./gradlew :wazuh-indexer-content-manager:test --tests "*settings.PluginSettingsTests*"
...
BUILD SUCCESSFUL in 12s
8 actionable tasks: 1 executed, 7 up-to-date

```

**Testing in a real deploy**:
Before deploying the change, the ceilings were enforced

After deploying:

| Check | Result |
| --- | --- |
| `PUT _cluster/settings` with `100000`, all five settings | 200, values read back correctly |
| `PUT _cluster/settings` with `-1`, all five settings | 400 `Failed to parse value [-1] for setting [<key>] must be >= 0` |
| Effective defaults with both scopes nulled | `100` / `200` / `200` / `100` / `100` (unchanged) |
| Raise `max_filters` to `120`, create 120 draft filters | all 120 created (old ceiling was 100) |
| Create the 121st filter at limit `120` | 400 — the limit still bites, at the configured value |

### Artifacts Affected

- `wazuh-indexer-content-manager` plugin
- Documentation

### Configuration Changes

| Setting | Before | After |
| --- | --- | --- |
| `plugins.content_manager.max_integrations` | Integer, default `100`, range `0`–`100`, dynamic | Integer, default `100`, minimum `0`, **no upper bound**, dynamic |
| `plugins.content_manager.max_decoders` | Integer, default `200`, range `0`–`200`, dynamic | Integer, default `200`, minimum `0`, **no upper bound**, dynamic |
| `plugins.content_manager.max_rules` | Integer, default `200`, range `0`–`200`, dynamic | Integer, default `200`, minimum `0`, **no upper bound**, dynamic |
| `plugins.content_manager.max_kvdbs` | Integer, default `100`, range `0`–`100`, dynamic | Integer, default `100`, minimum `0`, **no upper bound**, dynamic |
| `plugins.content_manager.max_filters` | Integer, default `100`, range `0`–`100`, dynamic | Integer, default `100`, minimum `0`, **no upper bound**, dynamic |

- No new settings, no renamed settings, no removed settings.
- Default values unchanged, minimums unchanged (`0`), scope and dynamism unchanged.

### Documentation Updates

| File | Settings updated |
| --- | --- |
| `docs/ref/modules/content-manager/configuration.md` | `max_integrations`, `max_decoders`, `max_rules`, `max_kvdbs`, `max_filters` |
| `docs/ref/modules/notifications/configuration.md` | `max_notification_configs`, `max_notification_groups`, `max_notification_senders`, `max_active_responses` |
| `docs/ref/modules/security-analytics/configuration.md` | `max_detectors`, `max_rules_per_detector` |
| `docs/ref/modules/security-analytics/index.md` | "Detector constraints" no longer refers the reader to the settings' "full ranges" |
| `docs/ref/modules/alerting/configuration.md` | `max_monitors` |
| `docs/ref/modules/reporting/index.md` | `max_report_definitions` |

### Tests Introduced

Five new cases in `PluginSettingsTests.java`, each covering all five settings:

| Test | Scope |
| --- | --- |
| `testResourceLimitDefaults` | Guards the five defaults against accidental drift now that they are literals rather than aliases of the deleted maximums. Asserts through the `PluginSettings` getters, so it also covers the singleton's initialization path. |
| `testResourceLimitsHaveNoUpperBound` | The regression test for this change: asserts `100000` parses for all five settings. Every one would have thrown before. |
| `testResourceLimitsAcceptIntegerMaxValue` | Upper extreme — confirms nothing else clamps the value on the way through. |
| `testResourceLimitsAcceptZero` | Confirms `0` is still valid (creation blocked), i.e. the floors were not moved while removing the ceilings. |
| `testResourceLimitsRejectNegativeValues` | Confirms `-1` still throws `IllegalArgumentException`, asserted directly against the `Setting` objects. |

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...