### PR TITLE
Increase content manager's default backoff time waiting for the setup plugin to be ready

### DIFF
--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v3
         id: verify-changelog
         with:
-          skipLabels: "autocut, skip-changelog"
+          skipLabels: "no-changelog"
           changeLogPath: "CHANGELOG.md"

--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -5,6 +5,8 @@ The Content Manager plugin is configured through settings in `opensearch.yml`. A
 
 - **`plugins.content_manager.cti.api`** (String, default `https://api.pre.cloud.wazuh.com/api/v1`) — base URL for the Wazuh CTI API.
 - **`plugins.content_manager.catalog.sync_interval`** (Integer, default `60`, range 10–1440) — sync interval in minutes.
+- **`plugins.content_manager.setup_wait.max_retries`** (Integer, default `4`, range 0–10) — number of retries the catalog sync job performs while waiting for the Setup plugin to report readiness on startup, before giving up until the next scheduled sync.
+- **`plugins.content_manager.setup_wait.backoff_base_seconds`** (Integer, default `20`, range 1–120) — base delay, in seconds, for the exponential backoff between those retries (delay for retry `n` is `base * 2^n`; with the defaults, 20s/40s/80s/160s = 300s / 5 min worst case).
 - **`plugins.content_manager.max_items_per_bulk`** (Integer, default `999`, range 10–999) — maximum documents per bulk indexing request.
 - **`plugins.content_manager.max_concurrent_bulks`** (Integer, default `5`, range 1–5) — maximum concurrent bulk operations.
 - **`plugins.content_manager.max_bulk_bytes`** (Long, default `5242880` / 5 MB, range 1048576–104857600 / 1–100 MB) — maximum request body size, in bytes, for a single bulk indexing request.
@@ -55,6 +57,20 @@ The plugin checks for new content every 60 minutes by default, but this can be c
 # opensearch.yml
 plugins.content_manager.catalog.sync_interval: 1440
 ```
+
+### Setup readiness wait (startup race)
+
+On node startup, the catalog sync job waits for the Setup plugin to finish creating its indices (signaled by the `.wazuh-setup-status` marker document) before it runs. If Setup has not finished within that wait, the sync is skipped for that run and deferred to the next scheduled run (`plugins.content_manager.catalog.sync_interval` minutes later, an hour by default) — on a slow-starting node (e.g. cluster still recovering shards), this can leave `.wazuh-cti-consumers` and the CTI content indices empty for up to that long.
+
+The wait uses exponential backoff, controlled by `plugins.content_manager.setup_wait.max_retries` and `plugins.content_manager.setup_wait.backoff_base_seconds`. With the defaults (4 retries, 20s base), the schedule is 20s, 40s, 80s, 160s — 300s (5 min) total before giving up. Increase these on environments where Setup is known to take longer to initialize:
+
+```yaml
+# opensearch.yml
+plugins.content_manager.setup_wait.max_retries: 4
+plugins.content_manager.setup_wait.backoff_base_seconds: 30
+```
+
+The example above raises the total worst-case wait to 30+60+120+240 = 450s (7.5 min).
 
 #### Custom CTI API endpoint
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -909,7 +909,9 @@ public class ContentManagerPlugin extends Plugin
                 PluginSettings.MAX_RULES,
                 PluginSettings.MAX_KVDBS,
                 PluginSettings.MAX_FILTERS,
-                PluginSettings.WAZUH_UID);
+                PluginSettings.WAZUH_UID,
+                PluginSettings.SETUP_WAIT_MAX_RETRIES,
+                PluginSettings.SETUP_WAIT_BACKOFF_BASE_SECONDS);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
@@ -40,6 +40,7 @@ import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.JobExecutor;
+import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
 /**
@@ -253,15 +254,17 @@ public class CatalogSyncJob implements JobExecutor {
      * Blocks until the Setup plugin reports its initialization as {@value
      * Constants#SETUP_STATUS_READY} via the {@value Constants#SETUP_STATUS_DOC_ID} marker document in
      * the {@value Constants#INDEX_SETUP_STATUS} index. Retries up to {@link
-     * Constants#MAX_SETUP_WAIT_RETRIES} times with exponential backoff (20s, 40s, 80s, 160s) before
-     * giving up. If the marker already reports {@value Constants#SETUP_STATUS_FAILED}, returns
-     * immediately without retrying — a failed Setup boot will not fix itself within the same boot.
-     * This method blocks the calling generic-pool thread for up to 300 seconds (5 min) in the worst
-     * case.
+     * PluginSettings#SETUP_WAIT_MAX_RETRIES} times with exponential backoff starting at {@link
+     * PluginSettings#SETUP_WAIT_BACKOFF_BASE_SECONDS} before giving up (defaults: 20s, 40s, 80s, 160s
+     * = 300s / 5 min worst case). If the marker already reports {@value
+     * Constants#SETUP_STATUS_FAILED}, returns immediately without retrying — a failed Setup boot will
+     * not fix itself within the same boot.
      *
      * @return true if the Setup plugin reported readiness, false otherwise.
      */
     boolean waitForSetup() {
+        int maxRetries = PluginSettings.getInstance().getSetupWaitMaxRetries();
+        int backoffBaseSeconds = PluginSettings.getInstance().getSetupWaitBackoffBaseSeconds();
         for (int attempt = 0; ; attempt++) {
             SetupStatus status = this.readSetupStatus();
             if (status == SetupStatus.READY) {
@@ -272,22 +275,33 @@ public class CatalogSyncJob implements JobExecutor {
                         "Setup plugin initialization failed. Skipping catalog synchronization until Setup succeeds (typically after a node restart.");
                 return false;
             }
-            if (attempt >= Constants.MAX_SETUP_WAIT_RETRIES) {
+            if (attempt >= maxRetries) {
                 return false;
             }
-            long delaySeconds = Constants.SETUP_WAIT_BACKOFF_BASE_SECONDS * (1L << attempt);
+            long delaySeconds = backoffBaseSeconds * (1L << attempt);
             log.info(
                     "Setup plugin initialization not complete yet. Retrying in {}s (attempt {}/{}).",
                     delaySeconds,
                     attempt + 1,
-                    Constants.MAX_SETUP_WAIT_RETRIES);
+                    maxRetries);
             try {
-                TimeUnit.SECONDS.sleep(delaySeconds);
+                this.sleepSeconds(delaySeconds);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return false;
             }
         }
+    }
+
+    /**
+     * Sleeps for the given number of seconds. Extracted from {@link #waitForSetup()} so tests can
+     * stub it out and exercise the full retry loop without actually blocking for its real duration.
+     *
+     * @param seconds The number of seconds to sleep.
+     * @throws InterruptedException if the thread is interrupted while sleeping.
+     */
+    void sleepSeconds(long seconds) throws InterruptedException {
+        TimeUnit.SECONDS.sleep(seconds);
     }
 
     /** The three states the Setup plugin's readiness marker can report. */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
@@ -253,10 +253,11 @@ public class CatalogSyncJob implements JobExecutor {
      * Blocks until the Setup plugin reports its initialization as {@value
      * Constants#SETUP_STATUS_READY} via the {@value Constants#SETUP_STATUS_DOC_ID} marker document in
      * the {@value Constants#INDEX_SETUP_STATUS} index. Retries up to {@link
-     * Constants#MAX_SETUP_WAIT_RETRIES} times with exponential backoff (5s, 10s, 20s) before giving
-     * up. If the marker already reports {@value Constants#SETUP_STATUS_FAILED}, returns immediately
-     * without retrying — a failed Setup boot will not fix itself within the same boot. This method
-     * blocks the calling generic-pool thread for up to 35 seconds in the worst case.
+     * Constants#MAX_SETUP_WAIT_RETRIES} times with exponential backoff (20s, 40s, 80s, 160s) before
+     * giving up. If the marker already reports {@value Constants#SETUP_STATUS_FAILED}, returns
+     * immediately without retrying — a failed Setup boot will not fix itself within the same boot.
+     * This method blocks the calling generic-pool thread for up to 300 seconds (5 min) in the worst
+     * case.
      *
      * @return true if the Setup plugin reported readiness, false otherwise.
      */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -82,6 +82,12 @@ public class PluginSettings {
     private static final long DEFAULT_PIT_KEEPALIVE = 120;
     private static final boolean DEFAULT_ENGINE_MOCK_ENABLED = false;
 
+    // Defaults for the Setup-plugin readiness wait in CatalogSyncJob#waitForSetup(). Worst-case
+    // total wait before giving up is baseSeconds * (2^maxRetries - 1); the defaults (20s, 4 retries)
+    // give 20+40+80+160 = 300s (5 min).
+    private static final int DEFAULT_SETUP_WAIT_MAX_RETRIES = 4;
+    private static final int DEFAULT_SETUP_WAIT_BACKOFF_BASE_SECONDS = 20;
+
     private static final Pattern CATALOG_URI_PATTERN =
             Pattern.compile(".*/catalog/contexts/([^/]+)/consumers/([^/?#]+)(?:[/?#].*)?$");
 
@@ -218,6 +224,32 @@ public class PluginSettings {
                     Setting.Property.NodeScope,
                     Setting.Property.Filtered);
 
+    /**
+     * Maximum number of retries {@code CatalogSyncJob#waitForSetup()} performs while waiting for the
+     * Setup plugin to report readiness, before giving up and deferring to the next scheduled sync.
+     */
+    public static final Setting<Integer> SETUP_WAIT_MAX_RETRIES =
+            Setting.intSetting(
+                    "plugins.content_manager.setup_wait.max_retries",
+                    DEFAULT_SETUP_WAIT_MAX_RETRIES,
+                    0,
+                    10,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Filtered);
+
+    /**
+     * Base delay, in seconds, for the exponential backoff {@code CatalogSyncJob#waitForSetup()} uses
+     * between retries (delay for retry {@code n} is {@code base * 2^n}).
+     */
+    public static final Setting<Integer> SETUP_WAIT_BACKOFF_BASE_SECONDS =
+            Setting.intSetting(
+                    "plugins.content_manager.setup_wait.backoff_base_seconds",
+                    DEFAULT_SETUP_WAIT_BACKOFF_BASE_SECONDS,
+                    1,
+                    120,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Filtered);
+
     /** Setting to enable mock engine service for testing environments. */
     public static final Setting<Boolean> ENGINE_MOCK_ENABLED =
             Setting.boolSetting(
@@ -344,6 +376,8 @@ public class PluginSettings {
     private final String catalogVulnerabilities;
     private final long pitKeepalive;
     private final boolean engineMockEnabled;
+    private final int setupWaitMaxRetries;
+    private final int setupWaitBackoffBaseSeconds;
     private final boolean createDetectors;
     private final boolean updateOnDemand;
     private final boolean policyUpdateEnabled;
@@ -376,6 +410,8 @@ public class PluginSettings {
         this.catalogVulnerabilities = CATALOG_VULNERABILITIES.get(settings);
         this.pitKeepalive = PIT_KEEPALIVE.get(settings);
         this.engineMockEnabled = ENGINE_MOCK_ENABLED.get(settings);
+        this.setupWaitMaxRetries = SETUP_WAIT_MAX_RETRIES.get(settings);
+        this.setupWaitBackoffBaseSeconds = SETUP_WAIT_BACKOFF_BASE_SECONDS.get(settings);
         this.createDetectors = CREATE_DETECTORS.get(settings);
         this.updateOnDemand = UPDATE_ON_DEMAND.get(settings);
         this.policyUpdateEnabled = POLICY_UPDATE_ENABLED.get(settings);
@@ -721,6 +757,26 @@ public class PluginSettings {
         return this.engineMockEnabled;
     }
 
+    /**
+     * Retrieves the maximum number of retries {@code CatalogSyncJob#waitForSetup()} performs while
+     * waiting for the Setup plugin to report readiness.
+     *
+     * @return the maximum number of retries.
+     */
+    public int getSetupWaitMaxRetries() {
+        return this.setupWaitMaxRetries;
+    }
+
+    /**
+     * Retrieves the base delay, in seconds, for the exponential backoff {@code
+     * CatalogSyncJob#waitForSetup()} uses between retries.
+     *
+     * @return the base backoff delay in seconds.
+     */
+    public int getSetupWaitBackoffBaseSeconds() {
+        return this.setupWaitBackoffBaseSeconds;
+    }
+
     @Override
     public String toString() {
         return "{"
@@ -756,6 +812,12 @@ public class PluginSettings {
                 + "', "
                 + "catalogVulnerabilities='"
                 + this.catalogVulnerabilities
-                + "'}";
+                + "', "
+                + "setupWaitMaxRetries="
+                + this.setupWaitMaxRetries
+                + ", "
+                + "setupWaitBackoffBaseSeconds="
+                + this.setupWaitBackoffBaseSeconds
+                + "}";
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -782,8 +782,11 @@ public class Constants {
     public static final String SETUP_STATUS_DOC_ID = "setup-status";
     public static final String SETUP_STATUS_READY = "ready";
     public static final String SETUP_STATUS_FAILED = "failed";
-    public static final int MAX_SETUP_WAIT_RETRIES = 3;
-    public static final int SETUP_WAIT_BACKOFF_BASE_SECONDS = 5;
+    // Total worst-case wait before giving up is BASE * (2^RETRIES - 1) seconds: 20s, 40s, 80s, 160s =
+    // 300s (5 min). Keep this comfortably above the slowest observed Setup boot time, since giving up
+    // means waiting for the next scheduled run (an hour, by default).
+    public static final int MAX_SETUP_WAIT_RETRIES = 4;
+    public static final int SETUP_WAIT_BACKOFF_BASE_SECONDS = 20;
 
     // Resource-creation limit locks: serialize the count-then-create sequence used to enforce
     // plugins.content_manager.max_{integrations,decoders,rules,kvdbs,filters}, keyed per

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -782,11 +782,8 @@ public class Constants {
     public static final String SETUP_STATUS_DOC_ID = "setup-status";
     public static final String SETUP_STATUS_READY = "ready";
     public static final String SETUP_STATUS_FAILED = "failed";
-    // Total worst-case wait before giving up is BASE * (2^RETRIES - 1) seconds: 20s, 40s, 80s, 160s =
-    // 300s (5 min). Keep this comfortably above the slowest observed Setup boot time, since giving up
-    // means waiting for the next scheduled run (an hour, by default).
-    public static final int MAX_SETUP_WAIT_RETRIES = 4;
-    public static final int SETUP_WAIT_BACKOFF_BASE_SECONDS = 20;
+    // The retry count and backoff base for waitForSetup() are configurable settings; see
+    // PluginSettings#SETUP_WAIT_MAX_RETRIES and PluginSettings#SETUP_WAIT_BACKOFF_BASE_SECONDS.
 
     // Resource-creation limit locks: serialize the count-then-create sequence used to enforce
     // plugins.content_manager.max_{integrations,decoders,rules,kvdbs,filters}, keyed per

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
@@ -38,11 +38,15 @@ import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -149,6 +153,39 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
                 "waitForSetup() must not sleep through the backoff when the marker already says"
                         + " failed",
                 elapsedMillis < 1000);
+    }
+
+    /**
+     * When the Setup marker never becomes ready, {@code waitForSetup()} must exhaust the full,
+     * documented backoff schedule (20s, 40s, 80s, 160s = 300s / 5 min worst case) before giving up.
+     * {@code sleepSeconds} is stubbed out so the test exercises the real retry loop and logging
+     * without actually blocking for five minutes.
+     */
+    public void testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp() {
+        when(this.getResponse.isExists()).thenReturn(false);
+
+        CatalogSyncJob job = spy(this.catalogSyncJob);
+        try {
+            doNothing().when(job).sleepSeconds(anyLong());
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+
+        boolean result = job.waitForSetup();
+
+        Assert.assertFalse("Setup never became ready, so waitForSetup() must give up", result);
+        verify(this.getRequestBuilder, times(PluginSettings.getInstance().getSetupWaitMaxRetries() + 1))
+                .get();
+
+        InOrder inOrder = Mockito.inOrder(job);
+        try {
+            inOrder.verify(job).sleepSeconds(20L);
+            inOrder.verify(job).sleepSeconds(40L);
+            inOrder.verify(job).sleepSeconds(80L);
+            inOrder.verify(job).sleepSeconds(160L);
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /** When setup never completes, the synchronization pass is skipped entirely. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java
@@ -146,6 +146,57 @@ public class PluginSettingsTests extends OpenSearchTestCase {
         Assert.assertThrows(IllegalArgumentException.class, () -> PluginSettings.getInstance(settings));
     }
 
+    /** Tests that the Setup-wait backoff settings fall back to their documented defaults. */
+    public void testSetupWaitBackoffDefaults() {
+        PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);
+        Assert.assertEquals(4, pluginSettings.getSetupWaitMaxRetries());
+        Assert.assertEquals(20, pluginSettings.getSetupWaitBackoffBaseSeconds());
+    }
+
+    /** Tests that custom Setup-wait backoff values within bounds are honored. */
+    public void testSetupWaitBackoffCustom() {
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.setup_wait.max_retries", 6)
+                        .put("plugins.content_manager.setup_wait.backoff_base_seconds", 45)
+                        .build();
+        PluginSettings pluginSettings = PluginSettings.getInstance(settings);
+        Assert.assertEquals(6, pluginSettings.getSetupWaitMaxRetries());
+        Assert.assertEquals(45, pluginSettings.getSetupWaitBackoffBaseSeconds());
+    }
+
+    /** Tests that a negative setup_wait.max_retries is rejected. */
+    public void testSetupWaitMaxRetriesBelowMinThrows() {
+        Settings settings =
+                Settings.builder().put("plugins.content_manager.setup_wait.max_retries", -1).build();
+        Assert.assertThrows(IllegalArgumentException.class, () -> PluginSettings.getInstance(settings));
+    }
+
+    /** Tests that a setup_wait.max_retries above the documented ceiling is rejected. */
+    public void testSetupWaitMaxRetriesAboveMaxThrows() {
+        Settings settings =
+                Settings.builder().put("plugins.content_manager.setup_wait.max_retries", 11).build();
+        Assert.assertThrows(IllegalArgumentException.class, () -> PluginSettings.getInstance(settings));
+    }
+
+    /** Tests that a setup_wait.backoff_base_seconds below the 1s floor is rejected. */
+    public void testSetupWaitBackoffBaseSecondsBelowMinThrows() {
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.setup_wait.backoff_base_seconds", 0)
+                        .build();
+        Assert.assertThrows(IllegalArgumentException.class, () -> PluginSettings.getInstance(settings));
+    }
+
+    /** Tests that a setup_wait.backoff_base_seconds above the documented ceiling is rejected. */
+    public void testSetupWaitBackoffBaseSecondsAboveMaxThrows() {
+        Settings settings =
+                Settings.builder()
+                        .put("plugins.content_manager.setup_wait.backoff_base_seconds", 121)
+                        .build();
+        Assert.assertThrows(IllegalArgumentException.class, () -> PluginSettings.getInstance(settings));
+    }
+
     /** Tests that the resource limit settings fall back to their documented defaults. */
     public void testResourceLimitDefaults() {
         PluginSettings pluginSettings = PluginSettings.getInstance(Settings.EMPTY);


### PR DESCRIPTION
## Description

Increase content manager's default backoff time waiting for the setup plugin to be ready.

Worst-case scenario, the content manager's initialization process waits for 5 minutes before giving up. In such case, it will be retried on the next scheduled content update (every 1h by default).

## Proposed Changes

Closes https://github.com/wazuh/wazuh-indexer/issues/1797

### Results and Evidence

```
Starting Gradle Daemon...
Gradle Daemon started in 3 s 644 ms
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 9.5.1
  OS Info               : Linux 7.0.0-28-generic (amd64)
  JDK Version           : 25 (Eclipse Temurin JDK 25 (25.0.2+10-LTS))
  JAVA_HOME             : /home/alex/.jdks/temurin-25.0.2
  Random Testing Seed   : 355C74B7EB7E0392
  Crypto Standard       : any-supported
=======================================
> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava UP-TO-DATE
> Task :copyPluginPropertiesTemplate UP-TO-DATE
> Task :pluginProperties UP-TO-DATE
> Task :prepareJavaAgent UP-TO-DATE
> Task :copyYamlTestsTask NO-SOURCE
> Task :copyRestApiSpecsTask NO-SOURCE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
> Task :test
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
WARNING: Please consider reporting this to the maintainers of class net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.jna.Native in an unnamed module (file:/home/alex/.gradle/caches/modules-2/files-2.1/net.java.dev.jna/jna/5.16.0/ebea09f91dc9f7048099f963fb8d6f919f0a4d9c/jna-5.16.0.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
Aug 06, 2026 3:30:40 PM org.opensearch.javaagent.bootstrap.AgentPolicy setPolicy
INFO: Policy attached successfully: org.opensearch.bootstrap.BootstrapForTesting$1@59d3c0cc
Aug 06, 2026 3:30:41 PM org.apache.lucene.internal.vectorization.VectorizationProvider lookup
WARNING: Java vector incubator module is not readable. For optimal vector performance, pass '--add-modules jdk.incubator.vector' to enable Vector API.
[2026-08-06T15:30:42,301][INFO ][c.w.c.j.j.CatalogSyncJobTests] [testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp] before test
[2026-08-06T15:30:43,646][INFO ][c.w.c.j.j.CatalogSyncJob ] [testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp] Setup plugin initialization not complete yet. Retrying in 20s (attempt 1/4).
[2026-08-06T15:30:43,648][INFO ][c.w.c.j.j.CatalogSyncJob ] [testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp] Setup plugin initialization not complete yet. Retrying in 40s (attempt 2/4).
[2026-08-06T15:30:43,650][INFO ][c.w.c.j.j.CatalogSyncJob ] [testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp] Setup plugin initialization not complete yet. Retrying in 80s (attempt 3/4).
[2026-08-06T15:30:43,651][INFO ][c.w.c.j.j.CatalogSyncJob ] [testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp] Setup plugin initialization not complete yet. Retrying in 160s (attempt 4/4).
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [jar:file:/home/alex/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-slf4j-impl/2.25.4/7c27f97ecedecf58341d4d4467bc3a58fbad73f/log4j-slf4j-impl-2.25.4.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
[2026-08-06T15:30:43,825][INFO ][c.w.c.j.j.CatalogSyncJobTests] [testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp] after test
BUILD SUCCESSFUL in 30s
8 actionable tasks: 1 executed, 7 up-to-date
15:30:44: Execution finished ':test --tests "com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJobTests.testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp"'.
```

### Artifacts Affected

None

### Configuration Changes

None

### Documentation Updates

New settings documented.

> modified:   docs/ref/modules/content-manager/configuration.md

### Tests Introduced

New unit test to ensure the backoff and retries are applied correctly.

> modified:   plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java

Extended unit tests to cover the new settings.

> modified:   plugins/content-manager/src/test/java/com/wazuh/contentmanager/settings/PluginSettingsTests.java 


## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
