### PR TITLE
Fix findings dashboards failing with "too many docvalue_fields"

### DIFF
--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -8,6 +8,7 @@
     "settings": {
       "index": {
         "codec": "zstd",
+        "max_docvalue_fields_search": 200,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/wcs/generator/count_and_update_total_fields.sh
+++ b/wcs/generator/count_and_update_total_fields.sh
@@ -4,6 +4,8 @@
 # This script analyzes OpenSearch index templates to:
 # - Count total fields and update mapping.total_fields.limit
 # - Count nested fields and update mapping.nested_fields.limit
+# - Count date fields and update index.max_docvalue_fields_search (the dashboard requests one
+#   docvalue_field per date field of the index pattern, so this limit must exceed the date count)
 # Usage:
 #   ./count_and_update_total_fields.sh <module|all> [--apply]
 # If --apply is not passed the script runs in dry-run mode and prints proposed values.
@@ -89,6 +91,9 @@ process_module() {
   # jq filter to count nested fields
   JQ_NESTED_FILTER='def count_nested: [ .. | objects | select(.type == "nested") ] | length; .template.mappings.properties | count_nested'
 
+  # jq filter to count date fields (includes multi-fields, which the dashboard also maps)
+  JQ_DATE_FILTER='[ .template.mappings.properties | .. | objects | select(.type == "date" or .type == "date_nanos") ] | length'
+
   TOTAL_FIELDS=$(jq -r "$JQ_FILTER" "$REPO_ROOT/$INDEX_TEMPLATE_PATH" 2>/tmp/jq_error.log) || {
     echo "Error: Could not parse JSON or find .template.mappings.properties in $INDEX_TEMPLATE_PATH" >&2
     cat /tmp/jq_error.log >&2 || true
@@ -105,6 +110,13 @@ process_module() {
   }
   rm -f /tmp/jq_nested_error.log
 
+  DATE_FIELDS=$(jq -r "$JQ_DATE_FILTER" "$REPO_ROOT/$INDEX_TEMPLATE_PATH" 2>/tmp/jq_date_error.log) || {
+    echo "Error: Could not count date fields in $INDEX_TEMPLATE_PATH" >&2
+    cat /tmp/jq_date_error.log >&2 || true
+    rm -f /tmp/jq_date_error.log
+    return 1
+  }
+  rm -f /tmp/jq_date_error.log
 
   # compute next multiple of 500 for total fields
   PROPOSED_TOTAL=$((((TOTAL_FIELDS + 499) / 500) * 500))
@@ -121,6 +133,10 @@ process_module() {
     PROPOSED_NESTED=50
   fi
 
+  # compute strictly-next multiple of 100 for docvalue fields, so there is always headroom
+  # for new date fields (a count equal to the limit is legal but leaves no margin)
+  PROPOSED_DOCVALUE=$(((DATE_FIELDS / 100 + 1) * 100))
+
   cat <<EOF
 Module: $MODULE
 Index template: $INDEX_TEMPLATE_PATH
@@ -128,12 +144,39 @@ Total fields: $TOTAL_FIELDS
 Proposed mapping.total_fields.limit: $PROPOSED_TOTAL
 Nested fields: $NESTED_FIELDS
 Proposed mapping.nested_fields.limit: $PROPOSED_NESTED
+Date fields: $DATE_FIELDS
+Proposed index.max_docvalue_fields_search: $PROPOSED_DOCVALUE
 EOF
 
   if ! $APPLY; then
     echo "Dry-run mode. To apply the change add --apply" >&2
     return 0
   fi
+
+  # Build the jq clause that raises index.max_docvalue_fields_search, or nothing if the file
+  # already allows at least the proposed value. The limit is never lowered, since an explicit
+  # higher value may have been set on purpose.
+  docvalue_clause() {
+    local file="$1"
+    local prefix="$2" # ".template.settings" or ".settings"
+    local current flat_key
+
+    flat_key=false
+    if jq -e "${prefix}[\"index.max_docvalue_fields_search\"]" "$file" >/dev/null 2>&1; then
+      flat_key=true
+    fi
+
+    current=$(jq -r "${prefix}[\"index.max_docvalue_fields_search\"] // ${prefix}.index[\"max_docvalue_fields_search\"] // empty" "$file" 2>/dev/null || true)
+    if [[ -n "$current" && $current -ge $PROPOSED_DOCVALUE ]]; then
+      return 0
+    fi
+
+    if $flat_key; then
+      echo "${prefix}[\"index.max_docvalue_fields_search\"] = $PROPOSED_DOCVALUE"
+    else
+      echo "${prefix}.index[\"max_docvalue_fields_search\"] = $PROPOSED_DOCVALUE"
+    fi
+  }
 
   # Update JSON files in place using jq
   update_file() {
@@ -144,6 +187,7 @@ EOF
     fi
 
     local updated=false
+    local dv_clause=""
 
     # Handle .template.settings structure
     if jq -e '.template? and .template.settings?' "$REPO_ROOT/$file" >/dev/null 2>&1; then
@@ -155,13 +199,17 @@ EOF
       if [[ $NESTED_FIELDS -gt 0 && $PROPOSED_NESTED -gt 50 ]]; then
         jq_update_cmd="$jq_update_cmd | .template.settings[\"mapping.nested_fields.limit\"] = $PROPOSED_NESTED"
       fi
+      dv_clause=$(docvalue_clause "$REPO_ROOT/$file" ".template.settings")
+      if [[ -n "$dv_clause" ]]; then
+        jq_update_cmd="$jq_update_cmd | $dv_clause"
+      fi
 
       jq "$jq_update_cmd" "$REPO_ROOT/$file" >"$tmpfile"
       if [[ -n "$last_hex" && "$last_hex" != "0a" ]]; then
         perl -0777 -pe 's/\n\z//' "$tmpfile" >"${tmpfile}.fix" && mv "${tmpfile}.fix" "$tmpfile"
       fi
       mv "$tmpfile" "$REPO_ROOT/$file"
-      echo "Updated $file -> total_fields: $PROPOSED_TOTAL, nested_fields: $PROPOSED_NESTED"
+      echo "Updated $file -> total_fields: $PROPOSED_TOTAL, nested_fields: $PROPOSED_NESTED${dv_clause:+, max_docvalue_fields_search: $PROPOSED_DOCVALUE}"
       updated=true
     # Handle .settings structure
     elif jq -e '.settings?' "$REPO_ROOT/$file" >/dev/null 2>&1; then
@@ -173,13 +221,17 @@ EOF
       if [[ $NESTED_FIELDS -gt 0 && $PROPOSED_NESTED -gt 50 ]]; then
         jq_update_cmd="$jq_update_cmd | .settings[\"mapping.nested_fields.limit\"] = $PROPOSED_NESTED"
       fi
+      dv_clause=$(docvalue_clause "$REPO_ROOT/$file" ".settings")
+      if [[ -n "$dv_clause" ]]; then
+        jq_update_cmd="$jq_update_cmd | $dv_clause"
+      fi
 
       jq "$jq_update_cmd" "$REPO_ROOT/$file" >"$tmpfile"
       if [[ -n "$last_hex" && "$last_hex" != "0a" ]]; then
         perl -0777 -pe 's/\n\z//' "$tmpfile" >"${tmpfile}.fix" && mv "${tmpfile}.fix" "$tmpfile"
       fi
       mv "$tmpfile" "$REPO_ROOT/$file"
-      echo "Updated $file -> total_fields: $PROPOSED_TOTAL, nested_fields: $PROPOSED_NESTED"
+      echo "Updated $file -> total_fields: $PROPOSED_TOTAL, nested_fields: $PROPOSED_NESTED${dv_clause:+, max_docvalue_fields_search: $PROPOSED_DOCVALUE}"
       updated=true
     fi
 

--- a/wcs/stateless/events/findings/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/findings/fields/template-settings-legacy.json
@@ -21,7 +21,8 @@
         "wazuh.cluster.name",
         "wazuh.cluster.node",
         "wazuh.schema.version"
-      ]
+      ],
+      "max_docvalue_fields_search": 200
     },
     "mapping.nested_fields.limit": 50
   }

--- a/wcs/stateless/events/findings/fields/template-settings.json
+++ b/wcs/stateless/events/findings/fields/template-settings.json
@@ -23,7 +23,8 @@
           "wazuh.cluster.name",
           "wazuh.cluster.node",
           "wazuh.schema.version"
-        ]
+        ],
+        "max_docvalue_fields_search": 200
       },
       "mapping.nested_fields.limit": 50
     }


### PR DESCRIPTION
## Description

A fresh 5.0.0 AIO install shows `search_phase_execution_exception` on every visualization backed by the findings index
The root cause is on the indexer side, in the `wazuh-findings-v5` index template.

The dashboard requests one `docvalue_field` per **date** field of the index pattern — it needs the
normalized, timezone-format table value from doc values rather than the raw `_source` representation.

Closes https://github.com/wazuh/wazuh-indexer/issues/1800

## Proposed Changes

- Set `index.max_docvalue_fields_search: 200` on the findings index template,
- Automate the limit in `wcs/generator/count_and_update_total_fields.sh`

### Results and Evidence

Before the changes

<img width="2473" height="1282" alt="Image" src="https://github.com/user-attachments/assets/41f68318-68c5-4ab4-8f84-4028175501ea" />

After the changes

<img width="2473" height="1282" alt="Image" src="https://github.com/user-attachments/assets/9555d03b-b270-4bc7-b938-7c1c6cae1c08" />

### Artifacts Affected

- Setup plugin
- WCS

### Configuration Changes

`index.max_docvalue_fields_search: 200` is added to the `wazuh-findings-v5` index template.


### Documentation Updates

NA

### Tests Introduced

NA 

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
