### PR TITLE
Fix setup status always marked as ready after initialization failure

### DIFF
--- a/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
@@ -229,14 +229,11 @@ public class SetupPlugin extends Plugin implements ClusterPlugin, ActionPlugin {
 
                                             try {
                                                 SetupPlugin.this.indices.forEach(Index::initialize);
+                                                SetupPlugin.this.setupStatusIndex.markReady();
                                             } catch (Exception e) {
                                                 log.error("Setup initialization failed: {}", e.getMessage(), e);
                                                 SetupPlugin.this.setupStatusIndex.markFailed();
                                             }
-
-                                            // Signal that all indices are ready. Consumers of this
-                                            // marker may now start working with them.
-                                            SetupPlugin.this.setupStatusIndex.markReady();
                                         });
                     }
 


### PR DESCRIPTION
## Description

`SetupPlugin.onNodeStarted()` calls `markReady()` unconditionally after the try-catch block that handles index initialization failures. When `Index::initialize` throws, the catch block calls `markFailed()`, but execution falls through to `markReady()` on line 239, which immediately overwrites the failed status with "ready".

This causes `CatalogSyncJob.waitForSetup()` to always see a "ready" status and proceed even when setup initialization has failed, making its "failed" exit branch dead code.

## Proposed Changes

- Moved `setupStatusIndex.markReady()` inside the try block so it only executes when all indices initialize successfully.

### Results and Evidence

Before (simplified):
```java
try {
    indices.forEach(Index::initialize);
} catch (Exception e) {
    log.error("Setup initialization failed: {}", e.getMessage(), e);
    setupStatusIndex.markFailed();  // overwritten below
}
setupStatusIndex.markReady();  // always runs
```

After:
```java
try {
    indices.forEach(Index::initialize);
    setupStatusIndex.markReady();   // only on success
} catch (Exception e) {
    log.error("Setup initialization failed: {}", e.getMessage(), e);
    setupStatusIndex.markFailed();  // now persists
}
```

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. The existing test suite passes. The bug is in runtime control flow that is not covered by unit tests.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
