### PR TITLE
Fix exponential backoff error

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -312,37 +312,36 @@ public class ApiClient implements AutoCloseable {
     /**
      * Computes how long to wait before the next 429 retry, in seconds.
      *
-     * <p>Prefers the server's {@code Retry-After} header, parsed either as delta-seconds or an
-     * RFC-1123 HTTP-date. When the header is absent, unparseable, or non-positive, falls back to an
-     * exponential backoff of {@code base * 2^attempt}. The total number of retries is bounded by
-     * {@code max_retries}.
+     * <p>The wait is the greater of the exponential backoff floor ({@code base * 2^attempt}) and the
+     * server's {@code Retry-After} header (parsed as delta-seconds or an RFC-1123 HTTP-date). The
+     * backoff floor is always enforced, so a missing, zero, or too-small {@code Retry-After} cannot
+     * collapse the wait to near-zero and burn every retry in milliseconds; a {@code Retry-After} that
+     * asks for longer than the floor is honored. The total number of retries is bounded by {@code
+     * max_retries}.
      *
      * @param response the 429 response.
-     * @param attempt the zero-based retry attempt index (used for the backoff fallback).
+     * @param attempt the zero-based retry attempt index (drives the backoff floor).
      * @return the wait in seconds, never negative.
      */
     long computeRetryDelaySeconds(SimpleHttpResponse response, int attempt) {
         PluginSettings settings = PluginSettings.getInstance();
 
-        long delay = -1;
-        Header retryAfter = response.getFirstHeader(HttpHeaders.RETRY_AFTER);
-        if (retryAfter != null && retryAfter.getValue() != null) {
-            String value = retryAfter.getValue().trim();
+        long backoff = (long) settings.getClientRetryBackoffBaseSeconds() * (1L << attempt);
+
+        long retryAfter = -1;
+        Header header = response.getFirstHeader(HttpHeaders.RETRY_AFTER);
+        if (header != null && header.getValue() != null) {
+            String value = header.getValue().trim();
             try {
-                delay = Long.parseLong(value);
+                retryAfter = Long.parseLong(value);
             } catch (NumberFormatException e) {
                 Instant when = DateUtils.parseStandardDate(value);
                 if (when != null) {
-                    delay = when.getEpochSecond() - Instant.now().getEpochSecond();
+                    retryAfter = when.getEpochSecond() - Instant.now().getEpochSecond();
                 }
             }
         }
 
-        if (delay < 0) {
-            // No usable Retry-After: exponential backoff fallback (base * 2^attempt).
-            delay = (long) settings.getClientRetryBackoffBaseSeconds() * (1L << attempt);
-        }
-
-        return Math.max(0, delay);
+        return Math.max(backoff, Math.max(0, retryAfter));
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -312,21 +312,17 @@ public class ApiClient implements AutoCloseable {
     /**
      * Computes how long to wait before the next 429 retry, in seconds.
      *
-     * <p>The wait is the greater of the exponential backoff floor ({@code base * 2^attempt}) and the
-     * server's {@code Retry-After} header (parsed as delta-seconds or an RFC-1123 HTTP-date). The
-     * backoff floor is always enforced, so a missing, zero, or too-small {@code Retry-After} cannot
-     * collapse the wait to near-zero and burn every retry in milliseconds; a {@code Retry-After} that
-     * asks for longer than the floor is honored. The total number of retries is bounded by {@code
-     * max_retries}.
+     * <p>A positive {@code Retry-After} header (parsed as delta-seconds or an RFC-1123 HTTP-date) is
+     * honored verbatim. Only when {@code Retry-After} is missing, unparseable, or non-positive does
+     * the method fall back to exponential backoff ({@code base * 2^attempt}). The total number of
+     * retries is bounded by {@code max_retries}.
      *
      * @param response the 429 response.
-     * @param attempt the zero-based retry attempt index (drives the backoff floor).
+     * @param attempt the zero-based retry attempt index (drives the backoff fallback).
      * @return the wait in seconds, never negative.
      */
     long computeRetryDelaySeconds(SimpleHttpResponse response, int attempt) {
         PluginSettings settings = PluginSettings.getInstance();
-
-        long backoff = (long) settings.getClientRetryBackoffBaseSeconds() * (1L << attempt);
 
         long retryAfter = -1;
         Header header = response.getFirstHeader(HttpHeaders.RETRY_AFTER);
@@ -342,6 +338,12 @@ public class ApiClient implements AutoCloseable {
             }
         }
 
-        return Math.max(backoff, Math.max(0, retryAfter));
+        if (retryAfter > 0) {
+            // Trust an explicit, positive Retry-After exactly as the server asked.
+            return retryAfter;
+        }
+
+        // Missing, unparseable, or non-positive (e.g. CTI's bogus Retry-After: 0): exponential backoff.
+        return (long) settings.getClientRetryBackoffBaseSeconds() * (1L << attempt);
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/client/ApiClientRetryTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/client/ApiClientRetryTests.java
@@ -139,43 +139,45 @@ public class ApiClientRetryTests extends OpenSearchTestCase {
                 .executeOnce(any(SimpleHttpRequest.class), anyLong());
     }
 
-    /** A numeric Retry-After larger than the backoff floor is honored verbatim. */
-    public void testRetryAfterLargerThanFloorHonored() {
+    /**
+     * A positive Retry-After is honored verbatim, even when it is smaller than the exponential
+     * backoff would be at this attempt — the server's explicit short wait must not be inflated.
+     */
+    public void testPositiveRetryAfterHonoredVerbatim() {
         ApiClient client = realMethodClient();
-        int base = PluginSettings.getInstance().getClientRetryBackoffBaseSeconds();
-        long above = base * 4L; // strictly greater than the attempt-0 floor (base * 1)
 
+        // attempt 3 → backoff would be base * 2^3 (e.g. 240s); a 20s Retry-After must still win.
         long delay =
-                client.computeRetryDelaySeconds(
-                        response(HttpStatus.SC_TOO_MANY_REQUESTS, Long.toString(above)), 0);
+                client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, "20"), 3);
 
-        assertEquals(above, delay);
+        assertEquals(20L, delay);
     }
 
     /**
      * Regression for the observed 60s/0s/0s collapse: a {@code Retry-After: 0} must NOT be honored
-     * verbatim — the exponential backoff floor (base * 2^attempt) is applied instead.
+     * verbatim — it is treated as unusable and the exponential backoff (base * 2^attempt) applies.
      */
-    public void testZeroRetryAfterFlooredToBackoff() {
+    public void testZeroRetryAfterFallsBackToBackoff() {
         ApiClient client = realMethodClient();
         int base = PluginSettings.getInstance().getClientRetryBackoffBaseSeconds();
 
         long delay = client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, "0"), 1);
 
-        assertEquals((long) base * 2, delay); // max(base * 2^1, 0)
+        assertEquals((long) base * 2, delay); // 2^1 = 2
     }
 
-    /** A Retry-After smaller than the backoff floor is raised to the floor. */
-    public void testSmallRetryAfterFlooredToBackoff() {
+    /** A negative Retry-After is treated as unusable and falls back to exponential backoff. */
+    public void testNegativeRetryAfterFallsBackToBackoff() {
         ApiClient client = realMethodClient();
         int base = PluginSettings.getInstance().getClientRetryBackoffBaseSeconds();
 
-        long delay = client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, "5"), 2);
+        long delay =
+                client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, "-5"), 0);
 
-        assertEquals((long) base * 4, delay); // max(base * 2^2, 5)
+        assertEquals((long) base, delay); // 2^0 = 1
     }
 
-    /** An HTTP-date Retry-After larger than the floor is converted to a delta and honored. */
+    /** A positive HTTP-date Retry-After is converted to a delta and honored. */
     public void testRetryAfterHttpDate() {
         ApiClient client = realMethodClient();
         String httpDate = DateUtils.formatStandardDate(Instant.now().plusSeconds(180));

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/client/ApiClientRetryTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/client/ApiClientRetryTests.java
@@ -33,9 +33,11 @@ import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.settings.PluginSettingsTests;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,7 +72,9 @@ public class ApiClientRetryTests extends OpenSearchTestCase {
 
     /**
      * A {@link #realMethodClient()} with {@code executeOnce} stubbed to return the scripted responses
-     * in order (repeating the last one once exhausted), standing in for the network.
+     * in order (repeating the last one once exhausted), standing in for the network. The retry delay
+     * is stubbed to {@code 0} so these control-flow tests do not sleep; delay computation is covered
+     * by the dedicated {@code computeRetryDelaySeconds} tests.
      */
     private static ApiClient scriptedClient(SimpleHttpResponse... responses) throws Exception {
         ApiClient client = realMethodClient();
@@ -84,6 +88,7 @@ public class ApiClientRetryTests extends OpenSearchTestCase {
                         })
                 .when(client)
                 .executeOnce(any(SimpleHttpRequest.class), anyLong());
+        doReturn(0L).when(client).computeRetryDelaySeconds(any(SimpleHttpResponse.class), anyInt());
         return client;
     }
 
@@ -134,25 +139,52 @@ public class ApiClientRetryTests extends OpenSearchTestCase {
                 .executeOnce(any(SimpleHttpRequest.class), anyLong());
     }
 
-    /** A numeric Retry-After header is honored verbatim. */
-    public void testRetryAfterNumericSeconds() {
+    /** A numeric Retry-After larger than the backoff floor is honored verbatim. */
+    public void testRetryAfterLargerThanFloorHonored() {
         ApiClient client = realMethodClient();
+        int base = PluginSettings.getInstance().getClientRetryBackoffBaseSeconds();
+        long above = base * 4L; // strictly greater than the attempt-0 floor (base * 1)
 
-        long delay = client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, "5"), 0);
+        long delay =
+                client.computeRetryDelaySeconds(
+                        response(HttpStatus.SC_TOO_MANY_REQUESTS, Long.toString(above)), 0);
 
-        assertEquals(5L, delay);
+        assertEquals(above, delay);
     }
 
-    /** An HTTP-date Retry-After header is converted to a delta in seconds. */
+    /**
+     * Regression for the observed 60s/0s/0s collapse: a {@code Retry-After: 0} must NOT be honored
+     * verbatim — the exponential backoff floor (base * 2^attempt) is applied instead.
+     */
+    public void testZeroRetryAfterFlooredToBackoff() {
+        ApiClient client = realMethodClient();
+        int base = PluginSettings.getInstance().getClientRetryBackoffBaseSeconds();
+
+        long delay = client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, "0"), 1);
+
+        assertEquals((long) base * 2, delay); // max(base * 2^1, 0)
+    }
+
+    /** A Retry-After smaller than the backoff floor is raised to the floor. */
+    public void testSmallRetryAfterFlooredToBackoff() {
+        ApiClient client = realMethodClient();
+        int base = PluginSettings.getInstance().getClientRetryBackoffBaseSeconds();
+
+        long delay = client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, "5"), 2);
+
+        assertEquals((long) base * 4, delay); // max(base * 2^2, 5)
+    }
+
+    /** An HTTP-date Retry-After larger than the floor is converted to a delta and honored. */
     public void testRetryAfterHttpDate() {
         ApiClient client = realMethodClient();
-        String httpDate = DateUtils.formatStandardDate(Instant.now().plusSeconds(30));
+        String httpDate = DateUtils.formatStandardDate(Instant.now().plusSeconds(180));
 
         long delay =
                 client.computeRetryDelaySeconds(response(HttpStatus.SC_TOO_MANY_REQUESTS, httpDate), 0);
 
-        // Allow a small tolerance for clock movement between formatting and evaluation.
-        assertTrue("delay was " + delay, delay >= 25 && delay <= 31);
+        // ~180s, with a small tolerance for clock movement between formatting and evaluation.
+        assertTrue("delay was " + delay, delay >= 175 && delay <= 181);
     }
 
     /** A missing Retry-After header falls back to exponential backoff: base * 2^attempt. */


### PR DESCRIPTION
## Description

This PR adds a positive-value guard on the `Retry-After` header returned with CTI `HTTP 429` responses.

The case we hit: when the CTI API rate-limits a request it replies `429` with a `Retry-After` telling us how long to wait. We observed the API returning `Retry-After: 0` while it was still rate-limiting. Our code honored that `0` literally, so the wait collapsed to nothing and all retries were burned in milliseconds, the `60s → 0s → 0s` sequence seen in the logs

To fix it the retry delay now honors a `Retry-After` only when it is a positive value; a `0`, negative, missing, or unparseable value is treated as unusable, and we fall back to our own exponential backoff (`base * 2^attempt`) instead of retrying instantly. A legitimate positive wait (e.g. `20s`) is still respected exactly, so we never inflate a real short delay.

Closes #1807 · relates to #1819

## Proposed Changes

Modify `computeRetryDelaySeconds` to include the positive guard

## Results and Evidence

Unit test working as expected 

Live testing


`ApiClient` backoff on a real 429 

```
WARN c.w.c.c.c.c.ApiClient - CTI API rate-limited request [...changes?from_offset=0&to_offset=1] (HTTP 429); retrying in 60s (attempt 1/3).
WARN c.w.c.c.c.c.ApiClient - CTI API rate-limited request [...changes?from_offset=0&to_offset=1] (HTTP 429); retrying in 60s (attempt 2/3).
WARN c.w.c.c.c.c.ApiClient - CTI API rate-limited request [...changes?from_offset=0&to_offset=1] (HTTP 429); retrying in 120s (attempt 3/3).
```

## Artifacts Affected

Content manager plugin

## Configuration Changes

NA

## Documentation Updates

NA

## Tests Introduced

`ApiClientRetryTests`, `StatusCodeAwareRetryStrategyTests`, and the live suite `1807-cti-retry.sh`.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...