### PR TITLE
Set 'index.auto_expand_replicas' to 0-1

### DIFF
--- a/.github/workflows/5_builderpackage_schema.yml
+++ b/.github/workflows/5_builderpackage_schema.yml
@@ -42,12 +42,6 @@ jobs:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: bash wcs/generator/generate_schema.sh
 
-      - name: Convert static mappings to dynamic_templates
-        run: |
-          echo "Converting generated static mappings to dynamic_templates..."
-          
-          find plugins/setup/src/main/resources/templates/streams/ -name "events.json" -type f -exec python3 wcs/generator/convert_to_dynamic_templates.py {} {} \;
-
       - name: Push changes
         env:
           GITHUB_TOKEN: ${{ secrets.INDEXER_BOT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,6 @@
 - ECS object removal [(#604)](https://github.com/wazuh/wazuh-indexer-plugins/issues/604)
 - Removal of alerts and archives index templates [(#689)](https://github.com/wazuh/wazuh-indexer-plugins/issues/689)
 - Make Unclassified events standard WCS category [(#1348)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1348)
-- Some Wazuh indices get 1 replica on multi-node clusters due to `auto_expand_replicas` [(#1354)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1354)
 
 ### Fixed
 - Wrong folder structure under `ecs` folder [(#461)](https://github.com/wazuh/wazuh-indexer-plugins/issues/461)

--- a/plugins/content-manager/build.gradle
+++ b/plugins/content-manager/build.gradle
@@ -262,7 +262,7 @@ testClusters.integTest {
   systemProperty "INDEXER_TEST_ENV", "true"
   systemProperty "DEPLOY_KEY", ""
   systemProperty "wazuh.version", "${wazuh_version}-beta3"
-  setting 'plugins.content_manager.catalog.update_on_start', 'true'
+  setting 'plugins.content_manager.catalog.update_on_start', 'false'
   setting 'plugins.content_manager.catalog.update_on_schedule', 'false'
   setting 'plugins.content_manager.catalog.create_detectors', 'false'
   setting 'plugins.content_manager.telemetry.enabled', 'false'
@@ -270,7 +270,7 @@ testClusters.integTest {
   setting 'plugins.content_manager.catalog.ruleset', "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta3-t1-ruleset-5/consumers/public-ruleset-5"
   setting 'plugins.content_manager.catalog.iocs', "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/t1-iocs-5/consumers/public-iocs-5"
   setting 'plugins.content_manager.catalog.vulnerabilities', "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/t1-vulnerabilities-5/consumers/public-vulnerabilities-5"
-    
+
   // Cluster shrink exception thrown if numberOfNodes is set to 1, so only apply if > 1
   if (_numNodes > 1) numberOfNodes = _numNodes
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -717,6 +717,7 @@ public class ContentManagerPlugin extends Plugin
                 Settings settings =
                         Settings.builder()
                                 .put("index.number_of_replicas", 0)
+                                .put("index.auto_expand_replicas", "0-1")
                                 .put("index.hidden", true)
                                 .put(Constants.KEY_INDEX_REFRESH_INTERVAL, Constants.REFRESH_INTERVAL_DISABLED)
                                 .build();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ConsumersIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ConsumersIndex.java
@@ -165,6 +165,7 @@ public class ConsumersIndex {
         Settings settings =
                 Settings.builder()
                         .put("index.number_of_replicas", 0)
+                        .put("index.auto_expand_replicas", "0-1")
                         .put("hidden", true)
                         .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD)
                         .put(Constants.KEY_INDEX_REFRESH_INTERVAL, Constants.REFRESH_INTERVAL_DISABLED)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -228,6 +228,7 @@ public class ContentIndex {
         Settings.Builder settingsBuilder =
                 Settings.builder()
                         .put("index.number_of_replicas", 0)
+                        .put("index.auto_expand_replicas", "0-1")
                         .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD);
         if (Constants.INDEX_CVES.equals(this.indexName)) {
             settingsBuilder.put("index.hidden", true);
@@ -289,6 +290,7 @@ public class ContentIndex {
         Settings settings =
                 Settings.builder()
                         .put("index.number_of_replicas", 0)
+                        .put("index.auto_expand_replicas", "0-1")
                         .put("index.hidden", true)
                         .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD)
                         .build();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ResourceLockService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ResourceLockService.java
@@ -245,6 +245,7 @@ public class ResourceLockService {
         Settings settings =
                 Settings.builder()
                         .put("index.number_of_replicas", 0)
+                        .put("index.auto_expand_replicas", "0-1")
                         .put("index.hidden", true)
                         .put(Constants.KEY_INDEX_CODEC, Constants.CODEC_ZSTD)
                         .put(Constants.KEY_INDEX_REFRESH_INTERVAL, Constants.REFRESH_INTERVAL_DISABLED)

--- a/plugins/content-manager/src/main/resources/mappings/internal-state-mapping.json
+++ b/plugins/content-manager/src/main/resources/mappings/internal-state-mapping.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "hidden": true,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/content/filters.json
+++ b/plugins/setup/src/main/resources/templates/content/filters.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 50,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/content/ioc.json
+++ b/plugins/setup/src/main/resources/templates/content/ioc.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 200,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/cve.json
+++ b/plugins/setup/src/main/resources/templates/cve.json
@@ -13,7 +13,8 @@
         "query.default_field": [
           "name"
         ],
-        "refresh_interval": "5s"
+        "refresh_interval": "5s",
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000
     },

--- a/plugins/setup/src/main/resources/templates/cve.json
+++ b/plugins/setup/src/main/resources/templates/cve.json
@@ -8,13 +8,13 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
           "name"
         ],
-        "refresh_interval": "5s",
-        "max_docvalue_fields_search": 100
+        "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000
     },

--- a/plugins/setup/src/main/resources/templates/cve.json
+++ b/plugins/setup/src/main/resources/templates/cve.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/ism-config.json
+++ b/plugins/setup/src/main/resources/templates/ism-config.json
@@ -8,6 +8,7 @@
       "index": {
         "codec": "zstd",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "number_of_shards": "1",
         "refresh_interval": "5s",
         "hidden": true

--- a/plugins/setup/src/main/resources/templates/settings.json
+++ b/plugins/setup/src/main/resources/templates/settings.json
@@ -6,11 +6,12 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "hidden": true,
         "number_of_replicas": "0",
         "number_of_shards": "1",
-        "refresh_interval": "-1"
+        "refresh_interval": "2s"
       }
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/setup-status.json
+++ b/plugins/setup/src/main/resources/templates/setup-status.json
@@ -9,6 +9,7 @@
         "codec": "zstd",
         "hidden": true,
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "number_of_shards": "1",
         "refresh_interval": "-1"
       }

--- a/plugins/setup/src/main/resources/templates/states/agent-config.json
+++ b/plugins/setup/src/main/resources/templates/states/agent-config.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "mapping.total_fields.limit": 1000,
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/states/agent-stats.json
+++ b/plugins/setup/src/main/resources/templates/states/agent-stats.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "mapping.total_fields.limit": 1000,
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/states/fim-files.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-files.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-groups.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-groups.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-networks.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-networks.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-packages.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-packages.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-ports.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-ports.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-processes.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-processes.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-services.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-services.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-system.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-system.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/inventory-users.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-users.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/sca.json
+++ b/plugins/setup/src/main/resources/templates/states/sca.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
+++ b/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
@@ -6,6 +6,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "gc_deletes": "15s",
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 50,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -9,7 +9,7 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
-        "max_docvalue_fields_search": 50,
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [

--- a/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
+++ b/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
+++ b/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
@@ -9,14 +9,14 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
           "title",
           "user"
         ],
-        "refresh_interval": "1s",
-        "max_docvalue_fields_search": 100
+        "refresh_interval": "1s"
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "ai-assistant-sessions-policy",

--- a/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
+++ b/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
@@ -15,7 +15,8 @@
           "title",
           "user"
         ],
-        "refresh_interval": "1s"
+        "refresh_interval": "1s",
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "ai-assistant-sessions-policy",

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -21,7 +21,8 @@
           "wazuh.cluster.node",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "2s"
+        "refresh_interval": "2s",
+        "max_docvalue_fields_search": 100
       },
       "mapping.nested_fields.limit": 50,
       "mapping.total_fields.limit": 1000,

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",
@@ -30,20160 +31,332 @@
     "mappings": {
       "date_detection": false,
       "dynamic": "strict_allow_templates",
-      "dynamic_templates": [
-        {
-          "wcs_agent_build_original": {
-            "path_match": "agent.build.original",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_agent_ephemeral_id": {
-            "path_match": "agent.ephemeral_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_agent_groups": {
-            "path_match": "agent.groups",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_agent_id": {
-            "path_match": "agent.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_agent_name": {
-            "path_match": "agent.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_agent_type": {
-            "path_match": "agent.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_agent_version": {
-            "path_match": "agent.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_cmmc": {
-            "path_match": "check.compliance.cmmc",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_fedramp": {
-            "path_match": "check.compliance.fedramp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_gdpr": {
-            "path_match": "check.compliance.gdpr",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_hipaa": {
-            "path_match": "check.compliance.hipaa",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_iso_27001": {
-            "path_match": "check.compliance.iso_27001",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_nis2": {
-            "path_match": "check.compliance.nis2",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_nist_800_171": {
-            "path_match": "check.compliance.nist_800_171",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_nist_800_53": {
-            "path_match": "check.compliance.nist_800_53",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_pci_dss": {
-            "path_match": "check.compliance.pci_dss",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_compliance_tsc": {
-            "path_match": "check.compliance.tsc",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_condition": {
-            "path_match": "check.condition",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_description": {
-            "path_match": "check.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_id": {
-            "path_match": "check.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_mitre_subtechnique_id": {
-            "path_match": "check.mitre.subtechnique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_mitre_subtechnique_name": {
-            "path_match": "check.mitre.subtechnique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_mitre_tactic_id": {
-            "path_match": "check.mitre.tactic.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_mitre_tactic_name": {
-            "path_match": "check.mitre.tactic.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_mitre_technique_id": {
-            "path_match": "check.mitre.technique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_mitre_technique_name": {
-            "path_match": "check.mitre.technique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_name": {
-            "path_match": "check.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_rationale": {
-            "path_match": "check.rationale",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_reason": {
-            "path_match": "check.reason",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_references": {
-            "path_match": "check.references",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_remediation": {
-            "path_match": "check.remediation",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_result": {
-            "path_match": "check.result",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_check_rules": {
-            "path_match": "check.rules",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_address": {
-            "path_match": "client.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_as_number": {
-            "path_match": "client.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_client_as_organization_name": {
-            "path_match": "client.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_bytes": {
-            "path_match": "client.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_client_domain": {
-            "path_match": "client.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_city_name": {
-            "path_match": "client.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_continent_code": {
-            "path_match": "client.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_continent_name": {
-            "path_match": "client.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_country_iso_code": {
-            "path_match": "client.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_country_name": {
-            "path_match": "client.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_location": {
-            "path_match": "client.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_name": {
-            "path_match": "client.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_postal_code": {
-            "path_match": "client.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_region_iso_code": {
-            "path_match": "client.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_region_name": {
-            "path_match": "client.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_geo_timezone": {
-            "path_match": "client.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_ip": {
-            "path_match": "client.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_client_mac": {
-            "path_match": "client.mac",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_nat_ip": {
-            "path_match": "client.nat.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_client_nat_port": {
-            "path_match": "client.nat.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_client_packets": {
-            "path_match": "client.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_client_port": {
-            "path_match": "client.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_client_registered_domain": {
-            "path_match": "client.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_subdomain": {
-            "path_match": "client.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_top_level_domain": {
-            "path_match": "client.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_domain": {
-            "path_match": "client.user.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_email": {
-            "path_match": "client.user.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_full_name": {
-            "path_match": "client.user.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_group_domain": {
-            "path_match": "client.user.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_group_id": {
-            "path_match": "client.user.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_group_name": {
-            "path_match": "client.user.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_hash": {
-            "path_match": "client.user.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_id": {
-            "path_match": "client.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_name": {
-            "path_match": "client.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_client_user_roles": {
-            "path_match": "client.user.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_account_id": {
-            "path_match": "cloud.account.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_account_name": {
-            "path_match": "cloud.account.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_availability_zone": {
-            "path_match": "cloud.availability_zone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_instance_id": {
-            "path_match": "cloud.instance.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_instance_name": {
-            "path_match": "cloud.instance.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_machine_type": {
-            "path_match": "cloud.machine.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_account_id": {
-            "path_match": "cloud.origin.account.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_account_name": {
-            "path_match": "cloud.origin.account.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_availability_zone": {
-            "path_match": "cloud.origin.availability_zone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_instance_id": {
-            "path_match": "cloud.origin.instance.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_instance_name": {
-            "path_match": "cloud.origin.instance.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_machine_type": {
-            "path_match": "cloud.origin.machine.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_project_id": {
-            "path_match": "cloud.origin.project.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_project_name": {
-            "path_match": "cloud.origin.project.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_provider": {
-            "path_match": "cloud.origin.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_region": {
-            "path_match": "cloud.origin.region",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_origin_service_name": {
-            "path_match": "cloud.origin.service.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_project_id": {
-            "path_match": "cloud.project.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_project_name": {
-            "path_match": "cloud.project.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_provider": {
-            "path_match": "cloud.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_region": {
-            "path_match": "cloud.region",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_service_name": {
-            "path_match": "cloud.service.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_account_id": {
-            "path_match": "cloud.target.account.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_account_name": {
-            "path_match": "cloud.target.account.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_availability_zone": {
-            "path_match": "cloud.target.availability_zone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_instance_id": {
-            "path_match": "cloud.target.instance.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_instance_name": {
-            "path_match": "cloud.target.instance.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_machine_type": {
-            "path_match": "cloud.target.machine.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_project_id": {
-            "path_match": "cloud.target.project.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_project_name": {
-            "path_match": "cloud.target.project.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_provider": {
-            "path_match": "cloud.target.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_region": {
-            "path_match": "cloud.target.region",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_cloud_target_service_name": {
-            "path_match": "cloud.target.service.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_cmmc": {
-            "path_match": "compliance.cmmc",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_fedramp": {
-            "path_match": "compliance.fedramp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_gdpr": {
-            "path_match": "compliance.gdpr",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_hipaa": {
-            "path_match": "compliance.hipaa",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_iso_27001": {
-            "path_match": "compliance.iso_27001",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_nis2": {
-            "path_match": "compliance.nis2",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_nist_800_171": {
-            "path_match": "compliance.nist_800_171",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_nist_800_53": {
-            "path_match": "compliance.nist_800_53",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_pci_dss": {
-            "path_match": "compliance.pci_dss",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_compliance_tsc": {
-            "path_match": "compliance.tsc",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_container_cpu_usage": {
-            "path_match": "container.cpu.usage",
-            "mapping": {
-              "scaling_factor": 1000,
-              "type": "scaled_float"
-            }
-          }
-        },
-        {
-          "wcs_container_disk_read_bytes": {
-            "path_match": "container.disk.read.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_container_disk_write_bytes": {
-            "path_match": "container.disk.write.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_container_id": {
-            "path_match": "container.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_container_image_hash_all": {
-            "path_match": "container.image.hash.all",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_container_image_name": {
-            "path_match": "container.image.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_container_image_tag": {
-            "path_match": "container.image.tag",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_container_labels": {
-            "path_match": "container.labels",
-            "mapping": {
-              "type": "object"
-            }
-          }
-        },
-        {
-          "wcs_container_memory_usage": {
-            "path_match": "container.memory.usage",
-            "mapping": {
-              "scaling_factor": 1000,
-              "type": "scaled_float"
-            }
-          }
-        },
-        {
-          "wcs_container_name": {
-            "path_match": "container.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_container_network_egress_bytes": {
-            "path_match": "container.network.egress.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_container_network_ingress_bytes": {
-            "path_match": "container.network.ingress.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_container_runtime": {
-            "path_match": "container.runtime",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_container_security_context_privileged": {
-            "path_match": "container.security_context.privileged",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_data_stream_dataset": {
-            "path_match": "data_stream.dataset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_data_stream_namespace": {
-            "path_match": "data_stream.namespace",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_data_stream_type": {
-            "path_match": "data_stream.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_address": {
-            "path_match": "destination.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_as_number": {
-            "path_match": "destination.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_destination_as_organization_name": {
-            "path_match": "destination.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_bytes": {
-            "path_match": "destination.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_destination_domain": {
-            "path_match": "destination.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_city_name": {
-            "path_match": "destination.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_continent_code": {
-            "path_match": "destination.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_continent_name": {
-            "path_match": "destination.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_country_iso_code": {
-            "path_match": "destination.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_country_name": {
-            "path_match": "destination.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_location": {
-            "path_match": "destination.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_name": {
-            "path_match": "destination.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_postal_code": {
-            "path_match": "destination.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_region_iso_code": {
-            "path_match": "destination.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_region_name": {
-            "path_match": "destination.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_geo_timezone": {
-            "path_match": "destination.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_ip": {
-            "path_match": "destination.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_destination_mac": {
-            "path_match": "destination.mac",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_nat_ip": {
-            "path_match": "destination.nat.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_destination_nat_port": {
-            "path_match": "destination.nat.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_destination_packets": {
-            "path_match": "destination.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_destination_port": {
-            "path_match": "destination.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_destination_registered_domain": {
-            "path_match": "destination.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_subdomain": {
-            "path_match": "destination.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_top_level_domain": {
-            "path_match": "destination.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_domain": {
-            "path_match": "destination.user.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_email": {
-            "path_match": "destination.user.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_full_name": {
-            "path_match": "destination.user.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_group_domain": {
-            "path_match": "destination.user.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_group_id": {
-            "path_match": "destination.user.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_group_name": {
-            "path_match": "destination.user.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_hash": {
-            "path_match": "destination.user.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_id": {
-            "path_match": "destination.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_name": {
-            "path_match": "destination.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_destination_user_roles": {
-            "path_match": "destination.user.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_device_id": {
-            "path_match": "device.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_device_manufacturer": {
-            "path_match": "device.manufacturer",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_device_model_identifier": {
-            "path_match": "device.model.identifier",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_device_model_name": {
-            "path_match": "device.model.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_device_serial_number": {
-            "path_match": "device.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_digest_algorithm": {
-            "path_match": "dll.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_exists": {
-            "path_match": "dll.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_flags": {
-            "path_match": "dll.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_signing_id": {
-            "path_match": "dll.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_status": {
-            "path_match": "dll.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_subject_name": {
-            "path_match": "dll.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_team_id": {
-            "path_match": "dll.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_thumbprint_sha256": {
-            "path_match": "dll.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_timestamp": {
-            "path_match": "dll.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_trusted": {
-            "path_match": "dll.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_dll_code_signature_valid": {
-            "path_match": "dll.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_cdhash": {
-            "path_match": "dll.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_md5": {
-            "path_match": "dll.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_sha1": {
-            "path_match": "dll.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_sha256": {
-            "path_match": "dll.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_sha384": {
-            "path_match": "dll.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_sha512": {
-            "path_match": "dll.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_ssdeep": {
-            "path_match": "dll.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_hash_tlsh": {
-            "path_match": "dll.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_name": {
-            "path_match": "dll.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_origin_referrer_url": {
-            "path_match": "dll.origin_referrer_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_origin_url": {
-            "path_match": "dll.origin_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_path": {
-            "path_match": "dll.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_architecture": {
-            "path_match": "dll.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_company": {
-            "path_match": "dll.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_description": {
-            "path_match": "dll.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_file_version": {
-            "path_match": "dll.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_go_import_hash": {
-            "path_match": "dll.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_go_imports": {
-            "path_match": "dll.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_go_imports_names_entropy": {
-            "path_match": "dll.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_go_imports_names_var_entropy": {
-            "path_match": "dll.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_go_stripped": {
-            "path_match": "dll.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_imphash": {
-            "path_match": "dll.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_import_hash": {
-            "path_match": "dll.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_imports": {
-            "path_match": "dll.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_imports_names_entropy": {
-            "path_match": "dll.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_imports_names_var_entropy": {
-            "path_match": "dll.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_original_file_name": {
-            "path_match": "dll.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_pehash": {
-            "path_match": "dll.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_product": {
-            "path_match": "dll.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_sections_entropy": {
-            "path_match": "dll.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_sections_name": {
-            "path_match": "dll.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_sections_physical_size": {
-            "path_match": "dll.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_sections_var_entropy": {
-            "path_match": "dll.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dll_pe_sections_virtual_size": {
-            "path_match": "dll.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dns_answers_class": {
-            "path_match": "dns.answers.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_answers_data": {
-            "path_match": "dns.answers.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_answers_name": {
-            "path_match": "dns.answers.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_answers_ttl": {
-            "path_match": "dns.answers.ttl",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_dns_answers_type": {
-            "path_match": "dns.answers.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_header_flags": {
-            "path_match": "dns.header_flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_id": {
-            "path_match": "dns.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_op_code": {
-            "path_match": "dns.op_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_question_class": {
-            "path_match": "dns.question.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_question_name": {
-            "path_match": "dns.question.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_question_registered_domain": {
-            "path_match": "dns.question.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_question_subdomain": {
-            "path_match": "dns.question.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_question_top_level_domain": {
-            "path_match": "dns.question.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_question_type": {
-            "path_match": "dns.question.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_resolved_ip": {
-            "path_match": "dns.resolved_ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_dns_response_code": {
-            "path_match": "dns.response_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_dns_type": {
-            "path_match": "dns.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_extension": {
-            "path_match": "email.attachments.file.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_cdhash": {
-            "path_match": "email.attachments.file.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_md5": {
-            "path_match": "email.attachments.file.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_sha1": {
-            "path_match": "email.attachments.file.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_sha256": {
-            "path_match": "email.attachments.file.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_sha384": {
-            "path_match": "email.attachments.file.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_sha512": {
-            "path_match": "email.attachments.file.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_ssdeep": {
-            "path_match": "email.attachments.file.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_hash_tlsh": {
-            "path_match": "email.attachments.file.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_mime_type": {
-            "path_match": "email.attachments.file.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_name": {
-            "path_match": "email.attachments.file.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_attachments_file_size": {
-            "path_match": "email.attachments.file.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_email_bcc_address": {
-            "path_match": "email.bcc.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_cc_address": {
-            "path_match": "email.cc.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_content_type": {
-            "path_match": "email.content_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_delivery_timestamp": {
-            "path_match": "email.delivery_timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_email_direction": {
-            "path_match": "email.direction",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_from_address": {
-            "path_match": "email.from.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_local_id": {
-            "path_match": "email.local_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_message_id": {
-            "path_match": "email.message_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_origination_timestamp": {
-            "path_match": "email.origination_timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_email_reply_to_address": {
-            "path_match": "email.reply_to.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_sender_address": {
-            "path_match": "email.sender.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_subject": {
-            "path_match": "email.subject",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_to_address": {
-            "path_match": "email.to.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_email_x_mailer": {
-            "path_match": "email.x_mailer",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_error_code": {
-            "path_match": "error.code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_error_id": {
-            "path_match": "error.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_error_message": {
-            "path_match": "error.message",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_error_stack_trace": {
-            "path_match": "error.stack_trace",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_error_type": {
-            "path_match": "error.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_action": {
-            "path_match": "event.action",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_agent_id_status": {
-            "path_match": "event.agent_id_status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_category": {
-            "path_match": "event.category",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_changed_fields": {
-            "path_match": "event.changed_fields",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_code": {
-            "path_match": "event.code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_collector": {
-            "path_match": "event.collector",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_created": {
-            "path_match": "event.created",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_event_dataset": {
-            "path_match": "event.dataset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_duration": {
-            "path_match": "event.duration",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_event_end": {
-            "path_match": "event.end",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_event_hash": {
-            "path_match": "event.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_id": {
-            "path_match": "event.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_ingested": {
-            "path_match": "event.ingested",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_event_kind": {
-            "path_match": "event.kind",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_module": {
-            "path_match": "event.module",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_original": {
-            "path_match": "event.original",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_outcome": {
-            "path_match": "event.outcome",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_provider": {
-            "path_match": "event.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_reason": {
-            "path_match": "event.reason",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_reference": {
-            "path_match": "event.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_risk_score": {
-            "path_match": "event.risk_score",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_event_risk_score_norm": {
-            "path_match": "event.risk_score_norm",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_event_sequence": {
-            "path_match": "event.sequence",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_event_severity": {
-            "path_match": "event.severity",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_event_start": {
-            "path_match": "event.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_event_timezone": {
-            "path_match": "event.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_type": {
-            "path_match": "event.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_event_url": {
-            "path_match": "event.url",
-            "mapping": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_faas_coldstart": {
-            "path_match": "faas.coldstart",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_faas_execution": {
-            "path_match": "faas.execution",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_faas_id": {
-            "path_match": "faas.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_faas_name": {
-            "path_match": "faas.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_faas_trigger_request_id": {
-            "path_match": "faas.trigger.request_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_faas_trigger_type": {
-            "path_match": "faas.trigger.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_faas_version": {
-            "path_match": "faas.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_accessed": {
-            "path_match": "file.accessed",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_attributes": {
-            "path_match": "file.attributes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_digest_algorithm": {
-            "path_match": "file.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_exists": {
-            "path_match": "file.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_flags": {
-            "path_match": "file.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_signing_id": {
-            "path_match": "file.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_status": {
-            "path_match": "file.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_subject_name": {
-            "path_match": "file.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_team_id": {
-            "path_match": "file.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_thumbprint_sha256": {
-            "path_match": "file.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_timestamp": {
-            "path_match": "file.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_trusted": {
-            "path_match": "file.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_file_code_signature_valid": {
-            "path_match": "file.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_file_created": {
-            "path_match": "file.created",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_ctime": {
-            "path_match": "file.ctime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_device": {
-            "path_match": "file.device",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_diff": {
-            "path_match": "file.diff",
-            "mapping": {
-              "type": "match_only_text"
-            }
-          }
-        },
-        {
-          "wcs_file_directory": {
-            "path_match": "file.directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_drive_letter": {
-            "path_match": "file.drive_letter",
-            "mapping": {
-              "ignore_above": 1,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_architecture": {
-            "path_match": "file.elf.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_byte_order": {
-            "path_match": "file.elf.byte_order",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_cpu_type": {
-            "path_match": "file.elf.cpu_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_creation_date": {
-            "path_match": "file.elf.creation_date",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_exports": {
-            "path_match": "file.elf.exports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_go_import_hash": {
-            "path_match": "file.elf.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_go_imports": {
-            "path_match": "file.elf.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_go_imports_names_entropy": {
-            "path_match": "file.elf.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_go_imports_names_var_entropy": {
-            "path_match": "file.elf.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_go_stripped": {
-            "path_match": "file.elf.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_abi_version": {
-            "path_match": "file.elf.header.abi_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_class": {
-            "path_match": "file.elf.header.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_data": {
-            "path_match": "file.elf.header.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_entrypoint": {
-            "path_match": "file.elf.header.entrypoint",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_object_version": {
-            "path_match": "file.elf.header.object_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_os_abi": {
-            "path_match": "file.elf.header.os_abi",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_type": {
-            "path_match": "file.elf.header.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_header_version": {
-            "path_match": "file.elf.header.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_import_hash": {
-            "path_match": "file.elf.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_imports": {
-            "path_match": "file.elf.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_imports_names_entropy": {
-            "path_match": "file.elf.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_imports_names_var_entropy": {
-            "path_match": "file.elf.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_chi2": {
-            "path_match": "file.elf.sections.chi2",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_entropy": {
-            "path_match": "file.elf.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_flags": {
-            "path_match": "file.elf.sections.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_name": {
-            "path_match": "file.elf.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_physical_offset": {
-            "path_match": "file.elf.sections.physical_offset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_physical_size": {
-            "path_match": "file.elf.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_type": {
-            "path_match": "file.elf.sections.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_var_entropy": {
-            "path_match": "file.elf.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_virtual_address": {
-            "path_match": "file.elf.sections.virtual_address",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_sections_virtual_size": {
-            "path_match": "file.elf.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_segments_sections": {
-            "path_match": "file.elf.segments.sections",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_segments_type": {
-            "path_match": "file.elf.segments.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_shared_libraries": {
-            "path_match": "file.elf.shared_libraries",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_elf_telfhash": {
-            "path_match": "file.elf.telfhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_extension": {
-            "path_match": "file.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_fork_name": {
-            "path_match": "file.fork_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_gid": {
-            "path_match": "file.gid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_group": {
-            "path_match": "file.group",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_cdhash": {
-            "path_match": "file.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_md5": {
-            "path_match": "file.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_sha1": {
-            "path_match": "file.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_sha256": {
-            "path_match": "file.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_sha384": {
-            "path_match": "file.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_sha512": {
-            "path_match": "file.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_ssdeep": {
-            "path_match": "file.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_hash_tlsh": {
-            "path_match": "file.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_inode": {
-            "path_match": "file.inode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_go_import_hash": {
-            "path_match": "file.macho.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_go_imports": {
-            "path_match": "file.macho.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_go_imports_names_entropy": {
-            "path_match": "file.macho.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_go_imports_names_var_entropy": {
-            "path_match": "file.macho.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_go_stripped": {
-            "path_match": "file.macho.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_import_hash": {
-            "path_match": "file.macho.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_imports": {
-            "path_match": "file.macho.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_imports_names_entropy": {
-            "path_match": "file.macho.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_imports_names_var_entropy": {
-            "path_match": "file.macho.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_sections_entropy": {
-            "path_match": "file.macho.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_sections_name": {
-            "path_match": "file.macho.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_sections_physical_size": {
-            "path_match": "file.macho.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_sections_var_entropy": {
-            "path_match": "file.macho.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_sections_virtual_size": {
-            "path_match": "file.macho.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_macho_symhash": {
-            "path_match": "file.macho.symhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_mime_type": {
-            "path_match": "file.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_mode": {
-            "path_match": "file.mode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_mtime": {
-            "path_match": "file.mtime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_name": {
-            "path_match": "file.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_origin_referrer_url": {
-            "path_match": "file.origin_referrer_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_origin_url": {
-            "path_match": "file.origin_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_owner": {
-            "path_match": "file.owner",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_path": {
-            "path_match": "file.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_architecture": {
-            "path_match": "file.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_company": {
-            "path_match": "file.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_description": {
-            "path_match": "file.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_file_version": {
-            "path_match": "file.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_go_import_hash": {
-            "path_match": "file.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_go_imports": {
-            "path_match": "file.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_go_imports_names_entropy": {
-            "path_match": "file.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_go_imports_names_var_entropy": {
-            "path_match": "file.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_go_stripped": {
-            "path_match": "file.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_imphash": {
-            "path_match": "file.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_import_hash": {
-            "path_match": "file.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_imports": {
-            "path_match": "file.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_imports_names_entropy": {
-            "path_match": "file.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_imports_names_var_entropy": {
-            "path_match": "file.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_original_file_name": {
-            "path_match": "file.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_pehash": {
-            "path_match": "file.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_product": {
-            "path_match": "file.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_sections_entropy": {
-            "path_match": "file.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_sections_name": {
-            "path_match": "file.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_sections_physical_size": {
-            "path_match": "file.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_sections_var_entropy": {
-            "path_match": "file.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_pe_sections_virtual_size": {
-            "path_match": "file.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_size": {
-            "path_match": "file.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_target_path": {
-            "path_match": "file.target_path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_type": {
-            "path_match": "file.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_uid": {
-            "path_match": "file.uid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_alternative_names": {
-            "path_match": "file.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_issuer_common_name": {
-            "path_match": "file.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_issuer_country": {
-            "path_match": "file.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_issuer_distinguished_name": {
-            "path_match": "file.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_issuer_locality": {
-            "path_match": "file.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_issuer_organization": {
-            "path_match": "file.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_issuer_organizational_unit": {
-            "path_match": "file.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_issuer_state_or_province": {
-            "path_match": "file.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_not_after": {
-            "path_match": "file.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_not_before": {
-            "path_match": "file.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_public_key_algorithm": {
-            "path_match": "file.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_public_key_curve": {
-            "path_match": "file.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_public_key_exponent": {
-            "path_match": "file.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_public_key_size": {
-            "path_match": "file.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_serial_number": {
-            "path_match": "file.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_signature_algorithm": {
-            "path_match": "file.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_subject_common_name": {
-            "path_match": "file.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_subject_country": {
-            "path_match": "file.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_subject_distinguished_name": {
-            "path_match": "file.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_subject_locality": {
-            "path_match": "file.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_subject_organization": {
-            "path_match": "file.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_subject_organizational_unit": {
-            "path_match": "file.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_subject_state_or_province": {
-            "path_match": "file.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_file_x509_version_number": {
-            "path_match": "file.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_agent_description": {
-            "path_match": "gen_ai.agent.description",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_agent_id": {
-            "path_match": "gen_ai.agent.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_agent_name": {
-            "path_match": "gen_ai.agent.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_operation_name": {
-            "path_match": "gen_ai.operation.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_output_type": {
-            "path_match": "gen_ai.output.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_choice_count": {
-            "path_match": "gen_ai.request.choice.count",
-            "mapping": {
-              "type": "integer"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_encoding_formats": {
-            "path_match": "gen_ai.request.encoding_formats",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_frequency_penalty": {
-            "path_match": "gen_ai.request.frequency_penalty",
-            "mapping": {
-              "type": "double"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_max_tokens": {
-            "path_match": "gen_ai.request.max_tokens",
-            "mapping": {
-              "type": "integer"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_model": {
-            "path_match": "gen_ai.request.model",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_presence_penalty": {
-            "path_match": "gen_ai.request.presence_penalty",
-            "mapping": {
-              "type": "double"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_seed": {
-            "path_match": "gen_ai.request.seed",
-            "mapping": {
-              "type": "integer"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_stop_sequences": {
-            "path_match": "gen_ai.request.stop_sequences",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_temperature": {
-            "path_match": "gen_ai.request.temperature",
-            "mapping": {
-              "type": "double"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_top_k": {
-            "path_match": "gen_ai.request.top_k",
-            "mapping": {
-              "type": "double"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_request_top_p": {
-            "path_match": "gen_ai.request.top_p",
-            "mapping": {
-              "type": "double"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_response_finish_reasons": {
-            "path_match": "gen_ai.response.finish_reasons",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_response_id": {
-            "path_match": "gen_ai.response.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_response_model": {
-            "path_match": "gen_ai.response.model",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_system": {
-            "path_match": "gen_ai.system",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_token_type": {
-            "path_match": "gen_ai.token.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_tool_call_id": {
-            "path_match": "gen_ai.tool.call.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_tool_name": {
-            "path_match": "gen_ai.tool.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_tool_type": {
-            "path_match": "gen_ai.tool.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_usage_input_tokens": {
-            "path_match": "gen_ai.usage.input_tokens",
-            "mapping": {
-              "type": "integer"
-            }
-          }
-        },
-        {
-          "wcs_gen_ai_usage_output_tokens": {
-            "path_match": "gen_ai.usage.output_tokens",
-            "mapping": {
-              "type": "integer"
-            }
-          }
-        },
-        {
-          "wcs_group_domain": {
-            "path_match": "group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_group_id": {
-            "path_match": "group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_group_name": {
-            "path_match": "group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_architecture": {
-            "path_match": "host.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_boot_id": {
-            "path_match": "host.boot.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_cpu_cores": {
-            "path_match": "host.cpu.cores",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_cpu_name": {
-            "path_match": "host.cpu.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_cpu_speed": {
-            "path_match": "host.cpu.speed",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_cpu_usage": {
-            "path_match": "host.cpu.usage",
-            "mapping": {
-              "scaling_factor": 1000,
-              "type": "scaled_float"
-            }
-          }
-        },
-        {
-          "wcs_host_disk_read_bytes": {
-            "path_match": "host.disk.read.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_disk_write_bytes": {
-            "path_match": "host.disk.write.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_domain": {
-            "path_match": "host.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_city_name": {
-            "path_match": "host.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_continent_code": {
-            "path_match": "host.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_continent_name": {
-            "path_match": "host.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_country_iso_code": {
-            "path_match": "host.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_country_name": {
-            "path_match": "host.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_location": {
-            "path_match": "host.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_name": {
-            "path_match": "host.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_postal_code": {
-            "path_match": "host.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_region_iso_code": {
-            "path_match": "host.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_region_name": {
-            "path_match": "host.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_geo_timezone": {
-            "path_match": "host.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_hostname": {
-            "path_match": "host.hostname",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_id": {
-            "path_match": "host.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_ip": {
-            "path_match": "host.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_host_mac": {
-            "path_match": "host.mac",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_memory_free": {
-            "path_match": "host.memory.free",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_memory_total": {
-            "path_match": "host.memory.total",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_memory_used_percentage": {
-            "path_match": "host.memory.used.percentage",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_name": {
-            "path_match": "host.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_network_egress_bytes": {
-            "path_match": "host.network.egress.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_egress_drops": {
-            "path_match": "host.network.egress.drops",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_egress_errors": {
-            "path_match": "host.network.egress.errors",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_egress_packets": {
-            "path_match": "host.network.egress.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_egress_queue": {
-            "path_match": "host.network.egress.queue",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_ingress_bytes": {
-            "path_match": "host.network.ingress.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_ingress_drops": {
-            "path_match": "host.network.ingress.drops",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_ingress_errors": {
-            "path_match": "host.network.ingress.errors",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_ingress_packets": {
-            "path_match": "host.network.ingress.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_network_ingress_queue": {
-            "path_match": "host.network.ingress.queue",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_host_os_family": {
-            "path_match": "host.os.family",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_os_full": {
-            "path_match": "host.os.full",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_os_kernel": {
-            "path_match": "host.os.kernel",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_os_name": {
-            "path_match": "host.os.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_os_platform": {
-            "path_match": "host.os.platform",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_os_type": {
-            "path_match": "host.os.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_os_version": {
-            "path_match": "host.os.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_pid_ns_ino": {
-            "path_match": "host.pid_ns_ino",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_risk_calculated_level": {
-            "path_match": "host.risk.calculated_level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_risk_calculated_score": {
-            "path_match": "host.risk.calculated_score",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_host_risk_calculated_score_norm": {
-            "path_match": "host.risk.calculated_score_norm",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_host_risk_static_level": {
-            "path_match": "host.risk.static_level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_risk_static_score": {
-            "path_match": "host.risk.static_score",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_host_risk_static_score_norm": {
-            "path_match": "host.risk.static_score_norm",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_host_type": {
-            "path_match": "host.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_host_uptime": {
-            "path_match": "host.uptime",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_http_request_body_bytes": {
-            "path_match": "http.request.body.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_http_request_body_content": {
-            "path_match": "http.request.body.content",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_http_request_bytes": {
-            "path_match": "http.request.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_http_request_id": {
-            "path_match": "http.request.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_http_request_method": {
-            "path_match": "http.request.method",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_http_request_mime_type": {
-            "path_match": "http.request.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_http_request_referrer": {
-            "path_match": "http.request.referrer",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_http_response_body_bytes": {
-            "path_match": "http.response.body.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_http_response_body_content": {
-            "path_match": "http.response.body.content",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_http_response_bytes": {
-            "path_match": "http.response.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_http_response_mime_type": {
-            "path_match": "http.response.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_http_response_status_code": {
-            "path_match": "http.response.status_code",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_http_version": {
-            "path_match": "http.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_interface_alias": {
-            "path_match": "interface.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_interface_id": {
-            "path_match": "interface.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_interface_mtu": {
-            "path_match": "interface.mtu",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_interface_name": {
-            "path_match": "interface.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_interface_state": {
-            "path_match": "interface.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_interface_type": {
-            "path_match": "interface.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_file_path": {
-            "path_match": "log.file.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_level": {
-            "path_match": "log.level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_logger": {
-            "path_match": "log.logger",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_origin_file_line": {
-            "path_match": "log.origin.file.line",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_log_origin_file_name": {
-            "path_match": "log.origin.file.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_origin_function": {
-            "path_match": "log.origin.function",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_appname": {
-            "path_match": "log.syslog.appname",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_facility_code": {
-            "path_match": "log.syslog.facility.code",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_facility_name": {
-            "path_match": "log.syslog.facility.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_hostname": {
-            "path_match": "log.syslog.hostname",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_msgid": {
-            "path_match": "log.syslog.msgid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_priority": {
-            "path_match": "log.syslog.priority",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_procid": {
-            "path_match": "log.syslog.procid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_severity_code": {
-            "path_match": "log.syslog.severity.code",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_severity_name": {
-            "path_match": "log.syslog.severity.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_structured_data": {
-            "path_match": "log.syslog.structured_data",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_log_syslog_version": {
-            "path_match": "log.syslog.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_mitre_subtechnique_id": {
-            "path_match": "mitre.subtechnique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_mitre_subtechnique_name": {
-            "path_match": "mitre.subtechnique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_mitre_tactic_id": {
-            "path_match": "mitre.tactic.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_mitre_tactic_name": {
-            "path_match": "mitre.tactic.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_mitre_technique_id": {
-            "path_match": "mitre.technique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_mitre_technique_name": {
-            "path_match": "mitre.technique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_application": {
-            "path_match": "network.application",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_broadcast": {
-            "path_match": "network.broadcast",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_network_bytes": {
-            "path_match": "network.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_network_community_id": {
-            "path_match": "network.community_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_dhcp": {
-            "path_match": "network.dhcp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_direction": {
-            "path_match": "network.direction",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_forwarded_ip": {
-            "path_match": "network.forwarded_ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_network_gateway": {
-            "path_match": "network.gateway",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_network_iana_number": {
-            "path_match": "network.iana_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_inner_vlan_id": {
-            "path_match": "network.inner.vlan.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_inner_vlan_name": {
-            "path_match": "network.inner.vlan.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_metric": {
-            "path_match": "network.metric",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_network_name": {
-            "path_match": "network.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_netmask": {
-            "path_match": "network.netmask",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_network_packets": {
-            "path_match": "network.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_network_protocol": {
-            "path_match": "network.protocol",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_transport": {
-            "path_match": "network.transport",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_type": {
-            "path_match": "network.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_vlan_id": {
-            "path_match": "network.vlan.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_network_vlan_name": {
-            "path_match": "network.vlan.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_alias": {
-            "path_match": "observer.egress.interface.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_id": {
-            "path_match": "observer.egress.interface.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_mtu": {
-            "path_match": "observer.egress.interface.mtu",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_name": {
-            "path_match": "observer.egress.interface.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_observer_ingress_interface_alias": {
-            "path_match": "observer.egress.interface.observer.ingress.interface.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_observer_ingress_interface_id": {
-            "path_match": "observer.egress.interface.observer.ingress.interface.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_observer_ingress_interface_mtu": {
-            "path_match": "observer.egress.interface.observer.ingress.interface.mtu",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_observer_ingress_interface_name": {
-            "path_match": "observer.egress.interface.observer.ingress.interface.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_observer_ingress_interface_state": {
-            "path_match": "observer.egress.interface.observer.ingress.interface.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_observer_ingress_interface_type": {
-            "path_match": "observer.egress.interface.observer.ingress.interface.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_state": {
-            "path_match": "observer.egress.interface.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_interface_type": {
-            "path_match": "observer.egress.interface.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_vlan_id": {
-            "path_match": "observer.egress.vlan.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_vlan_name": {
-            "path_match": "observer.egress.vlan.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_egress_zone": {
-            "path_match": "observer.egress.zone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_city_name": {
-            "path_match": "observer.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_continent_code": {
-            "path_match": "observer.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_continent_name": {
-            "path_match": "observer.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_country_iso_code": {
-            "path_match": "observer.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_country_name": {
-            "path_match": "observer.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_location": {
-            "path_match": "observer.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_name": {
-            "path_match": "observer.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_postal_code": {
-            "path_match": "observer.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_region_iso_code": {
-            "path_match": "observer.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_region_name": {
-            "path_match": "observer.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_geo_timezone": {
-            "path_match": "observer.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_hostname": {
-            "path_match": "observer.hostname",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_interface_alias": {
-            "path_match": "observer.ingress.interface.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_interface_id": {
-            "path_match": "observer.ingress.interface.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_interface_mtu": {
-            "path_match": "observer.ingress.interface.mtu",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_interface_name": {
-            "path_match": "observer.ingress.interface.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_interface_state": {
-            "path_match": "observer.ingress.interface.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_interface_type": {
-            "path_match": "observer.ingress.interface.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_vlan_id": {
-            "path_match": "observer.ingress.vlan.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_vlan_name": {
-            "path_match": "observer.ingress.vlan.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ingress_zone": {
-            "path_match": "observer.ingress.zone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_ip": {
-            "path_match": "observer.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_observer_mac": {
-            "path_match": "observer.mac",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_name": {
-            "path_match": "observer.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_os_family": {
-            "path_match": "observer.os.family",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_os_full": {
-            "path_match": "observer.os.full",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_os_kernel": {
-            "path_match": "observer.os.kernel",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_os_name": {
-            "path_match": "observer.os.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_os_platform": {
-            "path_match": "observer.os.platform",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_os_type": {
-            "path_match": "observer.os.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_os_version": {
-            "path_match": "observer.os.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_product": {
-            "path_match": "observer.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_serial_number": {
-            "path_match": "observer.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_type": {
-            "path_match": "observer.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_vendor": {
-            "path_match": "observer.vendor",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_observer_version": {
-            "path_match": "observer.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_api_version": {
-            "path_match": "orchestrator.api_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_cluster_id": {
-            "path_match": "orchestrator.cluster.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_cluster_name": {
-            "path_match": "orchestrator.cluster.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_cluster_url": {
-            "path_match": "orchestrator.cluster.url",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_cluster_version": {
-            "path_match": "orchestrator.cluster.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_namespace": {
-            "path_match": "orchestrator.namespace",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_organization": {
-            "path_match": "orchestrator.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_resource_annotation": {
-            "path_match": "orchestrator.resource.annotation",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_resource_id": {
-            "path_match": "orchestrator.resource.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_resource_ip": {
-            "path_match": "orchestrator.resource.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_resource_label": {
-            "path_match": "orchestrator.resource.label",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_resource_name": {
-            "path_match": "orchestrator.resource.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_resource_parent_type": {
-            "path_match": "orchestrator.resource.parent.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_resource_type": {
-            "path_match": "orchestrator.resource.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_orchestrator_type": {
-            "path_match": "orchestrator.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_organization_id": {
-            "path_match": "organization.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_organization_name": {
-            "path_match": "organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_architecture": {
-            "path_match": "package.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_build_version": {
-            "path_match": "package.build_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_checksum": {
-            "path_match": "package.checksum",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_description": {
-            "path_match": "package.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_install_scope": {
-            "path_match": "package.install_scope",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_installed": {
-            "path_match": "package.installed",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_package_license": {
-            "path_match": "package.license",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_name": {
-            "path_match": "package.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_path": {
-            "path_match": "package.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_previous_installed": {
-            "path_match": "package.previous.installed",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_package_reference": {
-            "path_match": "package.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_size": {
-            "path_match": "package.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_package_type": {
-            "path_match": "package.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_package_version": {
-            "path_match": "package.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_policy_description": {
-            "path_match": "policy.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_policy_file": {
-            "path_match": "policy.file",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_policy_id": {
-            "path_match": "policy.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_policy_name": {
-            "path_match": "policy.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_policy_references": {
-            "path_match": "policy.references",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_args": {
-            "path_match": "process.args",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_args_count": {
-            "path_match": "process.args_count",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_digest_algorithm": {
-            "path_match": "process.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_exists": {
-            "path_match": "process.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_flags": {
-            "path_match": "process.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_signing_id": {
-            "path_match": "process.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_status": {
-            "path_match": "process.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_subject_name": {
-            "path_match": "process.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_team_id": {
-            "path_match": "process.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_thumbprint_sha256": {
-            "path_match": "process.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_timestamp": {
-            "path_match": "process.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_trusted": {
-            "path_match": "process.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_code_signature_valid": {
-            "path_match": "process.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_command_line": {
-            "path_match": "process.command_line",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_architecture": {
-            "path_match": "process.elf.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_byte_order": {
-            "path_match": "process.elf.byte_order",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_cpu_type": {
-            "path_match": "process.elf.cpu_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_creation_date": {
-            "path_match": "process.elf.creation_date",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_exports": {
-            "path_match": "process.elf.exports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_go_import_hash": {
-            "path_match": "process.elf.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_go_imports": {
-            "path_match": "process.elf.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_go_imports_names_entropy": {
-            "path_match": "process.elf.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_go_imports_names_var_entropy": {
-            "path_match": "process.elf.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_go_stripped": {
-            "path_match": "process.elf.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_abi_version": {
-            "path_match": "process.elf.header.abi_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_class": {
-            "path_match": "process.elf.header.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_data": {
-            "path_match": "process.elf.header.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_entrypoint": {
-            "path_match": "process.elf.header.entrypoint",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_object_version": {
-            "path_match": "process.elf.header.object_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_os_abi": {
-            "path_match": "process.elf.header.os_abi",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_type": {
-            "path_match": "process.elf.header.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_header_version": {
-            "path_match": "process.elf.header.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_import_hash": {
-            "path_match": "process.elf.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_imports": {
-            "path_match": "process.elf.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_imports_names_entropy": {
-            "path_match": "process.elf.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_imports_names_var_entropy": {
-            "path_match": "process.elf.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_chi2": {
-            "path_match": "process.elf.sections.chi2",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_entropy": {
-            "path_match": "process.elf.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_flags": {
-            "path_match": "process.elf.sections.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_name": {
-            "path_match": "process.elf.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_physical_offset": {
-            "path_match": "process.elf.sections.physical_offset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_physical_size": {
-            "path_match": "process.elf.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_type": {
-            "path_match": "process.elf.sections.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_var_entropy": {
-            "path_match": "process.elf.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_virtual_address": {
-            "path_match": "process.elf.sections.virtual_address",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_sections_virtual_size": {
-            "path_match": "process.elf.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_segments_sections": {
-            "path_match": "process.elf.segments.sections",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_segments_type": {
-            "path_match": "process.elf.segments.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_shared_libraries": {
-            "path_match": "process.elf.shared_libraries",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_elf_telfhash": {
-            "path_match": "process.elf.telfhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_end": {
-            "path_match": "process.end",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_entity_id": {
-            "path_match": "process.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_args": {
-            "path_match": "process.entry_leader.args",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_args_count": {
-            "path_match": "process.entry_leader.args_count",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_attested_groups_name": {
-            "path_match": "process.entry_leader.attested_groups.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_attested_user_id": {
-            "path_match": "process.entry_leader.attested_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_attested_user_name": {
-            "path_match": "process.entry_leader.attested_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_command_line": {
-            "path_match": "process.entry_leader.command_line",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_entity_id": {
-            "path_match": "process.entry_leader.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_entry_meta_source_ip": {
-            "path_match": "process.entry_leader.entry_meta.source.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_entry_meta_type": {
-            "path_match": "process.entry_leader.entry_meta.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_executable": {
-            "path_match": "process.entry_leader.executable",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_group_id": {
-            "path_match": "process.entry_leader.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_group_name": {
-            "path_match": "process.entry_leader.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_interactive": {
-            "path_match": "process.entry_leader.interactive",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_name": {
-            "path_match": "process.entry_leader.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_entity_id": {
-            "path_match": "process.entry_leader.parent.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_pid": {
-            "path_match": "process.entry_leader.parent.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_session_leader_entity_id": {
-            "path_match": "process.entry_leader.parent.session_leader.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_session_leader_pid": {
-            "path_match": "process.entry_leader.parent.session_leader.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_session_leader_start": {
-            "path_match": "process.entry_leader.parent.session_leader.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_session_leader_vpid": {
-            "path_match": "process.entry_leader.parent.session_leader.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_start": {
-            "path_match": "process.entry_leader.parent.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_parent_vpid": {
-            "path_match": "process.entry_leader.parent.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_pid": {
-            "path_match": "process.entry_leader.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_real_group_id": {
-            "path_match": "process.entry_leader.real_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_real_group_name": {
-            "path_match": "process.entry_leader.real_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_real_user_id": {
-            "path_match": "process.entry_leader.real_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_real_user_name": {
-            "path_match": "process.entry_leader.real_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_same_as_process": {
-            "path_match": "process.entry_leader.same_as_process",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_saved_group_id": {
-            "path_match": "process.entry_leader.saved_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_saved_group_name": {
-            "path_match": "process.entry_leader.saved_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_saved_user_id": {
-            "path_match": "process.entry_leader.saved_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_saved_user_name": {
-            "path_match": "process.entry_leader.saved_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_start": {
-            "path_match": "process.entry_leader.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_supplemental_groups_id": {
-            "path_match": "process.entry_leader.supplemental_groups.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_supplemental_groups_name": {
-            "path_match": "process.entry_leader.supplemental_groups.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_tty_char_device_major": {
-            "path_match": "process.entry_leader.tty.char_device.major",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_tty_char_device_minor": {
-            "path_match": "process.entry_leader.tty.char_device.minor",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_user_id": {
-            "path_match": "process.entry_leader.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_user_name": {
-            "path_match": "process.entry_leader.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_vpid": {
-            "path_match": "process.entry_leader.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_entry_leader_working_directory": {
-            "path_match": "process.entry_leader.working_directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_env_vars": {
-            "path_match": "process.env_vars",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_executable": {
-            "path_match": "process.executable",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_exit_code": {
-            "path_match": "process.exit_code",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_group_id": {
-            "path_match": "process.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_args": {
-            "path_match": "process.group_leader.args",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_args_count": {
-            "path_match": "process.group_leader.args_count",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_command_line": {
-            "path_match": "process.group_leader.command_line",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_entity_id": {
-            "path_match": "process.group_leader.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_executable": {
-            "path_match": "process.group_leader.executable",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_group_id": {
-            "path_match": "process.group_leader.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_group_name": {
-            "path_match": "process.group_leader.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_interactive": {
-            "path_match": "process.group_leader.interactive",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_name": {
-            "path_match": "process.group_leader.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_pid": {
-            "path_match": "process.group_leader.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_real_group_id": {
-            "path_match": "process.group_leader.real_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_real_group_name": {
-            "path_match": "process.group_leader.real_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_real_user_id": {
-            "path_match": "process.group_leader.real_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_real_user_name": {
-            "path_match": "process.group_leader.real_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_same_as_process": {
-            "path_match": "process.group_leader.same_as_process",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_saved_group_id": {
-            "path_match": "process.group_leader.saved_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_saved_group_name": {
-            "path_match": "process.group_leader.saved_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_saved_user_id": {
-            "path_match": "process.group_leader.saved_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_saved_user_name": {
-            "path_match": "process.group_leader.saved_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_start": {
-            "path_match": "process.group_leader.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_supplemental_groups_id": {
-            "path_match": "process.group_leader.supplemental_groups.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_supplemental_groups_name": {
-            "path_match": "process.group_leader.supplemental_groups.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_tty_char_device_major": {
-            "path_match": "process.group_leader.tty.char_device.major",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_tty_char_device_minor": {
-            "path_match": "process.group_leader.tty.char_device.minor",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_user_id": {
-            "path_match": "process.group_leader.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_user_name": {
-            "path_match": "process.group_leader.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_vpid": {
-            "path_match": "process.group_leader.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_group_leader_working_directory": {
-            "path_match": "process.group_leader.working_directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_group_name": {
-            "path_match": "process.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_cdhash": {
-            "path_match": "process.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_md5": {
-            "path_match": "process.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_sha1": {
-            "path_match": "process.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_sha256": {
-            "path_match": "process.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_sha384": {
-            "path_match": "process.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_sha512": {
-            "path_match": "process.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_ssdeep": {
-            "path_match": "process.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_hash_tlsh": {
-            "path_match": "process.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_interactive": {
-            "path_match": "process.interactive",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_io_bytes_skipped_length": {
-            "path_match": "process.io.bytes_skipped.length",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_io_bytes_skipped_offset": {
-            "path_match": "process.io.bytes_skipped.offset",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_io_max_bytes_per_process_exceeded": {
-            "path_match": "process.io.max_bytes_per_process_exceeded",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_io_text": {
-            "path_match": "process.io.text",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_io_total_bytes_captured": {
-            "path_match": "process.io.total_bytes_captured",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_io_total_bytes_skipped": {
-            "path_match": "process.io.total_bytes_skipped",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_io_type": {
-            "path_match": "process.io.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_go_import_hash": {
-            "path_match": "process.macho.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_go_imports": {
-            "path_match": "process.macho.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_go_imports_names_entropy": {
-            "path_match": "process.macho.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_go_imports_names_var_entropy": {
-            "path_match": "process.macho.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_go_stripped": {
-            "path_match": "process.macho.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_import_hash": {
-            "path_match": "process.macho.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_imports": {
-            "path_match": "process.macho.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_imports_names_entropy": {
-            "path_match": "process.macho.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_imports_names_var_entropy": {
-            "path_match": "process.macho.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_sections_entropy": {
-            "path_match": "process.macho.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_sections_name": {
-            "path_match": "process.macho.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_sections_physical_size": {
-            "path_match": "process.macho.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_sections_var_entropy": {
-            "path_match": "process.macho.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_sections_virtual_size": {
-            "path_match": "process.macho.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_macho_symhash": {
-            "path_match": "process.macho.symhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_name": {
-            "path_match": "process.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_args": {
-            "path_match": "process.parent.args",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_args_count": {
-            "path_match": "process.parent.args_count",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_digest_algorithm": {
-            "path_match": "process.parent.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_exists": {
-            "path_match": "process.parent.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_flags": {
-            "path_match": "process.parent.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_signing_id": {
-            "path_match": "process.parent.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_status": {
-            "path_match": "process.parent.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_subject_name": {
-            "path_match": "process.parent.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_team_id": {
-            "path_match": "process.parent.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_thumbprint_sha256": {
-            "path_match": "process.parent.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_timestamp": {
-            "path_match": "process.parent.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_trusted": {
-            "path_match": "process.parent.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_code_signature_valid": {
-            "path_match": "process.parent.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_command_line": {
-            "path_match": "process.parent.command_line",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_architecture": {
-            "path_match": "process.parent.elf.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_byte_order": {
-            "path_match": "process.parent.elf.byte_order",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_cpu_type": {
-            "path_match": "process.parent.elf.cpu_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_creation_date": {
-            "path_match": "process.parent.elf.creation_date",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_exports": {
-            "path_match": "process.parent.elf.exports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_go_import_hash": {
-            "path_match": "process.parent.elf.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_go_imports": {
-            "path_match": "process.parent.elf.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_go_imports_names_entropy": {
-            "path_match": "process.parent.elf.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_go_imports_names_var_entropy": {
-            "path_match": "process.parent.elf.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_go_stripped": {
-            "path_match": "process.parent.elf.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_abi_version": {
-            "path_match": "process.parent.elf.header.abi_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_class": {
-            "path_match": "process.parent.elf.header.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_data": {
-            "path_match": "process.parent.elf.header.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_entrypoint": {
-            "path_match": "process.parent.elf.header.entrypoint",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_object_version": {
-            "path_match": "process.parent.elf.header.object_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_os_abi": {
-            "path_match": "process.parent.elf.header.os_abi",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_type": {
-            "path_match": "process.parent.elf.header.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_header_version": {
-            "path_match": "process.parent.elf.header.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_import_hash": {
-            "path_match": "process.parent.elf.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_imports": {
-            "path_match": "process.parent.elf.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_imports_names_entropy": {
-            "path_match": "process.parent.elf.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_imports_names_var_entropy": {
-            "path_match": "process.parent.elf.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_chi2": {
-            "path_match": "process.parent.elf.sections.chi2",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_entropy": {
-            "path_match": "process.parent.elf.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_flags": {
-            "path_match": "process.parent.elf.sections.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_name": {
-            "path_match": "process.parent.elf.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_physical_offset": {
-            "path_match": "process.parent.elf.sections.physical_offset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_physical_size": {
-            "path_match": "process.parent.elf.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_type": {
-            "path_match": "process.parent.elf.sections.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_var_entropy": {
-            "path_match": "process.parent.elf.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_virtual_address": {
-            "path_match": "process.parent.elf.sections.virtual_address",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_sections_virtual_size": {
-            "path_match": "process.parent.elf.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_segments_sections": {
-            "path_match": "process.parent.elf.segments.sections",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_segments_type": {
-            "path_match": "process.parent.elf.segments.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_shared_libraries": {
-            "path_match": "process.parent.elf.shared_libraries",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_elf_telfhash": {
-            "path_match": "process.parent.elf.telfhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_end": {
-            "path_match": "process.parent.end",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_entity_id": {
-            "path_match": "process.parent.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_executable": {
-            "path_match": "process.parent.executable",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_exit_code": {
-            "path_match": "process.parent.exit_code",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_group_id": {
-            "path_match": "process.parent.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_group_leader_entity_id": {
-            "path_match": "process.parent.group_leader.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_group_leader_pid": {
-            "path_match": "process.parent.group_leader.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_group_leader_start": {
-            "path_match": "process.parent.group_leader.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_group_leader_vpid": {
-            "path_match": "process.parent.group_leader.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_group_name": {
-            "path_match": "process.parent.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_cdhash": {
-            "path_match": "process.parent.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_md5": {
-            "path_match": "process.parent.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_sha1": {
-            "path_match": "process.parent.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_sha256": {
-            "path_match": "process.parent.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_sha384": {
-            "path_match": "process.parent.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_sha512": {
-            "path_match": "process.parent.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_ssdeep": {
-            "path_match": "process.parent.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_hash_tlsh": {
-            "path_match": "process.parent.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_interactive": {
-            "path_match": "process.parent.interactive",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_go_import_hash": {
-            "path_match": "process.parent.macho.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_go_imports": {
-            "path_match": "process.parent.macho.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_go_imports_names_entropy": {
-            "path_match": "process.parent.macho.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_go_imports_names_var_entropy": {
-            "path_match": "process.parent.macho.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_go_stripped": {
-            "path_match": "process.parent.macho.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_import_hash": {
-            "path_match": "process.parent.macho.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_imports": {
-            "path_match": "process.parent.macho.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_imports_names_entropy": {
-            "path_match": "process.parent.macho.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_imports_names_var_entropy": {
-            "path_match": "process.parent.macho.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_sections_entropy": {
-            "path_match": "process.parent.macho.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_sections_name": {
-            "path_match": "process.parent.macho.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_sections_physical_size": {
-            "path_match": "process.parent.macho.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_sections_var_entropy": {
-            "path_match": "process.parent.macho.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_sections_virtual_size": {
-            "path_match": "process.parent.macho.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_macho_symhash": {
-            "path_match": "process.parent.macho.symhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_name": {
-            "path_match": "process.parent.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_architecture": {
-            "path_match": "process.parent.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_company": {
-            "path_match": "process.parent.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_description": {
-            "path_match": "process.parent.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_file_version": {
-            "path_match": "process.parent.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_go_import_hash": {
-            "path_match": "process.parent.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_go_imports": {
-            "path_match": "process.parent.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_go_imports_names_entropy": {
-            "path_match": "process.parent.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_go_imports_names_var_entropy": {
-            "path_match": "process.parent.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_go_stripped": {
-            "path_match": "process.parent.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_imphash": {
-            "path_match": "process.parent.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_import_hash": {
-            "path_match": "process.parent.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_imports": {
-            "path_match": "process.parent.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_imports_names_entropy": {
-            "path_match": "process.parent.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_imports_names_var_entropy": {
-            "path_match": "process.parent.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_original_file_name": {
-            "path_match": "process.parent.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_pehash": {
-            "path_match": "process.parent.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_product": {
-            "path_match": "process.parent.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_sections_entropy": {
-            "path_match": "process.parent.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_sections_name": {
-            "path_match": "process.parent.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_sections_physical_size": {
-            "path_match": "process.parent.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_sections_var_entropy": {
-            "path_match": "process.parent.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pe_sections_virtual_size": {
-            "path_match": "process.parent.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_pid": {
-            "path_match": "process.parent.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_real_group_id": {
-            "path_match": "process.parent.real_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_real_group_name": {
-            "path_match": "process.parent.real_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_real_user_id": {
-            "path_match": "process.parent.real_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_real_user_name": {
-            "path_match": "process.parent.real_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_saved_group_id": {
-            "path_match": "process.parent.saved_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_saved_group_name": {
-            "path_match": "process.parent.saved_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_saved_user_id": {
-            "path_match": "process.parent.saved_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_saved_user_name": {
-            "path_match": "process.parent.saved_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_start": {
-            "path_match": "process.parent.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_supplemental_groups_id": {
-            "path_match": "process.parent.supplemental_groups.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_supplemental_groups_name": {
-            "path_match": "process.parent.supplemental_groups.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_thread_capabilities_effective": {
-            "path_match": "process.parent.thread.capabilities.effective",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_thread_capabilities_permitted": {
-            "path_match": "process.parent.thread.capabilities.permitted",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_thread_id": {
-            "path_match": "process.parent.thread.id",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_thread_name": {
-            "path_match": "process.parent.thread.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_title": {
-            "path_match": "process.parent.title",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_tty_char_device_major": {
-            "path_match": "process.parent.tty.char_device.major",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_tty_char_device_minor": {
-            "path_match": "process.parent.tty.char_device.minor",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_uptime": {
-            "path_match": "process.parent.uptime",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_user_id": {
-            "path_match": "process.parent.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_user_name": {
-            "path_match": "process.parent.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_vpid": {
-            "path_match": "process.parent.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_parent_working_directory": {
-            "path_match": "process.parent.working_directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_architecture": {
-            "path_match": "process.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_company": {
-            "path_match": "process.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_description": {
-            "path_match": "process.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_file_version": {
-            "path_match": "process.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_go_import_hash": {
-            "path_match": "process.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_go_imports": {
-            "path_match": "process.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_go_imports_names_entropy": {
-            "path_match": "process.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_go_imports_names_var_entropy": {
-            "path_match": "process.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_go_stripped": {
-            "path_match": "process.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_imphash": {
-            "path_match": "process.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_import_hash": {
-            "path_match": "process.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_imports": {
-            "path_match": "process.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_imports_names_entropy": {
-            "path_match": "process.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_imports_names_var_entropy": {
-            "path_match": "process.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_original_file_name": {
-            "path_match": "process.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_pehash": {
-            "path_match": "process.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_product": {
-            "path_match": "process.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_sections_entropy": {
-            "path_match": "process.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_sections_name": {
-            "path_match": "process.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_sections_physical_size": {
-            "path_match": "process.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_sections_var_entropy": {
-            "path_match": "process.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pe_sections_virtual_size": {
-            "path_match": "process.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_pid": {
-            "path_match": "process.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_args": {
-            "path_match": "process.previous.args",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_args_count": {
-            "path_match": "process.previous.args_count",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_command_line": {
-            "path_match": "process.previous.command_line",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_executable": {
-            "path_match": "process.previous.executable",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_name": {
-            "path_match": "process.previous.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_parent_pid": {
-            "path_match": "process.previous.parent.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_pid": {
-            "path_match": "process.previous.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_previous_state": {
-            "path_match": "process.previous.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_real_group_id": {
-            "path_match": "process.real_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_real_group_name": {
-            "path_match": "process.real_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_real_user_id": {
-            "path_match": "process.real_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_real_user_name": {
-            "path_match": "process.real_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_saved_group_id": {
-            "path_match": "process.saved_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_saved_group_name": {
-            "path_match": "process.saved_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_saved_user_id": {
-            "path_match": "process.saved_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_saved_user_name": {
-            "path_match": "process.saved_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_args": {
-            "path_match": "process.session_leader.args",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_args_count": {
-            "path_match": "process.session_leader.args_count",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_command_line": {
-            "path_match": "process.session_leader.command_line",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_entity_id": {
-            "path_match": "process.session_leader.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_executable": {
-            "path_match": "process.session_leader.executable",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_group_id": {
-            "path_match": "process.session_leader.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_group_name": {
-            "path_match": "process.session_leader.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_interactive": {
-            "path_match": "process.session_leader.interactive",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_name": {
-            "path_match": "process.session_leader.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_entity_id": {
-            "path_match": "process.session_leader.parent.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_pid": {
-            "path_match": "process.session_leader.parent.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_session_leader_entity_id": {
-            "path_match": "process.session_leader.parent.session_leader.entity_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_session_leader_pid": {
-            "path_match": "process.session_leader.parent.session_leader.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_session_leader_start": {
-            "path_match": "process.session_leader.parent.session_leader.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_session_leader_vpid": {
-            "path_match": "process.session_leader.parent.session_leader.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_start": {
-            "path_match": "process.session_leader.parent.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_parent_vpid": {
-            "path_match": "process.session_leader.parent.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_pid": {
-            "path_match": "process.session_leader.pid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_real_group_id": {
-            "path_match": "process.session_leader.real_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_real_group_name": {
-            "path_match": "process.session_leader.real_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_real_user_id": {
-            "path_match": "process.session_leader.real_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_real_user_name": {
-            "path_match": "process.session_leader.real_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_same_as_process": {
-            "path_match": "process.session_leader.same_as_process",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_saved_group_id": {
-            "path_match": "process.session_leader.saved_group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_saved_group_name": {
-            "path_match": "process.session_leader.saved_group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_saved_user_id": {
-            "path_match": "process.session_leader.saved_user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_saved_user_name": {
-            "path_match": "process.session_leader.saved_user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_start": {
-            "path_match": "process.session_leader.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_supplemental_groups_id": {
-            "path_match": "process.session_leader.supplemental_groups.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_supplemental_groups_name": {
-            "path_match": "process.session_leader.supplemental_groups.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_tty_char_device_major": {
-            "path_match": "process.session_leader.tty.char_device.major",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_tty_char_device_minor": {
-            "path_match": "process.session_leader.tty.char_device.minor",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_user_id": {
-            "path_match": "process.session_leader.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_user_name": {
-            "path_match": "process.session_leader.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_vpid": {
-            "path_match": "process.session_leader.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_session_leader_working_directory": {
-            "path_match": "process.session_leader.working_directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_start": {
-            "path_match": "process.start",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_process_state": {
-            "path_match": "process.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_supplemental_groups_id": {
-            "path_match": "process.supplemental_groups.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_supplemental_groups_name": {
-            "path_match": "process.supplemental_groups.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_thread_capabilities_effective": {
-            "path_match": "process.thread.capabilities.effective",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_thread_capabilities_permitted": {
-            "path_match": "process.thread.capabilities.permitted",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_thread_id": {
-            "path_match": "process.thread.id",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_thread_name": {
-            "path_match": "process.thread.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_title": {
-            "path_match": "process.title",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_tty_char_device_major": {
-            "path_match": "process.tty.char_device.major",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_tty_char_device_minor": {
-            "path_match": "process.tty.char_device.minor",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_tty_columns": {
-            "path_match": "process.tty.columns",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_tty_rows": {
-            "path_match": "process.tty.rows",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_uptime": {
-            "path_match": "process.uptime",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_user_id": {
-            "path_match": "process.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_user_name": {
-            "path_match": "process.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_process_vpid": {
-            "path_match": "process.vpid",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_process_working_directory": {
-            "path_match": "process.working_directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_registry_data_bytes": {
-            "path_match": "registry.data.bytes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_registry_data_strings": {
-            "path_match": "registry.data.strings",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_registry_data_type": {
-            "path_match": "registry.data.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_registry_hive": {
-            "path_match": "registry.hive",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_registry_key": {
-            "path_match": "registry.key",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_registry_path": {
-            "path_match": "registry.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_registry_value": {
-            "path_match": "registry.value",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_related_hash": {
-            "path_match": "related.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_related_hosts": {
-            "path_match": "related.hosts",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_related_ip": {
-            "path_match": "related.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_related_user": {
-            "path_match": "related.user",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_author": {
-            "path_match": "rule.author",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_category": {
-            "path_match": "rule.category",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_cmmc": {
-            "path_match": "rule.compliance.cmmc",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_fedramp": {
-            "path_match": "rule.compliance.fedramp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_gdpr": {
-            "path_match": "rule.compliance.gdpr",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_hipaa": {
-            "path_match": "rule.compliance.hipaa",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_iso_27001": {
-            "path_match": "rule.compliance.iso_27001",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_nis2": {
-            "path_match": "rule.compliance.nis2",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_nist_800_171": {
-            "path_match": "rule.compliance.nist_800_171",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_nist_800_53": {
-            "path_match": "rule.compliance.nist_800_53",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_pci_dss": {
-            "path_match": "rule.compliance.pci_dss",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_compliance_tsc": {
-            "path_match": "rule.compliance.tsc",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_description": {
-            "path_match": "rule.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_id": {
-            "path_match": "rule.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_level": {
-            "path_match": "rule.level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_license": {
-            "path_match": "rule.license",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_mitre_subtechnique_id": {
-            "path_match": "rule.mitre.subtechnique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_mitre_subtechnique_name": {
-            "path_match": "rule.mitre.subtechnique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_mitre_tactic_id": {
-            "path_match": "rule.mitre.tactic.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_mitre_tactic_name": {
-            "path_match": "rule.mitre.tactic.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_mitre_technique_id": {
-            "path_match": "rule.mitre.technique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_mitre_technique_name": {
-            "path_match": "rule.mitre.technique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_name": {
-            "path_match": "rule.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_reference": {
-            "path_match": "rule.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_ruleset": {
-            "path_match": "rule.ruleset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_sigma_id": {
-            "path_match": "rule.sigma_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_status": {
-            "path_match": "rule.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_tags": {
-            "path_match": "rule.tags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_title": {
-            "path_match": "rule.title",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_uuid": {
-            "path_match": "rule.uuid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_rule_version": {
-            "path_match": "rule.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_address": {
-            "path_match": "server.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_as_number": {
-            "path_match": "server.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_server_as_organization_name": {
-            "path_match": "server.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_bytes": {
-            "path_match": "server.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_server_domain": {
-            "path_match": "server.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_city_name": {
-            "path_match": "server.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_continent_code": {
-            "path_match": "server.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_continent_name": {
-            "path_match": "server.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_country_iso_code": {
-            "path_match": "server.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_country_name": {
-            "path_match": "server.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_location": {
-            "path_match": "server.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_name": {
-            "path_match": "server.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_postal_code": {
-            "path_match": "server.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_region_iso_code": {
-            "path_match": "server.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_region_name": {
-            "path_match": "server.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_geo_timezone": {
-            "path_match": "server.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_ip": {
-            "path_match": "server.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_server_mac": {
-            "path_match": "server.mac",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_nat_ip": {
-            "path_match": "server.nat.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_server_nat_port": {
-            "path_match": "server.nat.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_server_packets": {
-            "path_match": "server.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_server_port": {
-            "path_match": "server.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_server_registered_domain": {
-            "path_match": "server.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_subdomain": {
-            "path_match": "server.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_top_level_domain": {
-            "path_match": "server.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_domain": {
-            "path_match": "server.user.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_email": {
-            "path_match": "server.user.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_full_name": {
-            "path_match": "server.user.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_group_domain": {
-            "path_match": "server.user.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_group_id": {
-            "path_match": "server.user.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_group_name": {
-            "path_match": "server.user.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_hash": {
-            "path_match": "server.user.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_id": {
-            "path_match": "server.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_name": {
-            "path_match": "server.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_server_user_roles": {
-            "path_match": "server.user.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_address": {
-            "path_match": "service.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_environment": {
-            "path_match": "service.environment",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_ephemeral_id": {
-            "path_match": "service.ephemeral_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_id": {
-            "path_match": "service.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_name": {
-            "path_match": "service.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_node_name": {
-            "path_match": "service.node.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_node_role": {
-            "path_match": "service.node.role",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_node_roles": {
-            "path_match": "service.node.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_address": {
-            "path_match": "service.origin.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_environment": {
-            "path_match": "service.origin.environment",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_ephemeral_id": {
-            "path_match": "service.origin.ephemeral_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_id": {
-            "path_match": "service.origin.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_name": {
-            "path_match": "service.origin.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_node_name": {
-            "path_match": "service.origin.node.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_node_role": {
-            "path_match": "service.origin.node.role",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_node_roles": {
-            "path_match": "service.origin.node.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_previous_state": {
-            "path_match": "service.origin.previous.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_state": {
-            "path_match": "service.origin.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_type": {
-            "path_match": "service.origin.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_origin_version": {
-            "path_match": "service.origin.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_previous_state": {
-            "path_match": "service.previous.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_state": {
-            "path_match": "service.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_address": {
-            "path_match": "service.target.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_environment": {
-            "path_match": "service.target.environment",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_ephemeral_id": {
-            "path_match": "service.target.ephemeral_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_id": {
-            "path_match": "service.target.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_name": {
-            "path_match": "service.target.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_node_name": {
-            "path_match": "service.target.node.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_node_role": {
-            "path_match": "service.target.node.role",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_node_roles": {
-            "path_match": "service.target.node.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_previous_state": {
-            "path_match": "service.target.previous.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_state": {
-            "path_match": "service.target.state",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_type": {
-            "path_match": "service.target.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_target_version": {
-            "path_match": "service.target.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_type": {
-            "path_match": "service.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_service_version": {
-            "path_match": "service.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_address": {
-            "path_match": "source.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_as_number": {
-            "path_match": "source.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_source_as_organization_name": {
-            "path_match": "source.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_bytes": {
-            "path_match": "source.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_source_domain": {
-            "path_match": "source.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_city_name": {
-            "path_match": "source.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_continent_code": {
-            "path_match": "source.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_continent_name": {
-            "path_match": "source.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_country_iso_code": {
-            "path_match": "source.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_country_name": {
-            "path_match": "source.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_location": {
-            "path_match": "source.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_name": {
-            "path_match": "source.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_postal_code": {
-            "path_match": "source.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_region_iso_code": {
-            "path_match": "source.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_region_name": {
-            "path_match": "source.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_geo_timezone": {
-            "path_match": "source.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_ip": {
-            "path_match": "source.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_source_mac": {
-            "path_match": "source.mac",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_nat_ip": {
-            "path_match": "source.nat.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_source_nat_port": {
-            "path_match": "source.nat.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_source_packets": {
-            "path_match": "source.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_source_port": {
-            "path_match": "source.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_source_registered_domain": {
-            "path_match": "source.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_subdomain": {
-            "path_match": "source.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_top_level_domain": {
-            "path_match": "source.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_domain": {
-            "path_match": "source.user.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_email": {
-            "path_match": "source.user.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_full_name": {
-            "path_match": "source.user.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_group_domain": {
-            "path_match": "source.user.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_group_id": {
-            "path_match": "source.user.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_group_name": {
-            "path_match": "source.user.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_hash": {
-            "path_match": "source.user.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_id": {
-            "path_match": "source.user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_name": {
-            "path_match": "source.user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_source_user_roles": {
-            "path_match": "source.user.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_span_id": {
-            "path_match": "span.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_as_number": {
-            "path_match": "threat.enrichments.indicator.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_as_organization_name": {
-            "path_match": "threat.enrichments.indicator.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_confidence": {
-            "path_match": "threat.enrichments.indicator.confidence",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_description": {
-            "path_match": "threat.enrichments.indicator.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_email_address": {
-            "path_match": "threat.enrichments.indicator.email.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_feed_name": {
-            "path_match": "threat.enrichments.indicator.feed.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_accessed": {
-            "path_match": "threat.enrichments.indicator.file.accessed",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_attributes": {
-            "path_match": "threat.enrichments.indicator.file.attributes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_digest_algorithm": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_exists": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_flags": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_signing_id": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_status": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_subject_name": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_team_id": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_thumbprint_sha256": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_timestamp": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_trusted": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_code_signature_valid": {
-            "path_match": "threat.enrichments.indicator.file.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_created": {
-            "path_match": "threat.enrichments.indicator.file.created",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_ctime": {
-            "path_match": "threat.enrichments.indicator.file.ctime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_device": {
-            "path_match": "threat.enrichments.indicator.file.device",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_directory": {
-            "path_match": "threat.enrichments.indicator.file.directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_drive_letter": {
-            "path_match": "threat.enrichments.indicator.file.drive_letter",
-            "mapping": {
-              "ignore_above": 1,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_architecture": {
-            "path_match": "threat.enrichments.indicator.file.elf.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_byte_order": {
-            "path_match": "threat.enrichments.indicator.file.elf.byte_order",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_cpu_type": {
-            "path_match": "threat.enrichments.indicator.file.elf.cpu_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_creation_date": {
-            "path_match": "threat.enrichments.indicator.file.elf.creation_date",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_exports": {
-            "path_match": "threat.enrichments.indicator.file.elf.exports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_go_import_hash": {
-            "path_match": "threat.enrichments.indicator.file.elf.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_go_imports": {
-            "path_match": "threat.enrichments.indicator.file.elf.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_go_imports_names_entropy": {
-            "path_match": "threat.enrichments.indicator.file.elf.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_go_imports_names_var_entropy": {
-            "path_match": "threat.enrichments.indicator.file.elf.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_go_stripped": {
-            "path_match": "threat.enrichments.indicator.file.elf.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_abi_version": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.abi_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_class": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_data": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_entrypoint": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.entrypoint",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_object_version": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.object_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_os_abi": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.os_abi",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_type": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_header_version": {
-            "path_match": "threat.enrichments.indicator.file.elf.header.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_import_hash": {
-            "path_match": "threat.enrichments.indicator.file.elf.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_imports": {
-            "path_match": "threat.enrichments.indicator.file.elf.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_imports_names_entropy": {
-            "path_match": "threat.enrichments.indicator.file.elf.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_imports_names_var_entropy": {
-            "path_match": "threat.enrichments.indicator.file.elf.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_chi2": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.chi2",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_entropy": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_flags": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_name": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_physical_offset": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.physical_offset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_physical_size": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_type": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_var_entropy": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_virtual_address": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.virtual_address",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_sections_virtual_size": {
-            "path_match": "threat.enrichments.indicator.file.elf.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_segments_sections": {
-            "path_match": "threat.enrichments.indicator.file.elf.segments.sections",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_segments_type": {
-            "path_match": "threat.enrichments.indicator.file.elf.segments.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_shared_libraries": {
-            "path_match": "threat.enrichments.indicator.file.elf.shared_libraries",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_elf_telfhash": {
-            "path_match": "threat.enrichments.indicator.file.elf.telfhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_extension": {
-            "path_match": "threat.enrichments.indicator.file.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_fork_name": {
-            "path_match": "threat.enrichments.indicator.file.fork_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_gid": {
-            "path_match": "threat.enrichments.indicator.file.gid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_group": {
-            "path_match": "threat.enrichments.indicator.file.group",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_cdhash": {
-            "path_match": "threat.enrichments.indicator.file.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_md5": {
-            "path_match": "threat.enrichments.indicator.file.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_sha1": {
-            "path_match": "threat.enrichments.indicator.file.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_sha256": {
-            "path_match": "threat.enrichments.indicator.file.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_sha384": {
-            "path_match": "threat.enrichments.indicator.file.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_sha512": {
-            "path_match": "threat.enrichments.indicator.file.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_ssdeep": {
-            "path_match": "threat.enrichments.indicator.file.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_hash_tlsh": {
-            "path_match": "threat.enrichments.indicator.file.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_inode": {
-            "path_match": "threat.enrichments.indicator.file.inode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_mime_type": {
-            "path_match": "threat.enrichments.indicator.file.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_mode": {
-            "path_match": "threat.enrichments.indicator.file.mode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_mtime": {
-            "path_match": "threat.enrichments.indicator.file.mtime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_name": {
-            "path_match": "threat.enrichments.indicator.file.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_origin_referrer_url": {
-            "path_match": "threat.enrichments.indicator.file.origin_referrer_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_origin_url": {
-            "path_match": "threat.enrichments.indicator.file.origin_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_owner": {
-            "path_match": "threat.enrichments.indicator.file.owner",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_path": {
-            "path_match": "threat.enrichments.indicator.file.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_architecture": {
-            "path_match": "threat.enrichments.indicator.file.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_company": {
-            "path_match": "threat.enrichments.indicator.file.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_description": {
-            "path_match": "threat.enrichments.indicator.file.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_file_version": {
-            "path_match": "threat.enrichments.indicator.file.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_go_import_hash": {
-            "path_match": "threat.enrichments.indicator.file.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_go_imports": {
-            "path_match": "threat.enrichments.indicator.file.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_go_imports_names_entropy": {
-            "path_match": "threat.enrichments.indicator.file.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_go_imports_names_var_entropy": {
-            "path_match": "threat.enrichments.indicator.file.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_go_stripped": {
-            "path_match": "threat.enrichments.indicator.file.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_imphash": {
-            "path_match": "threat.enrichments.indicator.file.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_import_hash": {
-            "path_match": "threat.enrichments.indicator.file.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_imports": {
-            "path_match": "threat.enrichments.indicator.file.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_imports_names_entropy": {
-            "path_match": "threat.enrichments.indicator.file.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_imports_names_var_entropy": {
-            "path_match": "threat.enrichments.indicator.file.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_original_file_name": {
-            "path_match": "threat.enrichments.indicator.file.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_pehash": {
-            "path_match": "threat.enrichments.indicator.file.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_product": {
-            "path_match": "threat.enrichments.indicator.file.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_sections_entropy": {
-            "path_match": "threat.enrichments.indicator.file.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_sections_name": {
-            "path_match": "threat.enrichments.indicator.file.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_sections_physical_size": {
-            "path_match": "threat.enrichments.indicator.file.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_sections_var_entropy": {
-            "path_match": "threat.enrichments.indicator.file.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_pe_sections_virtual_size": {
-            "path_match": "threat.enrichments.indicator.file.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_size": {
-            "path_match": "threat.enrichments.indicator.file.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_target_path": {
-            "path_match": "threat.enrichments.indicator.file.target_path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_type": {
-            "path_match": "threat.enrichments.indicator.file.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_uid": {
-            "path_match": "threat.enrichments.indicator.file.uid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_alternative_names": {
-            "path_match": "threat.enrichments.indicator.file.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_issuer_common_name": {
-            "path_match": "threat.enrichments.indicator.file.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_issuer_country": {
-            "path_match": "threat.enrichments.indicator.file.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_issuer_distinguished_name": {
-            "path_match": "threat.enrichments.indicator.file.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_issuer_locality": {
-            "path_match": "threat.enrichments.indicator.file.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_issuer_organization": {
-            "path_match": "threat.enrichments.indicator.file.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_issuer_organizational_unit": {
-            "path_match": "threat.enrichments.indicator.file.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_issuer_state_or_province": {
-            "path_match": "threat.enrichments.indicator.file.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_not_after": {
-            "path_match": "threat.enrichments.indicator.file.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_not_before": {
-            "path_match": "threat.enrichments.indicator.file.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_public_key_algorithm": {
-            "path_match": "threat.enrichments.indicator.file.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_public_key_curve": {
-            "path_match": "threat.enrichments.indicator.file.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_public_key_exponent": {
-            "path_match": "threat.enrichments.indicator.file.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_public_key_size": {
-            "path_match": "threat.enrichments.indicator.file.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_serial_number": {
-            "path_match": "threat.enrichments.indicator.file.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_signature_algorithm": {
-            "path_match": "threat.enrichments.indicator.file.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_subject_common_name": {
-            "path_match": "threat.enrichments.indicator.file.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_subject_country": {
-            "path_match": "threat.enrichments.indicator.file.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_subject_distinguished_name": {
-            "path_match": "threat.enrichments.indicator.file.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_subject_locality": {
-            "path_match": "threat.enrichments.indicator.file.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_subject_organization": {
-            "path_match": "threat.enrichments.indicator.file.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_subject_organizational_unit": {
-            "path_match": "threat.enrichments.indicator.file.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_subject_state_or_province": {
-            "path_match": "threat.enrichments.indicator.file.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_file_x509_version_number": {
-            "path_match": "threat.enrichments.indicator.file.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_first_seen": {
-            "path_match": "threat.enrichments.indicator.first_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_city_name": {
-            "path_match": "threat.enrichments.indicator.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_continent_code": {
-            "path_match": "threat.enrichments.indicator.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_continent_name": {
-            "path_match": "threat.enrichments.indicator.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_country_iso_code": {
-            "path_match": "threat.enrichments.indicator.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_country_name": {
-            "path_match": "threat.enrichments.indicator.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_location": {
-            "path_match": "threat.enrichments.indicator.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_name": {
-            "path_match": "threat.enrichments.indicator.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_postal_code": {
-            "path_match": "threat.enrichments.indicator.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_region_iso_code": {
-            "path_match": "threat.enrichments.indicator.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_region_name": {
-            "path_match": "threat.enrichments.indicator.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_geo_timezone": {
-            "path_match": "threat.enrichments.indicator.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_id": {
-            "path_match": "threat.enrichments.indicator.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_ip": {
-            "path_match": "threat.enrichments.indicator.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_last_seen": {
-            "path_match": "threat.enrichments.indicator.last_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_marking_tlp": {
-            "path_match": "threat.enrichments.indicator.marking.tlp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_marking_tlp_version": {
-            "path_match": "threat.enrichments.indicator.marking.tlp_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_modified_at": {
-            "path_match": "threat.enrichments.indicator.modified_at",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_name": {
-            "path_match": "threat.enrichments.indicator.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_port": {
-            "path_match": "threat.enrichments.indicator.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_provider": {
-            "path_match": "threat.enrichments.indicator.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_reference": {
-            "path_match": "threat.enrichments.indicator.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_registry_data_bytes": {
-            "path_match": "threat.enrichments.indicator.registry.data.bytes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_registry_data_strings": {
-            "path_match": "threat.enrichments.indicator.registry.data.strings",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_registry_data_type": {
-            "path_match": "threat.enrichments.indicator.registry.data.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_registry_hive": {
-            "path_match": "threat.enrichments.indicator.registry.hive",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_registry_key": {
-            "path_match": "threat.enrichments.indicator.registry.key",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_registry_path": {
-            "path_match": "threat.enrichments.indicator.registry.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_registry_value": {
-            "path_match": "threat.enrichments.indicator.registry.value",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_scanner_stats": {
-            "path_match": "threat.enrichments.indicator.scanner_stats",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_sightings": {
-            "path_match": "threat.enrichments.indicator.sightings",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_software_alias": {
-            "path_match": "threat.enrichments.indicator.software.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_software_name": {
-            "path_match": "threat.enrichments.indicator.software.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_software_type": {
-            "path_match": "threat.enrichments.indicator.software.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_tags": {
-            "path_match": "threat.enrichments.indicator.tags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_type": {
-            "path_match": "threat.enrichments.indicator.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_domain": {
-            "path_match": "threat.enrichments.indicator.url.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_extension": {
-            "path_match": "threat.enrichments.indicator.url.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_fragment": {
-            "path_match": "threat.enrichments.indicator.url.fragment",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_full": {
-            "path_match": "threat.enrichments.indicator.url.full",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_original": {
-            "path_match": "threat.enrichments.indicator.url.original",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_password": {
-            "path_match": "threat.enrichments.indicator.url.password",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_path": {
-            "path_match": "threat.enrichments.indicator.url.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_port": {
-            "path_match": "threat.enrichments.indicator.url.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_query": {
-            "path_match": "threat.enrichments.indicator.url.query",
-            "mapping": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_registered_domain": {
-            "path_match": "threat.enrichments.indicator.url.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_scheme": {
-            "path_match": "threat.enrichments.indicator.url.scheme",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_subdomain": {
-            "path_match": "threat.enrichments.indicator.url.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_top_level_domain": {
-            "path_match": "threat.enrichments.indicator.url.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_url_username": {
-            "path_match": "threat.enrichments.indicator.url.username",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_alternative_names": {
-            "path_match": "threat.enrichments.indicator.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_issuer_common_name": {
-            "path_match": "threat.enrichments.indicator.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_issuer_country": {
-            "path_match": "threat.enrichments.indicator.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_issuer_distinguished_name": {
-            "path_match": "threat.enrichments.indicator.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_issuer_locality": {
-            "path_match": "threat.enrichments.indicator.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_issuer_organization": {
-            "path_match": "threat.enrichments.indicator.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_issuer_organizational_unit": {
-            "path_match": "threat.enrichments.indicator.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_issuer_state_or_province": {
-            "path_match": "threat.enrichments.indicator.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_not_after": {
-            "path_match": "threat.enrichments.indicator.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_not_before": {
-            "path_match": "threat.enrichments.indicator.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_public_key_algorithm": {
-            "path_match": "threat.enrichments.indicator.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_public_key_curve": {
-            "path_match": "threat.enrichments.indicator.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_public_key_exponent": {
-            "path_match": "threat.enrichments.indicator.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_public_key_size": {
-            "path_match": "threat.enrichments.indicator.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_serial_number": {
-            "path_match": "threat.enrichments.indicator.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_signature_algorithm": {
-            "path_match": "threat.enrichments.indicator.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_subject_common_name": {
-            "path_match": "threat.enrichments.indicator.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_subject_country": {
-            "path_match": "threat.enrichments.indicator.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_subject_distinguished_name": {
-            "path_match": "threat.enrichments.indicator.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_subject_locality": {
-            "path_match": "threat.enrichments.indicator.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_subject_organization": {
-            "path_match": "threat.enrichments.indicator.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_subject_organizational_unit": {
-            "path_match": "threat.enrichments.indicator.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_subject_state_or_province": {
-            "path_match": "threat.enrichments.indicator.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_indicator_x509_version_number": {
-            "path_match": "threat.enrichments.indicator.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_matched_atomic": {
-            "path_match": "threat.enrichments.matched.atomic",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_matched_field": {
-            "path_match": "threat.enrichments.matched.field",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_matched_id": {
-            "path_match": "threat.enrichments.matched.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_matched_index": {
-            "path_match": "threat.enrichments.matched.index",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_matched_occurred": {
-            "path_match": "threat.enrichments.matched.occurred",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_enrichments_matched_type": {
-            "path_match": "threat.enrichments.matched.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_feed_dashboard_id": {
-            "path_match": "threat.feed.dashboard_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_feed_description": {
-            "path_match": "threat.feed.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_feed_name": {
-            "path_match": "threat.feed.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_feed_reference": {
-            "path_match": "threat.feed.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_framework": {
-            "path_match": "threat.framework",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_group_alias": {
-            "path_match": "threat.group.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_group_id": {
-            "path_match": "threat.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_group_name": {
-            "path_match": "threat.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_group_reference": {
-            "path_match": "threat.group.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_as_number": {
-            "path_match": "threat.indicator.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_as_organization_name": {
-            "path_match": "threat.indicator.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_confidence": {
-            "path_match": "threat.indicator.confidence",
-            "mapping": {
-              "type": "short"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_description": {
-            "path_match": "threat.indicator.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_email_address": {
-            "path_match": "threat.indicator.email.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_accessed": {
-            "path_match": "threat.indicator.file.accessed",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_attributes": {
-            "path_match": "threat.indicator.file.attributes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_digest_algorithm": {
-            "path_match": "threat.indicator.file.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_exists": {
-            "path_match": "threat.indicator.file.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_flags": {
-            "path_match": "threat.indicator.file.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_signing_id": {
-            "path_match": "threat.indicator.file.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_status": {
-            "path_match": "threat.indicator.file.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_subject_name": {
-            "path_match": "threat.indicator.file.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_team_id": {
-            "path_match": "threat.indicator.file.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_thumbprint_sha256": {
-            "path_match": "threat.indicator.file.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_timestamp": {
-            "path_match": "threat.indicator.file.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_trusted": {
-            "path_match": "threat.indicator.file.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_code_signature_valid": {
-            "path_match": "threat.indicator.file.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_created": {
-            "path_match": "threat.indicator.file.created",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_ctime": {
-            "path_match": "threat.indicator.file.ctime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_device": {
-            "path_match": "threat.indicator.file.device",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_directory": {
-            "path_match": "threat.indicator.file.directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_drive_letter": {
-            "path_match": "threat.indicator.file.drive_letter",
-            "mapping": {
-              "ignore_above": 1,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_architecture": {
-            "path_match": "threat.indicator.file.elf.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_byte_order": {
-            "path_match": "threat.indicator.file.elf.byte_order",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_cpu_type": {
-            "path_match": "threat.indicator.file.elf.cpu_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_creation_date": {
-            "path_match": "threat.indicator.file.elf.creation_date",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_exports": {
-            "path_match": "threat.indicator.file.elf.exports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_go_import_hash": {
-            "path_match": "threat.indicator.file.elf.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_go_imports": {
-            "path_match": "threat.indicator.file.elf.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_go_imports_names_entropy": {
-            "path_match": "threat.indicator.file.elf.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_go_imports_names_var_entropy": {
-            "path_match": "threat.indicator.file.elf.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_go_stripped": {
-            "path_match": "threat.indicator.file.elf.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_abi_version": {
-            "path_match": "threat.indicator.file.elf.header.abi_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_class": {
-            "path_match": "threat.indicator.file.elf.header.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_data": {
-            "path_match": "threat.indicator.file.elf.header.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_entrypoint": {
-            "path_match": "threat.indicator.file.elf.header.entrypoint",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_object_version": {
-            "path_match": "threat.indicator.file.elf.header.object_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_os_abi": {
-            "path_match": "threat.indicator.file.elf.header.os_abi",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_type": {
-            "path_match": "threat.indicator.file.elf.header.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_header_version": {
-            "path_match": "threat.indicator.file.elf.header.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_import_hash": {
-            "path_match": "threat.indicator.file.elf.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_imports": {
-            "path_match": "threat.indicator.file.elf.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_imports_names_entropy": {
-            "path_match": "threat.indicator.file.elf.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_imports_names_var_entropy": {
-            "path_match": "threat.indicator.file.elf.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_chi2": {
-            "path_match": "threat.indicator.file.elf.sections.chi2",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_entropy": {
-            "path_match": "threat.indicator.file.elf.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_flags": {
-            "path_match": "threat.indicator.file.elf.sections.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_name": {
-            "path_match": "threat.indicator.file.elf.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_physical_offset": {
-            "path_match": "threat.indicator.file.elf.sections.physical_offset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_physical_size": {
-            "path_match": "threat.indicator.file.elf.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_type": {
-            "path_match": "threat.indicator.file.elf.sections.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_var_entropy": {
-            "path_match": "threat.indicator.file.elf.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_virtual_address": {
-            "path_match": "threat.indicator.file.elf.sections.virtual_address",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_sections_virtual_size": {
-            "path_match": "threat.indicator.file.elf.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_segments_sections": {
-            "path_match": "threat.indicator.file.elf.segments.sections",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_segments_type": {
-            "path_match": "threat.indicator.file.elf.segments.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_shared_libraries": {
-            "path_match": "threat.indicator.file.elf.shared_libraries",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_elf_telfhash": {
-            "path_match": "threat.indicator.file.elf.telfhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_extension": {
-            "path_match": "threat.indicator.file.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_fork_name": {
-            "path_match": "threat.indicator.file.fork_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_gid": {
-            "path_match": "threat.indicator.file.gid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_group": {
-            "path_match": "threat.indicator.file.group",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_cdhash": {
-            "path_match": "threat.indicator.file.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_md5": {
-            "path_match": "threat.indicator.file.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_sha1": {
-            "path_match": "threat.indicator.file.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_sha256": {
-            "path_match": "threat.indicator.file.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_sha384": {
-            "path_match": "threat.indicator.file.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_sha512": {
-            "path_match": "threat.indicator.file.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_ssdeep": {
-            "path_match": "threat.indicator.file.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_hash_tlsh": {
-            "path_match": "threat.indicator.file.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_inode": {
-            "path_match": "threat.indicator.file.inode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_mime_type": {
-            "path_match": "threat.indicator.file.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_mode": {
-            "path_match": "threat.indicator.file.mode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_mtime": {
-            "path_match": "threat.indicator.file.mtime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_name": {
-            "path_match": "threat.indicator.file.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_origin_referrer_url": {
-            "path_match": "threat.indicator.file.origin_referrer_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_origin_url": {
-            "path_match": "threat.indicator.file.origin_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_owner": {
-            "path_match": "threat.indicator.file.owner",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_path": {
-            "path_match": "threat.indicator.file.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_architecture": {
-            "path_match": "threat.indicator.file.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_company": {
-            "path_match": "threat.indicator.file.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_description": {
-            "path_match": "threat.indicator.file.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_file_version": {
-            "path_match": "threat.indicator.file.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_go_import_hash": {
-            "path_match": "threat.indicator.file.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_go_imports": {
-            "path_match": "threat.indicator.file.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_go_imports_names_entropy": {
-            "path_match": "threat.indicator.file.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_go_imports_names_var_entropy": {
-            "path_match": "threat.indicator.file.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_go_stripped": {
-            "path_match": "threat.indicator.file.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_imphash": {
-            "path_match": "threat.indicator.file.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_import_hash": {
-            "path_match": "threat.indicator.file.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_imports": {
-            "path_match": "threat.indicator.file.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_imports_names_entropy": {
-            "path_match": "threat.indicator.file.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_imports_names_var_entropy": {
-            "path_match": "threat.indicator.file.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_original_file_name": {
-            "path_match": "threat.indicator.file.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_pehash": {
-            "path_match": "threat.indicator.file.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_product": {
-            "path_match": "threat.indicator.file.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_sections_entropy": {
-            "path_match": "threat.indicator.file.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_sections_name": {
-            "path_match": "threat.indicator.file.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_sections_physical_size": {
-            "path_match": "threat.indicator.file.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_sections_var_entropy": {
-            "path_match": "threat.indicator.file.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_pe_sections_virtual_size": {
-            "path_match": "threat.indicator.file.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_size": {
-            "path_match": "threat.indicator.file.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_target_path": {
-            "path_match": "threat.indicator.file.target_path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_type": {
-            "path_match": "threat.indicator.file.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_uid": {
-            "path_match": "threat.indicator.file.uid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_alternative_names": {
-            "path_match": "threat.indicator.file.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_issuer_common_name": {
-            "path_match": "threat.indicator.file.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_issuer_country": {
-            "path_match": "threat.indicator.file.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_issuer_distinguished_name": {
-            "path_match": "threat.indicator.file.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_issuer_locality": {
-            "path_match": "threat.indicator.file.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_issuer_organization": {
-            "path_match": "threat.indicator.file.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_issuer_organizational_unit": {
-            "path_match": "threat.indicator.file.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_issuer_state_or_province": {
-            "path_match": "threat.indicator.file.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_not_after": {
-            "path_match": "threat.indicator.file.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_not_before": {
-            "path_match": "threat.indicator.file.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_public_key_algorithm": {
-            "path_match": "threat.indicator.file.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_public_key_curve": {
-            "path_match": "threat.indicator.file.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_public_key_exponent": {
-            "path_match": "threat.indicator.file.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_public_key_size": {
-            "path_match": "threat.indicator.file.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_serial_number": {
-            "path_match": "threat.indicator.file.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_signature_algorithm": {
-            "path_match": "threat.indicator.file.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_subject_common_name": {
-            "path_match": "threat.indicator.file.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_subject_country": {
-            "path_match": "threat.indicator.file.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_subject_distinguished_name": {
-            "path_match": "threat.indicator.file.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_subject_locality": {
-            "path_match": "threat.indicator.file.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_subject_organization": {
-            "path_match": "threat.indicator.file.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_subject_organizational_unit": {
-            "path_match": "threat.indicator.file.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_subject_state_or_province": {
-            "path_match": "threat.indicator.file.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_file_x509_version_number": {
-            "path_match": "threat.indicator.file.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_first_seen": {
-            "path_match": "threat.indicator.first_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_city_name": {
-            "path_match": "threat.indicator.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_continent_code": {
-            "path_match": "threat.indicator.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_continent_name": {
-            "path_match": "threat.indicator.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_country_iso_code": {
-            "path_match": "threat.indicator.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_country_name": {
-            "path_match": "threat.indicator.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_location": {
-            "path_match": "threat.indicator.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_name": {
-            "path_match": "threat.indicator.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_postal_code": {
-            "path_match": "threat.indicator.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_region_iso_code": {
-            "path_match": "threat.indicator.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_region_name": {
-            "path_match": "threat.indicator.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_geo_timezone": {
-            "path_match": "threat.indicator.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_id": {
-            "path_match": "threat.indicator.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_ip": {
-            "path_match": "threat.indicator.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_last_seen": {
-            "path_match": "threat.indicator.last_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_marking_tlp": {
-            "path_match": "threat.indicator.marking.tlp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_marking_tlp_version": {
-            "path_match": "threat.indicator.marking.tlp_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_modified_at": {
-            "path_match": "threat.indicator.modified_at",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_name": {
-            "path_match": "threat.indicator.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_port": {
-            "path_match": "threat.indicator.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_provider": {
-            "path_match": "threat.indicator.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_reference": {
-            "path_match": "threat.indicator.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_registry_data_bytes": {
-            "path_match": "threat.indicator.registry.data.bytes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_registry_data_strings": {
-            "path_match": "threat.indicator.registry.data.strings",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_registry_data_type": {
-            "path_match": "threat.indicator.registry.data.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_registry_hive": {
-            "path_match": "threat.indicator.registry.hive",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_registry_key": {
-            "path_match": "threat.indicator.registry.key",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_registry_path": {
-            "path_match": "threat.indicator.registry.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_registry_value": {
-            "path_match": "threat.indicator.registry.value",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_scanner_stats": {
-            "path_match": "threat.indicator.scanner_stats",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_sightings": {
-            "path_match": "threat.indicator.sightings",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_type": {
-            "path_match": "threat.indicator.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_domain": {
-            "path_match": "threat.indicator.url.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_extension": {
-            "path_match": "threat.indicator.url.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_fragment": {
-            "path_match": "threat.indicator.url.fragment",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_full": {
-            "path_match": "threat.indicator.url.full",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_original": {
-            "path_match": "threat.indicator.url.original",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_password": {
-            "path_match": "threat.indicator.url.password",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_path": {
-            "path_match": "threat.indicator.url.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_port": {
-            "path_match": "threat.indicator.url.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_query": {
-            "path_match": "threat.indicator.url.query",
-            "mapping": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_registered_domain": {
-            "path_match": "threat.indicator.url.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_scheme": {
-            "path_match": "threat.indicator.url.scheme",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_subdomain": {
-            "path_match": "threat.indicator.url.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_top_level_domain": {
-            "path_match": "threat.indicator.url.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_url_username": {
-            "path_match": "threat.indicator.url.username",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_alternative_names": {
-            "path_match": "threat.indicator.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_issuer_common_name": {
-            "path_match": "threat.indicator.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_issuer_country": {
-            "path_match": "threat.indicator.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_issuer_distinguished_name": {
-            "path_match": "threat.indicator.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_issuer_locality": {
-            "path_match": "threat.indicator.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_issuer_organization": {
-            "path_match": "threat.indicator.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_issuer_organizational_unit": {
-            "path_match": "threat.indicator.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_issuer_state_or_province": {
-            "path_match": "threat.indicator.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_not_after": {
-            "path_match": "threat.indicator.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_not_before": {
-            "path_match": "threat.indicator.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_public_key_algorithm": {
-            "path_match": "threat.indicator.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_public_key_curve": {
-            "path_match": "threat.indicator.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_public_key_exponent": {
-            "path_match": "threat.indicator.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_public_key_size": {
-            "path_match": "threat.indicator.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_serial_number": {
-            "path_match": "threat.indicator.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_signature_algorithm": {
-            "path_match": "threat.indicator.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_subject_common_name": {
-            "path_match": "threat.indicator.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_subject_country": {
-            "path_match": "threat.indicator.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_subject_distinguished_name": {
-            "path_match": "threat.indicator.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_subject_locality": {
-            "path_match": "threat.indicator.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_subject_organization": {
-            "path_match": "threat.indicator.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_subject_organizational_unit": {
-            "path_match": "threat.indicator.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_subject_state_or_province": {
-            "path_match": "threat.indicator.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_indicator_x509_version_number": {
-            "path_match": "threat.indicator.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_software_alias": {
-            "path_match": "threat.software.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_software_id": {
-            "path_match": "threat.software.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_software_name": {
-            "path_match": "threat.software.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_software_platforms": {
-            "path_match": "threat.software.platforms",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_software_reference": {
-            "path_match": "threat.software.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_software_type": {
-            "path_match": "threat.software.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_tactic_id": {
-            "path_match": "threat.tactic.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_tactic_name": {
-            "path_match": "threat.tactic.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_tactic_reference": {
-            "path_match": "threat.tactic.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_technique_id": {
-            "path_match": "threat.technique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_technique_name": {
-            "path_match": "threat.technique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_technique_reference": {
-            "path_match": "threat.technique.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_technique_subtechnique_id": {
-            "path_match": "threat.technique.subtechnique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_technique_subtechnique_name": {
-            "path_match": "threat.technique.subtechnique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_threat_technique_subtechnique_reference": {
-            "path_match": "threat.technique.subtechnique.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_cipher": {
-            "path_match": "tls.cipher",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_certificate": {
-            "path_match": "tls.client.certificate",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_certificate_chain": {
-            "path_match": "tls.client.certificate_chain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_hash_md5": {
-            "path_match": "tls.client.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_hash_sha1": {
-            "path_match": "tls.client.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_hash_sha256": {
-            "path_match": "tls.client.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_issuer": {
-            "path_match": "tls.client.issuer",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_ja3": {
-            "path_match": "tls.client.ja3",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_not_after": {
-            "path_match": "tls.client.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_not_before": {
-            "path_match": "tls.client.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_server_name": {
-            "path_match": "tls.client.server_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_subject": {
-            "path_match": "tls.client.subject",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_supported_ciphers": {
-            "path_match": "tls.client.supported_ciphers",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_alternative_names": {
-            "path_match": "tls.client.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_issuer_common_name": {
-            "path_match": "tls.client.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_issuer_country": {
-            "path_match": "tls.client.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_issuer_distinguished_name": {
-            "path_match": "tls.client.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_issuer_locality": {
-            "path_match": "tls.client.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_issuer_organization": {
-            "path_match": "tls.client.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_issuer_organizational_unit": {
-            "path_match": "tls.client.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_issuer_state_or_province": {
-            "path_match": "tls.client.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_not_after": {
-            "path_match": "tls.client.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_not_before": {
-            "path_match": "tls.client.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_public_key_algorithm": {
-            "path_match": "tls.client.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_public_key_curve": {
-            "path_match": "tls.client.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_public_key_exponent": {
-            "path_match": "tls.client.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_public_key_size": {
-            "path_match": "tls.client.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_serial_number": {
-            "path_match": "tls.client.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_signature_algorithm": {
-            "path_match": "tls.client.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_subject_common_name": {
-            "path_match": "tls.client.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_subject_country": {
-            "path_match": "tls.client.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_subject_distinguished_name": {
-            "path_match": "tls.client.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_subject_locality": {
-            "path_match": "tls.client.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_subject_organization": {
-            "path_match": "tls.client.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_subject_organizational_unit": {
-            "path_match": "tls.client.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_subject_state_or_province": {
-            "path_match": "tls.client.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_client_x509_version_number": {
-            "path_match": "tls.client.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_curve": {
-            "path_match": "tls.curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_established": {
-            "path_match": "tls.established",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_tls_next_protocol": {
-            "path_match": "tls.next_protocol",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_resumed": {
-            "path_match": "tls.resumed",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_certificate": {
-            "path_match": "tls.server.certificate",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_certificate_chain": {
-            "path_match": "tls.server.certificate_chain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_hash_md5": {
-            "path_match": "tls.server.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_hash_sha1": {
-            "path_match": "tls.server.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_hash_sha256": {
-            "path_match": "tls.server.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_issuer": {
-            "path_match": "tls.server.issuer",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_ja3s": {
-            "path_match": "tls.server.ja3s",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_not_after": {
-            "path_match": "tls.server.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_not_before": {
-            "path_match": "tls.server.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_subject": {
-            "path_match": "tls.server.subject",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_alternative_names": {
-            "path_match": "tls.server.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_issuer_common_name": {
-            "path_match": "tls.server.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_issuer_country": {
-            "path_match": "tls.server.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_issuer_distinguished_name": {
-            "path_match": "tls.server.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_issuer_locality": {
-            "path_match": "tls.server.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_issuer_organization": {
-            "path_match": "tls.server.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_issuer_organizational_unit": {
-            "path_match": "tls.server.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_issuer_state_or_province": {
-            "path_match": "tls.server.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_not_after": {
-            "path_match": "tls.server.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_not_before": {
-            "path_match": "tls.server.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_public_key_algorithm": {
-            "path_match": "tls.server.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_public_key_curve": {
-            "path_match": "tls.server.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_public_key_exponent": {
-            "path_match": "tls.server.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_public_key_size": {
-            "path_match": "tls.server.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_serial_number": {
-            "path_match": "tls.server.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_signature_algorithm": {
-            "path_match": "tls.server.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_subject_common_name": {
-            "path_match": "tls.server.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_subject_country": {
-            "path_match": "tls.server.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_subject_distinguished_name": {
-            "path_match": "tls.server.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_subject_locality": {
-            "path_match": "tls.server.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_subject_organization": {
-            "path_match": "tls.server.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_subject_organizational_unit": {
-            "path_match": "tls.server.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_subject_state_or_province": {
-            "path_match": "tls.server.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_server_x509_version_number": {
-            "path_match": "tls.server.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_version": {
-            "path_match": "tls.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_tls_version_protocol": {
-            "path_match": "tls.version_protocol",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_trace_id": {
-            "path_match": "trace.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_transaction_id": {
-            "path_match": "transaction.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_domain": {
-            "path_match": "url.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_extension": {
-            "path_match": "url.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_fragment": {
-            "path_match": "url.fragment",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_full": {
-            "path_match": "url.full",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_original": {
-            "path_match": "url.original",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_password": {
-            "path_match": "url.password",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_path": {
-            "path_match": "url.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_port": {
-            "path_match": "url.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_url_query": {
-            "path_match": "url.query",
-            "mapping": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_registered_domain": {
-            "path_match": "url.registered_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_scheme": {
-            "path_match": "url.scheme",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_subdomain": {
-            "path_match": "url.subdomain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_top_level_domain": {
-            "path_match": "url.top_level_domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_url_username": {
-            "path_match": "url.username",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_device_name": {
-            "path_match": "user_agent.device.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_name": {
-            "path_match": "user_agent.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_original": {
-            "path_match": "user_agent.original",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_os_family": {
-            "path_match": "user_agent.os.family",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_os_full": {
-            "path_match": "user_agent.os.full",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_os_kernel": {
-            "path_match": "user_agent.os.kernel",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_os_name": {
-            "path_match": "user_agent.os.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_os_platform": {
-            "path_match": "user_agent.os.platform",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_os_type": {
-            "path_match": "user_agent.os.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_os_version": {
-            "path_match": "user_agent.os.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_agent_version": {
-            "path_match": "user_agent.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_domain": {
-            "path_match": "user.changes.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_email": {
-            "path_match": "user.changes.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_full_name": {
-            "path_match": "user.changes.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_group_domain": {
-            "path_match": "user.changes.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_group_id": {
-            "path_match": "user.changes.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_group_name": {
-            "path_match": "user.changes.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_hash": {
-            "path_match": "user.changes.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_id": {
-            "path_match": "user.changes.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_name": {
-            "path_match": "user.changes.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_changes_roles": {
-            "path_match": "user.changes.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_domain": {
-            "path_match": "user.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_domain": {
-            "path_match": "user.effective.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_email": {
-            "path_match": "user.effective.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_full_name": {
-            "path_match": "user.effective.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_group_domain": {
-            "path_match": "user.effective.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_group_id": {
-            "path_match": "user.effective.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_group_name": {
-            "path_match": "user.effective.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_hash": {
-            "path_match": "user.effective.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_id": {
-            "path_match": "user.effective.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_name": {
-            "path_match": "user.effective.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_effective_roles": {
-            "path_match": "user.effective.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_email": {
-            "path_match": "user.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_full_name": {
-            "path_match": "user.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_group_domain": {
-            "path_match": "user.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_group_id": {
-            "path_match": "user.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_group_name": {
-            "path_match": "user.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_hash": {
-            "path_match": "user.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_id": {
-            "path_match": "user.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_name": {
-            "path_match": "user.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_risk_calculated_level": {
-            "path_match": "user.risk.calculated_level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_risk_calculated_score": {
-            "path_match": "user.risk.calculated_score",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_user_risk_calculated_score_norm": {
-            "path_match": "user.risk.calculated_score_norm",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_user_risk_static_level": {
-            "path_match": "user.risk.static_level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_risk_static_score": {
-            "path_match": "user.risk.static_score",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_user_risk_static_score_norm": {
-            "path_match": "user.risk.static_score_norm",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_user_roles": {
-            "path_match": "user.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_domain": {
-            "path_match": "user.target.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_email": {
-            "path_match": "user.target.email",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_full_name": {
-            "path_match": "user.target.full_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_group_domain": {
-            "path_match": "user.target.group.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_group_id": {
-            "path_match": "user.target.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_group_name": {
-            "path_match": "user.target.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_hash": {
-            "path_match": "user.target.hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_id": {
-            "path_match": "user.target.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_name": {
-            "path_match": "user.target.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_user_target_roles": {
-            "path_match": "user.target.roles",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_bus_type": {
-            "path_match": "volume.bus_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_default_access": {
-            "path_match": "volume.default_access",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_device_name": {
-            "path_match": "volume.device_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_device_type": {
-            "path_match": "volume.device_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_dos_name": {
-            "path_match": "volume.dos_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_file_system_type": {
-            "path_match": "volume.file_system_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_mount_name": {
-            "path_match": "volume.mount_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_nt_name": {
-            "path_match": "volume.nt_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_product_id": {
-            "path_match": "volume.product_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_product_name": {
-            "path_match": "volume.product_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_removable": {
-            "path_match": "volume.removable",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_volume_serial_number": {
-            "path_match": "volume.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_size": {
-            "path_match": "volume.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_volume_vendor_id": {
-            "path_match": "volume.vendor_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_vendor_name": {
-            "path_match": "volume.vendor_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_volume_writable": {
-            "path_match": "volume.writable",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_category": {
-            "path_match": "vulnerability.category",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_classification": {
-            "path_match": "vulnerability.classification",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_description": {
-            "path_match": "vulnerability.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_detected_at": {
-            "path_match": "vulnerability.detected_at",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_enumeration": {
-            "path_match": "vulnerability.enumeration",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_id": {
-            "path_match": "vulnerability.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_published_at": {
-            "path_match": "vulnerability.published_at",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_report_id": {
-            "path_match": "vulnerability.report_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_scanner_condition": {
-            "path_match": "vulnerability.scanner.condition",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_scanner_reference": {
-            "path_match": "vulnerability.scanner.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_scanner_source": {
-            "path_match": "vulnerability.scanner.source",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_scanner_vendor": {
-            "path_match": "vulnerability.scanner.vendor",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_score_base": {
-            "path_match": "vulnerability.score.base",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_score_environmental": {
-            "path_match": "vulnerability.score.environmental",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_score_temporal": {
-            "path_match": "vulnerability.score.temporal",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_score_version": {
-            "path_match": "vulnerability.score.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_severity": {
-            "path_match": "vulnerability.severity",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_vulnerability_under_evaluation": {
-            "path_match": "vulnerability.under_evaluation",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_build_original": {
-            "path_match": "wazuh.agent.build.original",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_ephemeral_id": {
-            "path_match": "wazuh.agent.ephemeral_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_groups": {
-            "path_match": "wazuh.agent.groups",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_architecture": {
-            "path_match": "wazuh.agent.host.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_boot_id": {
-            "path_match": "wazuh.agent.host.boot.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_cpu_cores": {
-            "path_match": "wazuh.agent.host.cpu.cores",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_cpu_name": {
-            "path_match": "wazuh.agent.host.cpu.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_cpu_speed": {
-            "path_match": "wazuh.agent.host.cpu.speed",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_cpu_usage": {
-            "path_match": "wazuh.agent.host.cpu.usage",
-            "mapping": {
-              "scaling_factor": 1000,
-              "type": "scaled_float"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_disk_read_bytes": {
-            "path_match": "wazuh.agent.host.disk.read.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_disk_write_bytes": {
-            "path_match": "wazuh.agent.host.disk.write.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_domain": {
-            "path_match": "wazuh.agent.host.domain",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_city_name": {
-            "path_match": "wazuh.agent.host.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_continent_code": {
-            "path_match": "wazuh.agent.host.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_continent_name": {
-            "path_match": "wazuh.agent.host.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_country_iso_code": {
-            "path_match": "wazuh.agent.host.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_country_name": {
-            "path_match": "wazuh.agent.host.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_location": {
-            "path_match": "wazuh.agent.host.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_name": {
-            "path_match": "wazuh.agent.host.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_postal_code": {
-            "path_match": "wazuh.agent.host.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_region_iso_code": {
-            "path_match": "wazuh.agent.host.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_region_name": {
-            "path_match": "wazuh.agent.host.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_geo_timezone": {
-            "path_match": "wazuh.agent.host.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_hostname": {
-            "path_match": "wazuh.agent.host.hostname",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_id": {
-            "path_match": "wazuh.agent.host.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_ip": {
-            "path_match": "wazuh.agent.host.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_mac": {
-            "path_match": "wazuh.agent.host.mac",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_memory_free": {
-            "path_match": "wazuh.agent.host.memory.free",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_memory_total": {
-            "path_match": "wazuh.agent.host.memory.total",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_memory_used_percentage": {
-            "path_match": "wazuh.agent.host.memory.used.percentage",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_name": {
-            "path_match": "wazuh.agent.host.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_egress_bytes": {
-            "path_match": "wazuh.agent.host.network.egress.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_egress_drops": {
-            "path_match": "wazuh.agent.host.network.egress.drops",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_egress_errors": {
-            "path_match": "wazuh.agent.host.network.egress.errors",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_egress_packets": {
-            "path_match": "wazuh.agent.host.network.egress.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_egress_queue": {
-            "path_match": "wazuh.agent.host.network.egress.queue",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_ingress_bytes": {
-            "path_match": "wazuh.agent.host.network.ingress.bytes",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_ingress_drops": {
-            "path_match": "wazuh.agent.host.network.ingress.drops",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_ingress_errors": {
-            "path_match": "wazuh.agent.host.network.ingress.errors",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_ingress_packets": {
-            "path_match": "wazuh.agent.host.network.ingress.packets",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_network_ingress_queue": {
-            "path_match": "wazuh.agent.host.network.ingress.queue",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_os_family": {
-            "path_match": "wazuh.agent.host.os.family",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_os_full": {
-            "path_match": "wazuh.agent.host.os.full",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_os_kernel": {
-            "path_match": "wazuh.agent.host.os.kernel",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_os_name": {
-            "path_match": "wazuh.agent.host.os.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_os_platform": {
-            "path_match": "wazuh.agent.host.os.platform",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_os_type": {
-            "path_match": "wazuh.agent.host.os.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_os_version": {
-            "path_match": "wazuh.agent.host.os.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_pid_ns_ino": {
-            "path_match": "wazuh.agent.host.pid_ns_ino",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_risk_calculated_level": {
-            "path_match": "wazuh.agent.host.risk.calculated_level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_risk_calculated_score": {
-            "path_match": "wazuh.agent.host.risk.calculated_score",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_risk_calculated_score_norm": {
-            "path_match": "wazuh.agent.host.risk.calculated_score_norm",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_risk_static_level": {
-            "path_match": "wazuh.agent.host.risk.static_level",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_risk_static_score": {
-            "path_match": "wazuh.agent.host.risk.static_score",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_risk_static_score_norm": {
-            "path_match": "wazuh.agent.host.risk.static_score_norm",
-            "mapping": {
-              "type": "float"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_type": {
-            "path_match": "wazuh.agent.host.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_host_uptime": {
-            "path_match": "wazuh.agent.host.uptime",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_id": {
-            "path_match": "wazuh.agent.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_name": {
-            "path_match": "wazuh.agent.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_type": {
-            "path_match": "wazuh.agent.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_agent_version": {
-            "path_match": "wazuh.agent.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_cluster_name": {
-            "path_match": "wazuh.cluster.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_cluster_node": {
-            "path_match": "wazuh.cluster.node",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_event_id": {
-            "path_match": "wazuh.event.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_integration_category": {
-            "path_match": "wazuh.integration.category",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_integration_decoders": {
-            "path_match": "wazuh.integration.decoders",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_integration_name": {
-            "path_match": "wazuh.integration.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_integration_rules": {
-            "path_match": "wazuh.integration.rules",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_protocol_location": {
-            "path_match": "wazuh.protocol.location",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_protocol_queue": {
-            "path_match": "wazuh.protocol.queue",
-            "mapping": {
-              "type": "byte"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_schema_version": {
-            "path_match": "wazuh.schema.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_space_event_discarded": {
-            "path_match": "wazuh.space.event_discarded",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_space_name": {
-            "path_match": "wazuh.space.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_as_number": {
-            "path_match": "wazuh.threat.enrichments.indicator.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_as_organization_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_confidence": {
-            "path_match": "wazuh.threat.enrichments.indicator.confidence",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_description": {
-            "path_match": "wazuh.threat.enrichments.indicator.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_email_address": {
-            "path_match": "wazuh.threat.enrichments.indicator.email.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_feed_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.feed.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_accessed": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.accessed",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_attributes": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.attributes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_digest_algorithm": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_exists": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_flags": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_signing_id": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_status": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_subject_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_team_id": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_thumbprint_sha256": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_timestamp": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_trusted": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_valid": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_created": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.created",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_ctime": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.ctime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_device": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.device",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_directory": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_drive_letter": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.drive_letter",
-            "mapping": {
-              "ignore_above": 1,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_architecture": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_byte_order": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.byte_order",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_cpu_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.cpu_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_creation_date": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.creation_date",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_exports": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.exports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_import_hash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports_names_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_stripped": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_abi_version": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.abi_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_class": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_data": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_entrypoint": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.entrypoint",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_object_version": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.object_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_os_abi": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.os_abi",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_version": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_import_hash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports_names_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_chi2": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.chi2",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_flags": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_physical_offset": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.physical_offset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_physical_size": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_var_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_virtual_address": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.virtual_address",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_virtual_size": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_segments_sections": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.segments.sections",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_segments_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.segments.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_shared_libraries": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.shared_libraries",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_elf_telfhash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.elf.telfhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_extension": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_fork_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.fork_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_gid": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.gid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_group": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.group",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_cdhash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_md5": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha1": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha256": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha384": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha512": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_ssdeep": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_hash_tlsh": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_inode": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.inode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_mime_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_mode": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.mode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_mtime": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.mtime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_origin_referrer_url": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.origin_referrer_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_origin_url": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.origin_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_owner": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.owner",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_path": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_architecture": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_company": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_description": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_file_version": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_import_hash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports_names_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_stripped": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_imphash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_import_hash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports_names_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_original_file_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_pehash": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_product": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_physical_size": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_var_entropy": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_virtual_size": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_size": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_target_path": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.target_path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_uid": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.uid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_alternative_names": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_common_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_country": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_distinguished_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_locality": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_organization": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_organizational_unit": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_state_or_province": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_not_after": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_not_before": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_algorithm": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_curve": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_exponent": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_size": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_serial_number": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_signature_algorithm": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_common_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_country": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_distinguished_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_locality": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_organization": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_organizational_unit": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_state_or_province": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_file_x509_version_number": {
-            "path_match": "wazuh.threat.enrichments.indicator.file.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_first_seen": {
-            "path_match": "wazuh.threat.enrichments.indicator.first_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_city_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_continent_code": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_continent_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_country_iso_code": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_country_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_location": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_postal_code": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_region_iso_code": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_region_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_geo_timezone": {
-            "path_match": "wazuh.threat.enrichments.indicator.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_id": {
-            "path_match": "wazuh.threat.enrichments.indicator.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_ip": {
-            "path_match": "wazuh.threat.enrichments.indicator.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_last_seen": {
-            "path_match": "wazuh.threat.enrichments.indicator.last_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_marking_tlp": {
-            "path_match": "wazuh.threat.enrichments.indicator.marking.tlp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_marking_tlp_version": {
-            "path_match": "wazuh.threat.enrichments.indicator.marking.tlp_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_modified_at": {
-            "path_match": "wazuh.threat.enrichments.indicator.modified_at",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_port": {
-            "path_match": "wazuh.threat.enrichments.indicator.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_provider": {
-            "path_match": "wazuh.threat.enrichments.indicator.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_reference": {
-            "path_match": "wazuh.threat.enrichments.indicator.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_registry_data_bytes": {
-            "path_match": "wazuh.threat.enrichments.indicator.registry.data.bytes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_registry_data_strings": {
-            "path_match": "wazuh.threat.enrichments.indicator.registry.data.strings",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_registry_data_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.registry.data.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_registry_hive": {
-            "path_match": "wazuh.threat.enrichments.indicator.registry.hive",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_registry_key": {
-            "path_match": "wazuh.threat.enrichments.indicator.registry.key",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_registry_path": {
-            "path_match": "wazuh.threat.enrichments.indicator.registry.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_registry_value": {
-            "path_match": "wazuh.threat.enrichments.indicator.registry.value",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_scanner_stats": {
-            "path_match": "wazuh.threat.enrichments.indicator.scanner_stats",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_sightings": {
-            "path_match": "wazuh.threat.enrichments.indicator.sightings",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_software_alias": {
-            "path_match": "wazuh.threat.enrichments.indicator.software.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_software_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.software.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_software_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.software.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_tags": {
-            "path_match": "wazuh.threat.enrichments.indicator.tags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_type": {
-            "path_match": "wazuh.threat.enrichments.indicator.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_alternative_names": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_common_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_country": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_distinguished_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_locality": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_organization": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_organizational_unit": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_state_or_province": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_not_after": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_not_before": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_algorithm": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_curve": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_exponent": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_size": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_serial_number": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_signature_algorithm": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_subject_common_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_subject_country": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_subject_distinguished_name": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_subject_locality": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_subject_organization": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_subject_organizational_unit": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_subject_state_or_province": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_indicator_x509_version_number": {
-            "path_match": "wazuh.threat.enrichments.indicator.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_matched_atomic": {
-            "path_match": "wazuh.threat.enrichments.matched.atomic",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_matched_field": {
-            "path_match": "wazuh.threat.enrichments.matched.field",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_matched_id": {
-            "path_match": "wazuh.threat.enrichments.matched.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_matched_index": {
-            "path_match": "wazuh.threat.enrichments.matched.index",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_matched_occurred": {
-            "path_match": "wazuh.threat.enrichments.matched.occurred",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_enrichments_matched_type": {
-            "path_match": "wazuh.threat.enrichments.matched.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_feed_dashboard_id": {
-            "path_match": "wazuh.threat.feed.dashboard_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_feed_description": {
-            "path_match": "wazuh.threat.feed.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_feed_name": {
-            "path_match": "wazuh.threat.feed.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_feed_reference": {
-            "path_match": "wazuh.threat.feed.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_framework": {
-            "path_match": "wazuh.threat.framework",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_group_alias": {
-            "path_match": "wazuh.threat.group.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_group_id": {
-            "path_match": "wazuh.threat.group.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_group_name": {
-            "path_match": "wazuh.threat.group.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_group_reference": {
-            "path_match": "wazuh.threat.group.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_as_number": {
-            "path_match": "wazuh.threat.indicator.as.number",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_as_organization_name": {
-            "path_match": "wazuh.threat.indicator.as.organization.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_confidence": {
-            "path_match": "wazuh.threat.indicator.confidence",
-            "mapping": {
-              "type": "short"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_description": {
-            "path_match": "wazuh.threat.indicator.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_email_address": {
-            "path_match": "wazuh.threat.indicator.email.address",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_accessed": {
-            "path_match": "wazuh.threat.indicator.file.accessed",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_attributes": {
-            "path_match": "wazuh.threat.indicator.file.attributes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_digest_algorithm": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.digest_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_exists": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.exists",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_flags": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_signing_id": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.signing_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_status": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.status",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_subject_name": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.subject_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_team_id": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.team_id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_thumbprint_sha256": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.thumbprint_sha256",
-            "mapping": {
-              "ignore_above": 64,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_timestamp": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.timestamp",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_trusted": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.trusted",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_code_signature_valid": {
-            "path_match": "wazuh.threat.indicator.file.code_signature.valid",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_created": {
-            "path_match": "wazuh.threat.indicator.file.created",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_ctime": {
-            "path_match": "wazuh.threat.indicator.file.ctime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_device": {
-            "path_match": "wazuh.threat.indicator.file.device",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_directory": {
-            "path_match": "wazuh.threat.indicator.file.directory",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_drive_letter": {
-            "path_match": "wazuh.threat.indicator.file.drive_letter",
-            "mapping": {
-              "ignore_above": 1,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_architecture": {
-            "path_match": "wazuh.threat.indicator.file.elf.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_byte_order": {
-            "path_match": "wazuh.threat.indicator.file.elf.byte_order",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_cpu_type": {
-            "path_match": "wazuh.threat.indicator.file.elf.cpu_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_creation_date": {
-            "path_match": "wazuh.threat.indicator.file.elf.creation_date",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_exports": {
-            "path_match": "wazuh.threat.indicator.file.elf.exports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_go_import_hash": {
-            "path_match": "wazuh.threat.indicator.file.elf.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_go_imports": {
-            "path_match": "wazuh.threat.indicator.file.elf.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_go_imports_names_entropy": {
-            "path_match": "wazuh.threat.indicator.file.elf.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_go_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.indicator.file.elf.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_go_stripped": {
-            "path_match": "wazuh.threat.indicator.file.elf.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_abi_version": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.abi_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_class": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.class",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_data": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.data",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_entrypoint": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.entrypoint",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_object_version": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.object_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_os_abi": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.os_abi",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_type": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_header_version": {
-            "path_match": "wazuh.threat.indicator.file.elf.header.version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_import_hash": {
-            "path_match": "wazuh.threat.indicator.file.elf.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_imports": {
-            "path_match": "wazuh.threat.indicator.file.elf.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_imports_names_entropy": {
-            "path_match": "wazuh.threat.indicator.file.elf.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.indicator.file.elf.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_chi2": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.chi2",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_entropy": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_flags": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.flags",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_name": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_physical_offset": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.physical_offset",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_physical_size": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_type": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_var_entropy": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_virtual_address": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.virtual_address",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_sections_virtual_size": {
-            "path_match": "wazuh.threat.indicator.file.elf.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_segments_sections": {
-            "path_match": "wazuh.threat.indicator.file.elf.segments.sections",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_segments_type": {
-            "path_match": "wazuh.threat.indicator.file.elf.segments.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_shared_libraries": {
-            "path_match": "wazuh.threat.indicator.file.elf.shared_libraries",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_elf_telfhash": {
-            "path_match": "wazuh.threat.indicator.file.elf.telfhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_extension": {
-            "path_match": "wazuh.threat.indicator.file.extension",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_fork_name": {
-            "path_match": "wazuh.threat.indicator.file.fork_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_gid": {
-            "path_match": "wazuh.threat.indicator.file.gid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_group": {
-            "path_match": "wazuh.threat.indicator.file.group",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_cdhash": {
-            "path_match": "wazuh.threat.indicator.file.hash.cdhash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_md5": {
-            "path_match": "wazuh.threat.indicator.file.hash.md5",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_sha1": {
-            "path_match": "wazuh.threat.indicator.file.hash.sha1",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_sha256": {
-            "path_match": "wazuh.threat.indicator.file.hash.sha256",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_sha384": {
-            "path_match": "wazuh.threat.indicator.file.hash.sha384",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_sha512": {
-            "path_match": "wazuh.threat.indicator.file.hash.sha512",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_ssdeep": {
-            "path_match": "wazuh.threat.indicator.file.hash.ssdeep",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_hash_tlsh": {
-            "path_match": "wazuh.threat.indicator.file.hash.tlsh",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_inode": {
-            "path_match": "wazuh.threat.indicator.file.inode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_mime_type": {
-            "path_match": "wazuh.threat.indicator.file.mime_type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_mode": {
-            "path_match": "wazuh.threat.indicator.file.mode",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_mtime": {
-            "path_match": "wazuh.threat.indicator.file.mtime",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_name": {
-            "path_match": "wazuh.threat.indicator.file.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_origin_referrer_url": {
-            "path_match": "wazuh.threat.indicator.file.origin_referrer_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_origin_url": {
-            "path_match": "wazuh.threat.indicator.file.origin_url",
-            "mapping": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_owner": {
-            "path_match": "wazuh.threat.indicator.file.owner",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_path": {
-            "path_match": "wazuh.threat.indicator.file.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_architecture": {
-            "path_match": "wazuh.threat.indicator.file.pe.architecture",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_company": {
-            "path_match": "wazuh.threat.indicator.file.pe.company",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_description": {
-            "path_match": "wazuh.threat.indicator.file.pe.description",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_file_version": {
-            "path_match": "wazuh.threat.indicator.file.pe.file_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_go_import_hash": {
-            "path_match": "wazuh.threat.indicator.file.pe.go_import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_go_imports": {
-            "path_match": "wazuh.threat.indicator.file.pe.go_imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_go_imports_names_entropy": {
-            "path_match": "wazuh.threat.indicator.file.pe.go_imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_go_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.indicator.file.pe.go_imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_go_stripped": {
-            "path_match": "wazuh.threat.indicator.file.pe.go_stripped",
-            "mapping": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_imphash": {
-            "path_match": "wazuh.threat.indicator.file.pe.imphash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_import_hash": {
-            "path_match": "wazuh.threat.indicator.file.pe.import_hash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_imports": {
-            "path_match": "wazuh.threat.indicator.file.pe.imports",
-            "mapping": {
-              "type": "flat_object"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_imports_names_entropy": {
-            "path_match": "wazuh.threat.indicator.file.pe.imports_names_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_imports_names_var_entropy": {
-            "path_match": "wazuh.threat.indicator.file.pe.imports_names_var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_original_file_name": {
-            "path_match": "wazuh.threat.indicator.file.pe.original_file_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_pehash": {
-            "path_match": "wazuh.threat.indicator.file.pe.pehash",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_product": {
-            "path_match": "wazuh.threat.indicator.file.pe.product",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_sections_entropy": {
-            "path_match": "wazuh.threat.indicator.file.pe.sections.entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_sections_name": {
-            "path_match": "wazuh.threat.indicator.file.pe.sections.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_sections_physical_size": {
-            "path_match": "wazuh.threat.indicator.file.pe.sections.physical_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_sections_var_entropy": {
-            "path_match": "wazuh.threat.indicator.file.pe.sections.var_entropy",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_pe_sections_virtual_size": {
-            "path_match": "wazuh.threat.indicator.file.pe.sections.virtual_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_size": {
-            "path_match": "wazuh.threat.indicator.file.size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_target_path": {
-            "path_match": "wazuh.threat.indicator.file.target_path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_type": {
-            "path_match": "wazuh.threat.indicator.file.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_uid": {
-            "path_match": "wazuh.threat.indicator.file.uid",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_alternative_names": {
-            "path_match": "wazuh.threat.indicator.file.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_issuer_common_name": {
-            "path_match": "wazuh.threat.indicator.file.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_issuer_country": {
-            "path_match": "wazuh.threat.indicator.file.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_issuer_distinguished_name": {
-            "path_match": "wazuh.threat.indicator.file.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_issuer_locality": {
-            "path_match": "wazuh.threat.indicator.file.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_issuer_organization": {
-            "path_match": "wazuh.threat.indicator.file.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_issuer_organizational_unit": {
-            "path_match": "wazuh.threat.indicator.file.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_issuer_state_or_province": {
-            "path_match": "wazuh.threat.indicator.file.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_not_after": {
-            "path_match": "wazuh.threat.indicator.file.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_not_before": {
-            "path_match": "wazuh.threat.indicator.file.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_public_key_algorithm": {
-            "path_match": "wazuh.threat.indicator.file.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_public_key_curve": {
-            "path_match": "wazuh.threat.indicator.file.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_public_key_exponent": {
-            "path_match": "wazuh.threat.indicator.file.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_public_key_size": {
-            "path_match": "wazuh.threat.indicator.file.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_serial_number": {
-            "path_match": "wazuh.threat.indicator.file.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_signature_algorithm": {
-            "path_match": "wazuh.threat.indicator.file.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_subject_common_name": {
-            "path_match": "wazuh.threat.indicator.file.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_subject_country": {
-            "path_match": "wazuh.threat.indicator.file.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_subject_distinguished_name": {
-            "path_match": "wazuh.threat.indicator.file.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_subject_locality": {
-            "path_match": "wazuh.threat.indicator.file.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_subject_organization": {
-            "path_match": "wazuh.threat.indicator.file.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_subject_organizational_unit": {
-            "path_match": "wazuh.threat.indicator.file.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_subject_state_or_province": {
-            "path_match": "wazuh.threat.indicator.file.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_file_x509_version_number": {
-            "path_match": "wazuh.threat.indicator.file.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_first_seen": {
-            "path_match": "wazuh.threat.indicator.first_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_city_name": {
-            "path_match": "wazuh.threat.indicator.geo.city_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_continent_code": {
-            "path_match": "wazuh.threat.indicator.geo.continent_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_continent_name": {
-            "path_match": "wazuh.threat.indicator.geo.continent_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_country_iso_code": {
-            "path_match": "wazuh.threat.indicator.geo.country_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_country_name": {
-            "path_match": "wazuh.threat.indicator.geo.country_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_location": {
-            "path_match": "wazuh.threat.indicator.geo.location",
-            "mapping": {
-              "type": "geo_point"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_name": {
-            "path_match": "wazuh.threat.indicator.geo.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_postal_code": {
-            "path_match": "wazuh.threat.indicator.geo.postal_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_region_iso_code": {
-            "path_match": "wazuh.threat.indicator.geo.region_iso_code",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_region_name": {
-            "path_match": "wazuh.threat.indicator.geo.region_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_geo_timezone": {
-            "path_match": "wazuh.threat.indicator.geo.timezone",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_id": {
-            "path_match": "wazuh.threat.indicator.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_ip": {
-            "path_match": "wazuh.threat.indicator.ip",
-            "mapping": {
-              "type": "ip"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_last_seen": {
-            "path_match": "wazuh.threat.indicator.last_seen",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_marking_tlp": {
-            "path_match": "wazuh.threat.indicator.marking.tlp",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_marking_tlp_version": {
-            "path_match": "wazuh.threat.indicator.marking.tlp_version",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_modified_at": {
-            "path_match": "wazuh.threat.indicator.modified_at",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_name": {
-            "path_match": "wazuh.threat.indicator.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_port": {
-            "path_match": "wazuh.threat.indicator.port",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_provider": {
-            "path_match": "wazuh.threat.indicator.provider",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_reference": {
-            "path_match": "wazuh.threat.indicator.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_registry_data_bytes": {
-            "path_match": "wazuh.threat.indicator.registry.data.bytes",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_registry_data_strings": {
-            "path_match": "wazuh.threat.indicator.registry.data.strings",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_registry_data_type": {
-            "path_match": "wazuh.threat.indicator.registry.data.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_registry_hive": {
-            "path_match": "wazuh.threat.indicator.registry.hive",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_registry_key": {
-            "path_match": "wazuh.threat.indicator.registry.key",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_registry_path": {
-            "path_match": "wazuh.threat.indicator.registry.path",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_registry_value": {
-            "path_match": "wazuh.threat.indicator.registry.value",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_scanner_stats": {
-            "path_match": "wazuh.threat.indicator.scanner_stats",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_sightings": {
-            "path_match": "wazuh.threat.indicator.sightings",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_type": {
-            "path_match": "wazuh.threat.indicator.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_alternative_names": {
-            "path_match": "wazuh.threat.indicator.x509.alternative_names",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_issuer_common_name": {
-            "path_match": "wazuh.threat.indicator.x509.issuer.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_issuer_country": {
-            "path_match": "wazuh.threat.indicator.x509.issuer.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_issuer_distinguished_name": {
-            "path_match": "wazuh.threat.indicator.x509.issuer.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_issuer_locality": {
-            "path_match": "wazuh.threat.indicator.x509.issuer.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_issuer_organization": {
-            "path_match": "wazuh.threat.indicator.x509.issuer.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_issuer_organizational_unit": {
-            "path_match": "wazuh.threat.indicator.x509.issuer.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_issuer_state_or_province": {
-            "path_match": "wazuh.threat.indicator.x509.issuer.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_not_after": {
-            "path_match": "wazuh.threat.indicator.x509.not_after",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_not_before": {
-            "path_match": "wazuh.threat.indicator.x509.not_before",
-            "mapping": {
-              "type": "date"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_public_key_algorithm": {
-            "path_match": "wazuh.threat.indicator.x509.public_key_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_public_key_curve": {
-            "path_match": "wazuh.threat.indicator.x509.public_key_curve",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_public_key_exponent": {
-            "path_match": "wazuh.threat.indicator.x509.public_key_exponent",
-            "mapping": {
-              "doc_values": false,
-              "index": false,
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_public_key_size": {
-            "path_match": "wazuh.threat.indicator.x509.public_key_size",
-            "mapping": {
-              "type": "long"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_serial_number": {
-            "path_match": "wazuh.threat.indicator.x509.serial_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_signature_algorithm": {
-            "path_match": "wazuh.threat.indicator.x509.signature_algorithm",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_subject_common_name": {
-            "path_match": "wazuh.threat.indicator.x509.subject.common_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_subject_country": {
-            "path_match": "wazuh.threat.indicator.x509.subject.country",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_subject_distinguished_name": {
-            "path_match": "wazuh.threat.indicator.x509.subject.distinguished_name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_subject_locality": {
-            "path_match": "wazuh.threat.indicator.x509.subject.locality",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_subject_organization": {
-            "path_match": "wazuh.threat.indicator.x509.subject.organization",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_subject_organizational_unit": {
-            "path_match": "wazuh.threat.indicator.x509.subject.organizational_unit",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_subject_state_or_province": {
-            "path_match": "wazuh.threat.indicator.x509.subject.state_or_province",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_indicator_x509_version_number": {
-            "path_match": "wazuh.threat.indicator.x509.version_number",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_software_alias": {
-            "path_match": "wazuh.threat.software.alias",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_software_id": {
-            "path_match": "wazuh.threat.software.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_software_name": {
-            "path_match": "wazuh.threat.software.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_software_platforms": {
-            "path_match": "wazuh.threat.software.platforms",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_software_reference": {
-            "path_match": "wazuh.threat.software.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_software_type": {
-            "path_match": "wazuh.threat.software.type",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_tactic_id": {
-            "path_match": "wazuh.threat.tactic.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_tactic_name": {
-            "path_match": "wazuh.threat.tactic.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_tactic_reference": {
-            "path_match": "wazuh.threat.tactic.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_technique_id": {
-            "path_match": "wazuh.threat.technique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_technique_name": {
-            "path_match": "wazuh.threat.technique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_technique_reference": {
-            "path_match": "wazuh.threat.technique.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_technique_subtechnique_id": {
-            "path_match": "wazuh.threat.technique.subtechnique.id",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_technique_subtechnique_name": {
-            "path_match": "wazuh.threat.technique.subtechnique.name",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        {
-          "wcs_wazuh_threat_technique_subtechnique_reference": {
-            "path_match": "wazuh.threat.technique.subtechnique.reference",
-            "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        }
-      ],
       "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
         "agent": {
           "properties": {
             "build": {
-              "properties": {}
+              "properties": {
+                "original": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ephemeral_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "groups": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "check": {
           "properties": {
             "compliance": {
-              "properties": {}
+              "properties": {
+                "cmmc": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "fedramp": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "gdpr": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "hipaa": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "iso_27001": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "nis2": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "nist_800_171": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "nist_800_53": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pci_dss": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tsc": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "condition": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "mitre": {
               "properties": {
                 "subtechnique": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "object"
                 },
                 "tactic": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "object"
                 },
                 "technique": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "object"
                 }
               }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "rationale": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reason": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "references": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "remediation": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "result": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "rules": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "client": {
           "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "as": {
               "properties": {
+                "number": {
+                  "type": "long"
+                },
                 "organization": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "geo": {
-              "properties": {}
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "nat": {
-              "properties": {}
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "user": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
@@ -20192,125 +365,520 @@
         "cloud": {
           "properties": {
             "account": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "availability_zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "instance": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "machine": {
-              "properties": {}
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "origin": {
               "properties": {
                 "account": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "instance": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "machine": {
-                  "properties": {}
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "project": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "service": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
             "project": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "region": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "service": {
-              "properties": {}
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "target": {
               "properties": {
                 "account": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "instance": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "machine": {
-                  "properties": {}
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "project": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "service": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }
           }
         },
         "compliance": {
-          "properties": {}
+          "properties": {
+            "cmmc": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fedramp": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "gdpr": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hipaa": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "iso_27001": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nis2": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nist_800_171": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nist_800_53": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "pci_dss": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "tsc": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "container": {
           "properties": {
             "cpu": {
-              "properties": {}
+              "properties": {
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
             },
             "disk": {
               "properties": {
                 "read": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
                 },
                 "write": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "image": {
               "properties": {
                 "hash": {
-                  "properties": {}
+                  "properties": {
+                    "all": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tag": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
+            "labels": {
+              "type": "object"
+            },
             "memory": {
-              "properties": {}
+              "properties": {
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "network": {
               "properties": {
                 "egress": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
                 },
                 "ingress": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             },
+            "runtime": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "security_context": {
-              "properties": {}
+              "properties": {
+                "privileged": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         },
         "data_stream": {
-          "properties": {}
+          "properties": {
+            "dataset": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "namespace": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "destination": {
           "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "as": {
               "properties": {
+                "number": {
+                  "type": "long"
+                },
                 "organization": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "geo": {
-              "properties": {}
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "nat": {
-              "properties": {}
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "user": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
@@ -20318,23 +886,213 @@
         },
         "device": {
           "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "manufacturer": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "model": {
-              "properties": {}
+              "properties": {
+                "identifier": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "serial_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "dll": {
           "properties": {
             "code_signature": {
-              "properties": {}
+              "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exists": {
+                  "type": "boolean"
+                },
+                "flags": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "thumbprint_sha256": {
+                  "ignore_above": 64,
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
             },
             "hash": {
-              "properties": {}
+              "properties": {
+                "cdhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha384": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tlsh": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "origin_referrer_url": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            },
+            "origin_url": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "pe": {
               "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flat_object"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "imphash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flat_object"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pehash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "sections": {
-                  "properties": {}
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             }
@@ -20343,10 +1101,79 @@
         "dns": {
           "properties": {
             "answers": {
-              "properties": {}
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ttl": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "header_flags": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "op_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "question": {
-              "properties": {}
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "registered_domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subdomain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "top_level_domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "resolved_ip": {
+              "type": "ip"
+            },
+            "response_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -20356,88 +1183,878 @@
               "properties": {
                 "file": {
                   "properties": {
+                    "extension": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "hash": {
-                      "properties": {}
+                      "properties": {
+                        "cdhash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha384": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlsh": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "mime_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "size": {
+                      "type": "long"
                     }
                   }
                 }
-              }
+              },
+              "type": "nested"
             },
             "bcc": {
-              "properties": {}
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "cc": {
-              "properties": {}
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "content_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "delivery_timestamp": {
+              "type": "date"
+            },
+            "direction": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "from": {
-              "properties": {}
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "local_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "message_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "origination_timestamp": {
+              "type": "date"
             },
             "reply_to": {
-              "properties": {}
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "sender": {
-              "properties": {}
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "subject": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "to": {
-              "properties": {}
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "x_mailer": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "error": {
-          "properties": {}
+          "properties": {
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "message": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "stack_trace": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "event": {
-          "properties": {}
+          "properties": {
+            "action": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "agent_id_status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "changed_fields": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "collector": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "created": {
+              "type": "date"
+            },
+            "dataset": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "duration": {
+              "type": "long"
+            },
+            "end": {
+              "type": "date"
+            },
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ingested": {
+              "type": "date"
+            },
+            "kind": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "module": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "doc_values": false,
+              "index": false,
+              "type": "keyword"
+            },
+            "outcome": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reason": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "risk_score": {
+              "type": "float"
+            },
+            "risk_score_norm": {
+              "type": "float"
+            },
+            "sequence": {
+              "type": "long"
+            },
+            "severity": {
+              "type": "long"
+            },
+            "start": {
+              "type": "date"
+            },
+            "timezone": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "url": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
         },
         "faas": {
           "properties": {
+            "coldstart": {
+              "type": "boolean"
+            },
+            "execution": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "trigger": {
-              "properties": {}
+              "properties": {
+                "request_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "file": {
           "properties": {
+            "accessed": {
+              "type": "date"
+            },
+            "attributes": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "code_signature": {
-              "properties": {}
+              "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exists": {
+                  "type": "boolean"
+                },
+                "flags": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "thumbprint_sha256": {
+                  "ignore_above": 64,
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "created": {
+              "type": "date"
+            },
+            "ctime": {
+              "type": "date"
+            },
+            "device": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "diff": {
+              "type": "match_only_text"
+            },
+            "directory": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "drive_letter": {
+              "ignore_above": 1,
+              "type": "keyword"
             },
             "elf": {
               "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "byte_order": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "creation_date": {
+                  "type": "date"
+                },
+                "exports": {
+                  "type": "flat_object"
+                },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flat_object"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "header": {
-                  "properties": {}
+                  "properties": {
+                    "abi_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "class": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "data": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "entrypoint": {
+                      "type": "long"
+                    },
+                    "object_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "os_abi": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flat_object"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "sections": {
-                  "properties": {}
+                  "properties": {
+                    "chi2": {
+                      "type": "long"
+                    },
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_offset": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_address": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 },
                 "segments": {
-                  "properties": {}
+                  "properties": {
+                    "sections": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "shared_libraries": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "telfhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
+            "extension": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fork_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "gid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "group": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "hash": {
-              "properties": {}
+              "properties": {
+                "cdhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha384": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tlsh": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "inode": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "macho": {
               "properties": {
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flat_object"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flat_object"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
                 "sections": {
-                  "properties": {}
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "symhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
+            },
+            "mime_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mode": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mtime": {
+              "type": "date"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "origin_referrer_url": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            },
+            "origin_url": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            },
+            "owner": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "pe": {
               "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flat_object"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "imphash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flat_object"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pehash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "sections": {
-                  "properties": {}
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             },
+            "size": {
+              "type": "long"
+            },
+            "target_path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "x509": {
               "properties": {
+                "alternative_names": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "issuer": {
-                  "properties": {}
+                  "properties": {
+                    "common_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "distinguished_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "locality": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organization": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organizational_unit": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "state_or_province": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "public_key_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "public_key_curve": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "public_key_exponent": {
+                  "doc_values": false,
+                  "index": false,
+                  "type": "long"
+                },
+                "public_key_size": {
+                  "type": "long"
+                },
+                "serial_number": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "signature_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "subject": {
-                  "properties": {}
+                  "properties": {
+                    "common_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "distinguished_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "locality": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organization": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "organizational_unit": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "state_or_province": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "version_number": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
@@ -20446,85 +2063,406 @@
         "gen_ai": {
           "properties": {
             "agent": {
-              "properties": {}
+              "properties": {
+                "description": {
+                  "doc_values": false,
+                  "index": false,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "operation": {
-              "properties": {}
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "output": {
-              "properties": {}
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "request": {
               "properties": {
                 "choice": {
-                  "properties": {}
+                  "properties": {
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "encoding_formats": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "frequency_penalty": {
+                  "type": "double"
+                },
+                "max_tokens": {
+                  "type": "integer"
+                },
+                "model": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "presence_penalty": {
+                  "type": "double"
+                },
+                "seed": {
+                  "type": "integer"
+                },
+                "stop_sequences": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "temperature": {
+                  "type": "double"
+                },
+                "top_k": {
+                  "type": "double"
+                },
+                "top_p": {
+                  "type": "double"
                 }
               }
             },
             "response": {
-              "properties": {}
+              "properties": {
+                "finish_reasons": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "model": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "system": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "token": {
-              "properties": {}
+              "properties": {
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "tool": {
               "properties": {
                 "call": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "usage": {
-              "properties": {}
+              "properties": {
+                "input_tokens": {
+                  "type": "integer"
+                },
+                "output_tokens": {
+                  "type": "integer"
+                }
+              }
             }
           }
         },
         "group": {
-          "properties": {}
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "host": {
           "properties": {
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "boot": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "cpu": {
-              "properties": {}
+              "properties": {
+                "cores": {
+                  "type": "long"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "speed": {
+                  "type": "long"
+                },
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              },
+              "type": "object"
             },
             "disk": {
               "properties": {
                 "read": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
                 },
                 "write": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "geo": {
-              "properties": {}
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "memory": {
               "properties": {
+                "free": {
+                  "type": "long"
+                },
+                "total": {
+                  "type": "long"
+                },
                 "used": {
-                  "properties": {}
+                  "properties": {
+                    "percentage": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "object"
                 }
-              }
+              },
+              "type": "object"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "network": {
               "properties": {
                 "egress": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "drops": {
+                      "type": "long"
+                    },
+                    "errors": {
+                      "type": "long"
+                    },
+                    "packets": {
+                      "type": "long"
+                    },
+                    "queue": {
+                      "type": "long"
+                    }
+                  }
                 },
                 "ingress": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "drops": {
+                      "type": "long"
+                    },
+                    "errors": {
+                      "type": "long"
+                    },
+                    "packets": {
+                      "type": "long"
+                    },
+                    "queue": {
+                      "type": "long"
+                    }
+                  }
                 }
               }
             },
             "os": {
-              "properties": {}
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "pid_ns_ino": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "risk": {
-              "properties": {}
+              "properties": {
+                "calculated_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "calculated_score": {
+                  "type": "float"
+                },
+                "calculated_score_norm": {
+                  "type": "float"
+                },
+                "static_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "static_score": {
+                  "type": "float"
+                },
+                "static_score_norm": {
+                  "type": "float"
+                }
+              }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uptime": {
+              "type": "long"
             }
           }
         },
@@ -20533,70 +2471,324 @@
             "request": {
               "properties": {
                 "body": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "content": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "bytes": {
+                  "type": "long"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "method": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "mime_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "referrer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "response": {
               "properties": {
                 "body": {
-                  "properties": {}
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    },
+                    "content": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "bytes": {
+                  "type": "long"
+                },
+                "mime_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status_code": {
+                  "type": "long"
                 }
               }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "interface": {
-          "properties": {}
+          "properties": {
+            "alias": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mtu": {
+              "type": "long"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "state": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "labels": {
+          "type": "object"
         },
         "log": {
           "properties": {
             "file": {
-              "properties": {}
+              "properties": {
+                "path": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "logger": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "origin": {
               "properties": {
                 "file": {
-                  "properties": {}
+                  "properties": {
+                    "line": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "function": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "syslog": {
               "properties": {
+                "appname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "facility": {
-                  "properties": {}
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "msgid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "priority": {
+                  "type": "long"
+                },
+                "procid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "severity": {
-                  "properties": {}
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "structured_data": {
+                  "type": "flat_object"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
-              }
+              },
+              "type": "object"
             }
           }
+        },
+        "message": {
+          "ignore_above": 1024,
+          "type": "keyword"
         },
         "mitre": {
           "properties": {
             "subtechnique": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
             },
             "tactic": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
             },
             "technique": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
             }
           }
         },
         "network": {
           "properties": {
+            "application": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "broadcast": {
+              "type": "ip"
+            },
+            "bytes": {
+              "type": "long"
+            },
+            "community_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "dhcp": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "direction": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "forwarded_ip": {
+              "type": "ip"
+            },
+            "gateway": {
+              "type": "ip"
+            },
+            "iana_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "inner": {
               "properties": {
                 "vlan": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
-              }
+              },
+              "type": "object"
+            },
+            "metric": {
+              "type": "long"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "netmask": {
+              "type": "ip"
+            },
+            "packets": {
+              "type": "long"
+            },
+            "protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "transport": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "vlan": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },
@@ -20606,402 +2798,2517 @@
               "properties": {
                 "interface": {
                   "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mtu": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "observer": {
                       "properties": {
                         "ingress": {
                           "properties": {
                             "interface": {
-                              "properties": {}
+                              "properties": {
+                                "alias": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "id": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "mtu": {
+                                  "type": "long"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
                             }
                           }
                         }
                       }
+                    },
+                    "state": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
                 "vlan": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "geo": {
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
-            "geo": {
-              "properties": {}
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "ingress": {
               "properties": {
                 "interface": {
-                  "properties": {}
+                  "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mtu": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "state": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "vlan": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "os": {
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
-            "os": {
-              "properties": {}
+            "product": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "serial_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "vendor": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "orchestrator": {
           "properties": {
+            "api_version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "cluster": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "url": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "namespace": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "organization": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "resource": {
               "properties": {
+                "annotation": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ip": {
+                  "type": "ip"
+                },
+                "label": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "parent": {
-                  "properties": {}
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "organization": {
-          "properties": {}
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "package": {
           "properties": {
+            "architecture": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "build_version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "checksum": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "install_scope": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "installed": {
+              "type": "date"
+            },
+            "license": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "previous": {
-              "properties": {}
+              "properties": {
+                "installed": {
+                  "type": "date"
+                }
+              }
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "size": {
+              "type": "long"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "policy": {
-          "properties": {}
+          "properties": {
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "file": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "references": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "process": {
           "properties": {
-            "code_signature": {
-              "properties": {}
+            "args": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
-            "elf": {
+            "args_count": {
+              "type": "long"
+            },
+            "code_signature": {
               "properties": {
-                "header": {
-                  "properties": {}
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
-                "sections": {
-                  "properties": {}
+                "exists": {
+                  "type": "boolean"
                 },
-                "segments": {
-                  "properties": {}
+                "flags": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "thumbprint_sha256": {
+                  "ignore_above": 64,
+                  "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "valid": {
+                  "type": "boolean"
                 }
               }
             },
+            "command_line": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "elf": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "byte_order": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "creation_date": {
+                  "type": "date"
+                },
+                "exports": {
+                  "type": "flat_object"
+                },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flat_object"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "header": {
+                  "properties": {
+                    "abi_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "class": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "data": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "entrypoint": {
+                      "type": "long"
+                    },
+                    "object_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "os_abi": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flat_object"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "sections": {
+                  "properties": {
+                    "chi2": {
+                      "type": "long"
+                    },
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_offset": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_address": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "segments": {
+                  "properties": {
+                    "sections": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "shared_libraries": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "telfhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "end": {
+              "type": "date"
+            },
+            "entity_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "entry_leader": {
               "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
                 "attested_groups": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "attested_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "command_line": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "entry_meta": {
                   "properties": {
                     "source": {
-                      "properties": {}
+                      "properties": {
+                        "ip": {
+                          "type": "ip"
+                        }
+                      }
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
+                "executable": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "interactive": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "parent": {
                   "properties": {
+                    "entity_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pid": {
+                      "type": "long"
+                    },
                     "session_leader": {
-                      "properties": {}
+                      "properties": {
+                        "entity_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "pid": {
+                          "type": "long"
+                        },
+                        "start": {
+                          "type": "date"
+                        },
+                        "vpid": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "start": {
+                      "type": "date"
+                    },
+                    "vpid": {
+                      "type": "long"
                     }
                   }
                 },
+                "pid": {
+                  "type": "long"
+                },
                 "real_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "real_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "same_as_process": {
+                  "type": "boolean"
                 },
                 "saved_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "saved_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
                 },
                 "supplemental_groups": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {}
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  },
+                  "type": "object"
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
-                "user": {
-                  "properties": {}
+                "vpid": {
+                  "type": "long"
+                },
+                "working_directory": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
+            "env_vars": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "executable": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "exit_code": {
+              "type": "long"
+            },
             "group": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "group_leader": {
               "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "command_line": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "interactive": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pid": {
+                  "type": "long"
                 },
                 "real_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "real_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "same_as_process": {
+                  "type": "boolean"
                 },
                 "saved_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "saved_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
                 },
                 "supplemental_groups": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {}
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  },
+                  "type": "object"
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
-                "user": {
-                  "properties": {}
+                "vpid": {
+                  "type": "long"
+                },
+                "working_directory": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "hash": {
-              "properties": {}
+              "properties": {
+                "cdhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "md5": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha1": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha256": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha384": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tlsh": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "interactive": {
+              "type": "boolean"
             },
             "io": {
               "properties": {
                 "bytes_skipped": {
-                  "properties": {}
+                  "properties": {
+                    "length": {
+                      "type": "long"
+                    },
+                    "offset": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "object"
+                },
+                "max_bytes_per_process_exceeded": {
+                  "type": "boolean"
+                },
+                "text": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "total_bytes_captured": {
+                  "type": "long"
+                },
+                "total_bytes_skipped": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
-              }
+              },
+              "type": "object"
             },
             "macho": {
               "properties": {
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flat_object"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flat_object"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
                 "sections": {
-                  "properties": {}
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "symhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "parent": {
               "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
                 "code_signature": {
-                  "properties": {}
+                  "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "exists": {
+                      "type": "boolean"
+                    },
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signing_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "status": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "team_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "thumbprint_sha256": {
+                      "ignore_above": 64,
+                      "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
+                    },
+                    "trusted": {
+                      "type": "boolean"
+                    },
+                    "valid": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "command_line": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "elf": {
                   "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "byte_order": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "cpu_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "creation_date": {
+                      "type": "date"
+                    },
+                    "exports": {
+                      "type": "flat_object"
+                    },
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flat_object"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
                     "header": {
-                      "properties": {}
+                      "properties": {
+                        "abi_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "class": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "data": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "entrypoint": {
+                          "type": "long"
+                        },
+                        "object_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "os_abi": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flat_object"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
                     },
                     "sections": {
-                      "properties": {}
+                      "properties": {
+                        "chi2": {
+                          "type": "long"
+                        },
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "flags": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_offset": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "var_entropy": {
+                          "type": "long"
+                        },
+                        "virtual_address": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
                     },
                     "segments": {
-                      "properties": {}
+                      "properties": {
+                        "sections": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "shared_libraries": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "telfhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
+                "end": {
+                  "type": "date"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exit_code": {
+                  "type": "long"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "group_leader": {
-                  "properties": {}
+                  "properties": {
+                    "entity_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pid": {
+                      "type": "long"
+                    },
+                    "start": {
+                      "type": "date"
+                    },
+                    "vpid": {
+                      "type": "long"
+                    }
+                  }
                 },
                 "hash": {
-                  "properties": {}
+                  "properties": {
+                    "cdhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha384": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha512": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ssdeep": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "tlsh": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "interactive": {
+                  "type": "boolean"
                 },
                 "macho": {
                   "properties": {
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flat_object"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flat_object"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
+                    },
                     "sections": {
-                      "properties": {}
+                      "properties": {
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "var_entropy": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "symhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "pe": {
                   "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "company": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "file_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flat_object"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
+                    "imphash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flat_object"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "original_file_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pehash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "product": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "sections": {
-                      "properties": {}
+                      "properties": {
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "var_entropy": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
                     }
                   }
                 },
+                "pid": {
+                  "type": "long"
+                },
                 "real_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "real_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "saved_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "saved_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
                 },
                 "supplemental_groups": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "thread": {
                   "properties": {
                     "capabilities": {
-                      "properties": {}
+                      "properties": {
+                        "effective": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "permitted": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "id": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
+                },
+                "title": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {}
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  },
+                  "type": "object"
+                },
+                "uptime": {
+                  "type": "long"
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
-                "user": {
-                  "properties": {}
+                "vpid": {
+                  "type": "long"
+                },
+                "working_directory": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "pe": {
               "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "company": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "file_version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flat_object"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "imphash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flat_object"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "original_file_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pehash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "product": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "sections": {
-                  "properties": {}
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             },
+            "pid": {
+              "type": "long"
+            },
             "previous": {
               "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "command_line": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "parent": {
-                  "properties": {}
+                  "properties": {
+                    "pid": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "real_group": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "real_user": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "saved_group": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "saved_user": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "session_leader": {
               "properties": {
-                "group": {
-                  "properties": {}
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
-                "parent": {
+                "args_count": {
+                  "type": "long"
+                },
+                "command_line": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
                   "properties": {
-                    "session_leader": {
-                      "properties": {}
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
+                "interactive": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "parent": {
+                  "properties": {
+                    "entity_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "pid": {
+                      "type": "long"
+                    },
+                    "session_leader": {
+                      "properties": {
+                        "entity_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "pid": {
+                          "type": "long"
+                        },
+                        "start": {
+                          "type": "date"
+                        },
+                        "vpid": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "start": {
+                      "type": "date"
+                    },
+                    "vpid": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "pid": {
+                  "type": "long"
+                },
                 "real_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "real_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "same_as_process": {
+                  "type": "boolean"
                 },
                 "saved_group": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "saved_user": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "start": {
+                  "type": "date"
                 },
                 "supplemental_groups": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {}
+                      "properties": {
+                        "major": {
+                          "type": "long"
+                        },
+                        "minor": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  },
+                  "type": "object"
+                },
+                "user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
-                "user": {
-                  "properties": {}
+                "vpid": {
+                  "type": "long"
+                },
+                "working_directory": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
+            "start": {
+              "type": "date"
+            },
+            "state": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "supplemental_groups": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "thread": {
               "properties": {
                 "capabilities": {
-                  "properties": {}
+                  "properties": {
+                    "effective": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "permitted": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "id": {
+                  "type": "long"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
+            },
+            "title": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "tty": {
               "properties": {
                 "char_device": {
-                  "properties": {}
+                  "properties": {
+                    "major": {
+                      "type": "long"
+                    },
+                    "minor": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "columns": {
+                  "type": "long"
+                },
+                "rows": {
+                  "type": "long"
+                }
+              },
+              "type": "object"
+            },
+            "uptime": {
+              "type": "long"
+            },
+            "user": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
-            "user": {
-              "properties": {}
+            "vpid": {
+              "type": "long"
+            },
+            "working_directory": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "registry": {
           "properties": {
             "data": {
-              "properties": {}
+              "properties": {
+                "bytes": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "strings": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hive": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "key": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "value": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "related": {
-          "properties": {}
+          "properties": {
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hosts": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "user": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "rule": {
           "properties": {
+            "author": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "compliance": {
-              "properties": {}
+              "properties": {
+                "cmmc": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "fedramp": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "gdpr": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "hipaa": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "iso_27001": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "nis2": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "nist_800_171": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "nist_800_53": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pci_dss": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tsc": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "level": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "license": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "mitre": {
               "properties": {
                 "subtechnique": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "object"
                 },
                 "tactic": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "object"
                 },
                 "technique": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "object"
                 }
               }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ruleset": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "sigma_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "status": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "tags": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "title": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "uuid": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "server": {
           "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "as": {
               "properties": {
+                "number": {
+                  "type": "long"
+                },
                 "organization": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "geo": {
-              "properties": {}
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "nat": {
-              "properties": {}
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "user": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
@@ -21009,60 +5316,355 @@
         },
         "service": {
           "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "environment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ephemeral_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "node": {
-              "properties": {}
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "role": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "origin": {
               "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "node": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "previous": {
-                  "properties": {}
+                  "properties": {
+                    "state": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "previous": {
-              "properties": {}
+              "properties": {
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "state": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "target": {
               "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "node": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "previous": {
-                  "properties": {}
+                  "properties": {
+                    "state": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "source": {
           "properties": {
+            "address": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "as": {
               "properties": {
+                "number": {
+                  "type": "long"
+                },
                 "organization": {
-                  "properties": {}
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
+            "bytes": {
+              "type": "long"
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "geo": {
-              "properties": {}
+              "properties": {
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "timezone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "nat": {
-              "properties": {}
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
+            "packets": {
+              "type": "long"
+            },
+            "port": {
+              "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "user": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
           }
         },
         "span": {
-          "properties": {}
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
         },
         "threat": {
           "properties": {
@@ -21072,189 +5674,1876 @@
                   "properties": {
                     "as": {
                       "properties": {
+                        "number": {
+                          "type": "long"
+                        },
                         "organization": {
-                          "properties": {}
+                          "properties": {
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
                         }
                       }
                     },
+                    "confidence": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "email": {
-                      "properties": {}
+                      "properties": {
+                        "address": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "feed": {
-                      "properties": {}
+                      "properties": {
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "file": {
                       "properties": {
+                        "accessed": {
+                          "type": "date"
+                        },
+                        "attributes": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "code_signature": {
-                          "properties": {}
+                          "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "exists": {
+                              "type": "boolean"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "signing_id": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "status": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "subject_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "team_id": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "thumbprint_sha256": {
+                              "ignore_above": 64,
+                              "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
+                            },
+                            "trusted": {
+                              "type": "boolean"
+                            },
+                            "valid": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "created": {
+                          "type": "date"
+                        },
+                        "ctime": {
+                          "type": "date"
+                        },
+                        "device": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "directory": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "drive_letter": {
+                          "ignore_above": 1,
+                          "type": "keyword"
                         },
                         "elf": {
                           "properties": {
+                            "architecture": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "byte_order": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "cpu_type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "creation_date": {
+                              "type": "date"
+                            },
+                            "exports": {
+                              "type": "flat_object"
+                            },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flat_object"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
                             "header": {
-                              "properties": {}
+                              "properties": {
+                                "abi_version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "class": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "data": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "entrypoint": {
+                                  "type": "long"
+                                },
+                                "object_version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "os_abi": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "imports": {
+                              "type": "flat_object"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
                             },
                             "sections": {
-                              "properties": {}
+                              "properties": {
+                                "chi2": {
+                                  "type": "long"
+                                },
+                                "entropy": {
+                                  "type": "long"
+                                },
+                                "flags": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_offset": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_size": {
+                                  "type": "long"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
+                                },
+                                "virtual_address": {
+                                  "type": "long"
+                                },
+                                "virtual_size": {
+                                  "type": "long"
+                                }
+                              },
+                              "type": "nested"
                             },
                             "segments": {
-                              "properties": {}
+                              "properties": {
+                                "sections": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              },
+                              "type": "nested"
+                            },
+                            "shared_libraries": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "telfhash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             }
                           }
                         },
+                        "extension": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "fork_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "gid": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "group": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "hash": {
-                          "properties": {}
+                          "properties": {
+                            "cdhash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "md5": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha1": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha256": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha384": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha512": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "ssdeep": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "tlsh": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "inode": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mime_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mode": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mtime": {
+                          "type": "date"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "origin_referrer_url": {
+                          "ignore_above": 8192,
+                          "type": "keyword"
+                        },
+                        "origin_url": {
+                          "ignore_above": 8192,
+                          "type": "keyword"
+                        },
+                        "owner": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "pe": {
                           "properties": {
+                            "architecture": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "company": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "description": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "file_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flat_object"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
+                            "imphash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "imports": {
+                              "type": "flat_object"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "original_file_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "pehash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "product": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "sections": {
-                              "properties": {}
+                              "properties": {
+                                "entropy": {
+                                  "type": "long"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_size": {
+                                  "type": "long"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
+                                },
+                                "virtual_size": {
+                                  "type": "long"
+                                }
+                              },
+                              "type": "nested"
                             }
                           }
                         },
+                        "size": {
+                          "type": "long"
+                        },
+                        "target_path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "uid": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "x509": {
                           "properties": {
+                            "alternative_names": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "issuer": {
-                              "properties": {}
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "not_after": {
+                              "type": "date"
+                            },
+                            "not_before": {
+                              "type": "date"
+                            },
+                            "public_key_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_curve": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_exponent": {
+                              "doc_values": false,
+                              "index": false,
+                              "type": "long"
+                            },
+                            "public_key_size": {
+                              "type": "long"
+                            },
+                            "serial_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "signature_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             },
                             "subject": {
-                              "properties": {}
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "version_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             }
                           }
                         }
                       }
                     },
+                    "first_seen": {
+                      "type": "date"
+                    },
                     "geo": {
-                      "properties": {}
+                      "properties": {
+                        "city_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "location": {
+                          "type": "geo_point"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "postal_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "timezone": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ip": {
+                      "type": "ip"
+                    },
+                    "last_seen": {
+                      "type": "date"
                     },
                     "marking": {
-                      "properties": {}
+                      "properties": {
+                        "tlp": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlp_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "modified_at": {
+                      "type": "date"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "port": {
+                      "type": "long"
+                    },
+                    "provider": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "registry": {
                       "properties": {
                         "data": {
-                          "properties": {}
+                          "properties": {
+                            "bytes": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "strings": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "hive": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "key": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "value": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     },
+                    "scanner_stats": {
+                      "type": "long"
+                    },
+                    "sightings": {
+                      "type": "long"
+                    },
                     "software": {
-                      "properties": {}
+                      "properties": {
+                        "alias": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "tags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "url": {
-                      "properties": {}
+                      "properties": {
+                        "domain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "extension": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "fragment": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "full": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "original": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "password": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "port": {
+                          "type": "long"
+                        },
+                        "query": {
+                          "ignore_above": 2083,
+                          "type": "keyword"
+                        },
+                        "registered_domain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "scheme": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subdomain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "top_level_domain": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "username": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "x509": {
                       "properties": {
+                        "alternative_names": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "issuer": {
-                          "properties": {}
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "not_after": {
+                          "type": "date"
+                        },
+                        "not_before": {
+                          "type": "date"
+                        },
+                        "public_key_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_curve": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_exponent": {
+                          "doc_values": false,
+                          "index": false,
+                          "type": "long"
+                        },
+                        "public_key_size": {
+                          "type": "long"
+                        },
+                        "serial_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "signature_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "subject": {
-                          "properties": {}
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "version_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     }
-                  }
+                  },
+                  "type": "object"
                 },
                 "matched": {
-                  "properties": {}
+                  "properties": {
+                    "atomic": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "field": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "index": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "occurred": {
+                      "type": "date"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "feed": {
+              "properties": {
+                "dashboard_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
-            "feed": {
-              "properties": {}
+            "framework": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "group": {
-              "properties": {}
+              "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "indicator": {
               "properties": {
                 "as": {
                   "properties": {
+                    "number": {
+                      "type": "long"
+                    },
                     "organization": {
-                      "properties": {}
+                      "properties": {
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     }
                   }
                 },
+                "confidence": {
+                  "type": "short"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "email": {
-                  "properties": {}
+                  "properties": {
+                    "address": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "file": {
                   "properties": {
+                    "accessed": {
+                      "type": "date"
+                    },
+                    "attributes": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "code_signature": {
-                      "properties": {}
+                      "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "exists": {
+                          "type": "boolean"
+                        },
+                        "flags": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "signing_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "status": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subject_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "team_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "thumbprint_sha256": {
+                          "ignore_above": 64,
+                          "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
+                        },
+                        "trusted": {
+                          "type": "boolean"
+                        },
+                        "valid": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "created": {
+                      "type": "date"
+                    },
+                    "ctime": {
+                      "type": "date"
+                    },
+                    "device": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "directory": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "drive_letter": {
+                      "ignore_above": 1,
+                      "type": "keyword"
                     },
                     "elf": {
                       "properties": {
+                        "architecture": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "byte_order": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "cpu_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "creation_date": {
+                          "type": "date"
+                        },
+                        "exports": {
+                          "type": "flat_object"
+                        },
+                        "go_import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "go_imports": {
+                          "type": "flat_object"
+                        },
+                        "go_imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "go_imports_names_var_entropy": {
+                          "type": "long"
+                        },
+                        "go_stripped": {
+                          "type": "boolean"
+                        },
                         "header": {
-                          "properties": {}
+                          "properties": {
+                            "abi_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "class": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "data": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "entrypoint": {
+                              "type": "long"
+                            },
+                            "object_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "os_abi": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "imports": {
+                          "type": "flat_object"
+                        },
+                        "imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "imports_names_var_entropy": {
+                          "type": "long"
                         },
                         "sections": {
-                          "properties": {}
+                          "properties": {
+                            "chi2": {
+                              "type": "long"
+                            },
+                            "entropy": {
+                              "type": "long"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_offset": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_size": {
+                              "type": "long"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "var_entropy": {
+                              "type": "long"
+                            },
+                            "virtual_address": {
+                              "type": "long"
+                            },
+                            "virtual_size": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "nested"
                         },
                         "segments": {
-                          "properties": {}
+                          "properties": {
+                            "sections": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          },
+                          "type": "nested"
+                        },
+                        "shared_libraries": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "telfhash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     },
+                    "extension": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "fork_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "gid": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "group": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "hash": {
-                      "properties": {}
+                      "properties": {
+                        "cdhash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha384": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlsh": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "inode": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mime_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mode": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mtime": {
+                      "type": "date"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "origin_referrer_url": {
+                      "ignore_above": 8192,
+                      "type": "keyword"
+                    },
+                    "origin_url": {
+                      "ignore_above": 8192,
+                      "type": "keyword"
+                    },
+                    "owner": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "pe": {
                       "properties": {
+                        "architecture": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "company": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "description": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "file_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "go_import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "go_imports": {
+                          "type": "flat_object"
+                        },
+                        "go_imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "go_imports_names_var_entropy": {
+                          "type": "long"
+                        },
+                        "go_stripped": {
+                          "type": "boolean"
+                        },
+                        "imphash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "imports": {
+                          "type": "flat_object"
+                        },
+                        "imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "imports_names_var_entropy": {
+                          "type": "long"
+                        },
+                        "original_file_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "pehash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "product": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "sections": {
-                          "properties": {}
+                          "properties": {
+                            "entropy": {
+                              "type": "long"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_size": {
+                              "type": "long"
+                            },
+                            "var_entropy": {
+                              "type": "long"
+                            },
+                            "virtual_size": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "nested"
                         }
                       }
                     },
+                    "size": {
+                      "type": "long"
+                    },
+                    "target_path": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "uid": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "x509": {
                       "properties": {
+                        "alternative_names": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "issuer": {
-                          "properties": {}
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "not_after": {
+                          "type": "date"
+                        },
+                        "not_before": {
+                          "type": "date"
+                        },
+                        "public_key_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_curve": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_exponent": {
+                          "doc_values": false,
+                          "index": false,
+                          "type": "long"
+                        },
+                        "public_key_size": {
+                          "type": "long"
+                        },
+                        "serial_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "signature_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "subject": {
-                          "properties": {}
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "version_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     }
                   }
                 },
+                "first_seen": {
+                  "type": "date"
+                },
                 "geo": {
-                  "properties": {}
+                  "properties": {
+                    "city_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "continent_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "continent_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country_iso_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "country_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "location": {
+                      "type": "geo_point"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "postal_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "region_iso_code": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "region_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "timezone": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ip": {
+                  "type": "ip"
+                },
+                "last_seen": {
+                  "type": "date"
                 },
                 "marking": {
-                  "properties": {}
+                  "properties": {
+                    "tlp": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "tlp_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "modified_at": {
+                  "type": "date"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "port": {
+                  "type": "long"
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "registry": {
                   "properties": {
                     "data": {
-                      "properties": {}
+                      "properties": {
+                        "bytes": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "strings": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "hive": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "key": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "value": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
+                "scanner_stats": {
+                  "type": "long"
+                },
+                "sightings": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "url": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "extension": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "fragment": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "full": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "original": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "password": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "port": {
+                      "type": "long"
+                    },
+                    "query": {
+                      "ignore_above": 2083,
+                      "type": "keyword"
+                    },
+                    "registered_domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "scheme": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subdomain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "top_level_domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "username": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "x509": {
                   "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "issuer": {
-                      "properties": {}
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "doc_values": false,
+                      "index": false,
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "subject": {
-                      "properties": {}
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 }
               }
             },
             "software": {
-              "properties": {}
+              "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platforms": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "tactic": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "technique": {
               "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "subtechnique": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }
@@ -21262,77 +7551,632 @@
         },
         "tls": {
           "properties": {
+            "cipher": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "client": {
               "properties": {
+                "certificate": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "certificate_chain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "hash": {
-                  "properties": {}
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "issuer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ja3": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "server_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "subject": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "supported_ciphers": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "x509": {
                   "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "issuer": {
-                      "properties": {}
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "doc_values": false,
+                      "index": false,
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "subject": {
-                      "properties": {}
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 }
               }
             },
+            "curve": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "established": {
+              "type": "boolean"
+            },
+            "next_protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "resumed": {
+              "type": "boolean"
+            },
             "server": {
               "properties": {
+                "certificate": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "certificate_chain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "hash": {
-                  "properties": {}
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "issuer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ja3s": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "not_after": {
+                  "type": "date"
+                },
+                "not_before": {
+                  "type": "date"
+                },
+                "subject": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "x509": {
                   "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "issuer": {
-                      "properties": {}
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "doc_values": false,
+                      "index": false,
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "subject": {
-                      "properties": {}
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 }
               }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version_protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "trace": {
-          "properties": {}
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "transaction": {
-          "properties": {}
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "url": {
-          "properties": {}
+          "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "extension": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "fragment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "password": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "port": {
+              "type": "long"
+            },
+            "query": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "scheme": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subdomain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "username": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
         "user": {
           "properties": {
             "changes": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
+            },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "effective": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
+            "email": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "group": {
-              "properties": {}
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "risk": {
-              "properties": {}
+              "properties": {
+                "calculated_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "calculated_score": {
+                  "type": "float"
+                },
+                "calculated_score_norm": {
+                  "type": "float"
+                },
+                "static_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "static_score": {
+                  "type": "float"
+                },
+                "static_score_norm": {
+                  "type": "float"
+                }
+              }
+            },
+            "roles": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "target": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
@@ -21341,23 +8185,199 @@
         "user_agent": {
           "properties": {
             "device": {
-              "properties": {}
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "original": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "os": {
-              "properties": {}
+              "properties": {
+                "family": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "kernel": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
         "volume": {
-          "properties": {}
+          "properties": {
+            "bus_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "default_access": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "device_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "device_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "dos_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "file_system_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "mount_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "nt_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "product_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "product_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "removable": {
+              "type": "boolean"
+            },
+            "serial_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "size": {
+              "type": "long"
+            },
+            "vendor_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "vendor_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "writable": {
+              "type": "boolean"
+            }
+          }
         },
         "vulnerability": {
           "properties": {
+            "category": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "classification": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "description": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "detected_at": {
+              "type": "date"
+            },
+            "enumeration": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "published_at": {
+              "type": "date"
+            },
+            "report_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "scanner": {
-              "properties": {}
+              "properties": {
+                "condition": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "source": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "vendor": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "score": {
-              "properties": {}
+              "properties": {
+                "base": {
+                  "type": "float"
+                },
+                "environmental": {
+                  "type": "float"
+                },
+                "temporal": {
+                  "type": "float"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "severity": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "under_evaluation": {
+              "type": "boolean"
             }
           }
         },
@@ -21366,73 +8386,359 @@
             "agent": {
               "properties": {
                 "build": {
-                  "properties": {}
+                  "properties": {
+                    "original": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "groups": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "host": {
                   "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "boot": {
-                      "properties": {}
+                      "properties": {
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "cpu": {
-                      "properties": {}
+                      "properties": {
+                        "cores": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "speed": {
+                          "type": "long"
+                        },
+                        "usage": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      },
+                      "type": "object"
                     },
                     "disk": {
                       "properties": {
                         "read": {
-                          "properties": {}
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
                         },
                         "write": {
-                          "properties": {}
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
                         }
                       }
                     },
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "geo": {
-                      "properties": {}
+                      "properties": {
+                        "city_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "location": {
+                          "type": "geo_point"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "postal_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "timezone": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "hostname": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ip": {
+                      "type": "ip"
+                    },
+                    "mac": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "memory": {
                       "properties": {
+                        "free": {
+                          "type": "long"
+                        },
+                        "total": {
+                          "type": "long"
+                        },
                         "used": {
-                          "properties": {}
+                          "properties": {
+                            "percentage": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "object"
                         }
-                      }
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "network": {
                       "properties": {
                         "egress": {
-                          "properties": {}
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            },
+                            "drops": {
+                              "type": "long"
+                            },
+                            "errors": {
+                              "type": "long"
+                            },
+                            "packets": {
+                              "type": "long"
+                            },
+                            "queue": {
+                              "type": "long"
+                            }
+                          }
                         },
                         "ingress": {
-                          "properties": {}
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            },
+                            "drops": {
+                              "type": "long"
+                            },
+                            "errors": {
+                              "type": "long"
+                            },
+                            "packets": {
+                              "type": "long"
+                            },
+                            "queue": {
+                              "type": "long"
+                            }
+                          }
                         }
                       }
                     },
                     "os": {
-                      "properties": {}
+                      "properties": {
+                        "family": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "full": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "kernel": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "platform": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "pid_ns_ino": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "risk": {
-                      "properties": {}
+                      "properties": {
+                        "calculated_level": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "calculated_score": {
+                          "type": "float"
+                        },
+                        "calculated_score_norm": {
+                          "type": "float"
+                        },
+                        "static_level": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "static_score": {
+                          "type": "float"
+                        },
+                        "static_score_norm": {
+                          "type": "float"
+                        }
+                      }
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "uptime": {
+                      "type": "long"
                     }
                   }
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
             "cluster": {
-              "properties": {}
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "event": {
-              "properties": {}
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "integration": {
-              "properties": {}
+              "properties": {
+                "category": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "decoders": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "rules": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "protocol": {
-              "properties": {}
+              "properties": {
+                "location": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "queue": {
+                  "type": "byte"
+                }
+              }
             },
             "schema": {
-              "properties": {}
+              "properties": {
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "space": {
-              "properties": {}
+              "properties": {
+                "event_discarded": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "threat": {
               "properties": {
@@ -21442,203 +8748,1764 @@
                       "properties": {
                         "as": {
                           "properties": {
+                            "number": {
+                              "type": "long"
+                            },
                             "organization": {
-                              "properties": {}
+                              "properties": {
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
                             }
                           }
                         },
+                        "confidence": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "description": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "email": {
-                          "properties": {}
+                          "properties": {
+                            "address": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
                         },
                         "feed": {
-                          "properties": {}
+                          "properties": {
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
                         },
                         "file": {
                           "properties": {
+                            "accessed": {
+                              "type": "date"
+                            },
+                            "attributes": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "code_signature": {
-                              "properties": {}
+                              "properties": {
+                                "digest_algorithm": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "exists": {
+                                  "type": "boolean"
+                                },
+                                "flags": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "signing_id": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "status": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "subject_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "team_id": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "thumbprint_sha256": {
+                                  "ignore_above": 64,
+                                  "type": "keyword"
+                                },
+                                "timestamp": {
+                                  "type": "date"
+                                },
+                                "trusted": {
+                                  "type": "boolean"
+                                },
+                                "valid": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "created": {
+                              "type": "date"
+                            },
+                            "ctime": {
+                              "type": "date"
+                            },
+                            "device": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "directory": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "drive_letter": {
+                              "ignore_above": 1,
+                              "type": "keyword"
                             },
                             "elf": {
                               "properties": {
+                                "architecture": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "byte_order": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "cpu_type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "creation_date": {
+                                  "type": "date"
+                                },
+                                "exports": {
+                                  "type": "flat_object"
+                                },
+                                "go_import_hash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "go_imports": {
+                                  "type": "flat_object"
+                                },
+                                "go_imports_names_entropy": {
+                                  "type": "long"
+                                },
+                                "go_imports_names_var_entropy": {
+                                  "type": "long"
+                                },
+                                "go_stripped": {
+                                  "type": "boolean"
+                                },
                                 "header": {
-                                  "properties": {}
+                                  "properties": {
+                                    "abi_version": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "class": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "data": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "entrypoint": {
+                                      "type": "long"
+                                    },
+                                    "object_version": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "os_abi": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "type": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "version": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    }
+                                  }
+                                },
+                                "import_hash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "imports": {
+                                  "type": "flat_object"
+                                },
+                                "imports_names_entropy": {
+                                  "type": "long"
+                                },
+                                "imports_names_var_entropy": {
+                                  "type": "long"
                                 },
                                 "sections": {
-                                  "properties": {}
+                                  "properties": {
+                                    "chi2": {
+                                      "type": "long"
+                                    },
+                                    "entropy": {
+                                      "type": "long"
+                                    },
+                                    "flags": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "name": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "physical_offset": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "physical_size": {
+                                      "type": "long"
+                                    },
+                                    "type": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "var_entropy": {
+                                      "type": "long"
+                                    },
+                                    "virtual_address": {
+                                      "type": "long"
+                                    },
+                                    "virtual_size": {
+                                      "type": "long"
+                                    }
+                                  },
+                                  "type": "nested"
                                 },
                                 "segments": {
-                                  "properties": {}
+                                  "properties": {
+                                    "sections": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "type": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    }
+                                  },
+                                  "type": "nested"
+                                },
+                                "shared_libraries": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "telfhash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
                                 }
                               }
                             },
+                            "extension": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "fork_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "gid": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "group": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "hash": {
-                              "properties": {}
+                              "properties": {
+                                "cdhash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "md5": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "sha1": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "sha256": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "sha384": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "sha512": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "ssdeep": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "tlsh": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "inode": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "mime_type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "mode": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "mtime": {
+                              "type": "date"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "origin_referrer_url": {
+                              "ignore_above": 8192,
+                              "type": "keyword"
+                            },
+                            "origin_url": {
+                              "ignore_above": 8192,
+                              "type": "keyword"
+                            },
+                            "owner": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "path": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             },
                             "pe": {
                               "properties": {
+                                "architecture": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "company": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "description": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "file_version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "go_import_hash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "go_imports": {
+                                  "type": "flat_object"
+                                },
+                                "go_imports_names_entropy": {
+                                  "type": "long"
+                                },
+                                "go_imports_names_var_entropy": {
+                                  "type": "long"
+                                },
+                                "go_stripped": {
+                                  "type": "boolean"
+                                },
+                                "imphash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "import_hash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "imports": {
+                                  "type": "flat_object"
+                                },
+                                "imports_names_entropy": {
+                                  "type": "long"
+                                },
+                                "imports_names_var_entropy": {
+                                  "type": "long"
+                                },
+                                "original_file_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "pehash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "product": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
                                 "sections": {
-                                  "properties": {}
+                                  "properties": {
+                                    "entropy": {
+                                      "type": "long"
+                                    },
+                                    "name": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "physical_size": {
+                                      "type": "long"
+                                    },
+                                    "var_entropy": {
+                                      "type": "long"
+                                    },
+                                    "virtual_size": {
+                                      "type": "long"
+                                    }
+                                  },
+                                  "type": "nested"
                                 }
                               }
                             },
+                            "size": {
+                              "type": "long"
+                            },
+                            "target_path": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "uid": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "x509": {
                               "properties": {
+                                "alternative_names": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
                                 "issuer": {
-                                  "properties": {}
+                                  "properties": {
+                                    "common_name": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "country": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "distinguished_name": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "locality": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "organization": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "organizational_unit": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "state_or_province": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    }
+                                  }
+                                },
+                                "not_after": {
+                                  "type": "date"
+                                },
+                                "not_before": {
+                                  "type": "date"
+                                },
+                                "public_key_algorithm": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "public_key_curve": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "public_key_exponent": {
+                                  "doc_values": false,
+                                  "index": false,
+                                  "type": "long"
+                                },
+                                "public_key_size": {
+                                  "type": "long"
+                                },
+                                "serial_number": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "signature_algorithm": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
                                 },
                                 "subject": {
-                                  "properties": {}
+                                  "properties": {
+                                    "common_name": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "country": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "distinguished_name": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "locality": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "organization": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "organizational_unit": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    },
+                                    "state_or_province": {
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
+                                    }
+                                  }
+                                },
+                                "version_number": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
                                 }
                               }
                             }
                           }
                         },
+                        "first_seen": {
+                          "type": "date"
+                        },
                         "geo": {
-                          "properties": {}
+                          "properties": {
+                            "city_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "continent_code": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "continent_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country_iso_code": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "location": {
+                              "type": "geo_point"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "postal_code": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "region_iso_code": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "region_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "timezone": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ip": {
+                          "type": "ip"
+                        },
+                        "last_seen": {
+                          "type": "date"
                         },
                         "marking": {
-                          "properties": {}
+                          "properties": {
+                            "tlp": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "tlp_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "modified_at": {
+                          "type": "date"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "port": {
+                          "type": "long"
+                        },
+                        "provider": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "reference": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "registry": {
                           "properties": {
                             "data": {
-                              "properties": {}
+                              "properties": {
+                                "bytes": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "strings": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "hive": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "key": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "path": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "value": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             }
                           }
                         },
+                        "scanner_stats": {
+                          "type": "long"
+                        },
+                        "sightings": {
+                          "type": "long"
+                        },
                         "software": {
-                          "properties": {}
+                          "properties": {
+                            "alias": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "tags": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "x509": {
                           "properties": {
+                            "alternative_names": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "issuer": {
-                              "properties": {}
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "not_after": {
+                              "type": "date"
+                            },
+                            "not_before": {
+                              "type": "date"
+                            },
+                            "public_key_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_curve": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_exponent": {
+                              "doc_values": false,
+                              "index": false,
+                              "type": "long"
+                            },
+                            "public_key_size": {
+                              "type": "long"
+                            },
+                            "serial_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "signature_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             },
                             "subject": {
-                              "properties": {}
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "version_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             }
                           }
                         }
-                      }
+                      },
+                      "type": "object"
                     },
                     "matched": {
-                      "properties": {}
+                      "properties": {
+                        "atomic": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "field": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "index": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "occurred": {
+                          "type": "date"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  },
+                  "type": "object"
+                },
+                "feed": {
+                  "properties": {
+                    "dashboard_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
-                "feed": {
-                  "properties": {}
+                "framework": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
-                  "properties": {}
+                  "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "indicator": {
                   "properties": {
                     "as": {
                       "properties": {
+                        "number": {
+                          "type": "long"
+                        },
                         "organization": {
-                          "properties": {}
+                          "properties": {
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
                         }
                       }
                     },
+                    "confidence": {
+                      "type": "short"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "email": {
-                      "properties": {}
+                      "properties": {
+                        "address": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "file": {
                       "properties": {
+                        "accessed": {
+                          "type": "date"
+                        },
+                        "attributes": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "code_signature": {
-                          "properties": {}
+                          "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "exists": {
+                              "type": "boolean"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "signing_id": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "status": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "subject_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "team_id": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "thumbprint_sha256": {
+                              "ignore_above": 64,
+                              "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
+                            },
+                            "trusted": {
+                              "type": "boolean"
+                            },
+                            "valid": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "created": {
+                          "type": "date"
+                        },
+                        "ctime": {
+                          "type": "date"
+                        },
+                        "device": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "directory": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "drive_letter": {
+                          "ignore_above": 1,
+                          "type": "keyword"
                         },
                         "elf": {
                           "properties": {
+                            "architecture": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "byte_order": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "cpu_type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "creation_date": {
+                              "type": "date"
+                            },
+                            "exports": {
+                              "type": "flat_object"
+                            },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flat_object"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
                             "header": {
-                              "properties": {}
+                              "properties": {
+                                "abi_version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "class": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "data": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "entrypoint": {
+                                  "type": "long"
+                                },
+                                "object_version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "os_abi": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "version": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "imports": {
+                              "type": "flat_object"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
                             },
                             "sections": {
-                              "properties": {}
+                              "properties": {
+                                "chi2": {
+                                  "type": "long"
+                                },
+                                "entropy": {
+                                  "type": "long"
+                                },
+                                "flags": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_offset": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_size": {
+                                  "type": "long"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
+                                },
+                                "virtual_address": {
+                                  "type": "long"
+                                },
+                                "virtual_size": {
+                                  "type": "long"
+                                }
+                              },
+                              "type": "nested"
                             },
                             "segments": {
-                              "properties": {}
+                              "properties": {
+                                "sections": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "type": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              },
+                              "type": "nested"
+                            },
+                            "shared_libraries": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "telfhash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             }
                           }
                         },
+                        "extension": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "fork_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "gid": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "group": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "hash": {
-                          "properties": {}
+                          "properties": {
+                            "cdhash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "md5": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha1": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha256": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha384": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha512": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "ssdeep": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "tlsh": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "inode": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mime_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mode": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "mtime": {
+                          "type": "date"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "origin_referrer_url": {
+                          "ignore_above": 8192,
+                          "type": "keyword"
+                        },
+                        "origin_url": {
+                          "ignore_above": 8192,
+                          "type": "keyword"
+                        },
+                        "owner": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "pe": {
                           "properties": {
+                            "architecture": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "company": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "description": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "file_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flat_object"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
+                            "imphash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "imports": {
+                              "type": "flat_object"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "original_file_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "pehash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "product": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "sections": {
-                              "properties": {}
+                              "properties": {
+                                "entropy": {
+                                  "type": "long"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_size": {
+                                  "type": "long"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
+                                },
+                                "virtual_size": {
+                                  "type": "long"
+                                }
+                              },
+                              "type": "nested"
                             }
                           }
                         },
+                        "size": {
+                          "type": "long"
+                        },
+                        "target_path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "uid": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "x509": {
                           "properties": {
+                            "alternative_names": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "issuer": {
-                              "properties": {}
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "not_after": {
+                              "type": "date"
+                            },
+                            "not_before": {
+                              "type": "date"
+                            },
+                            "public_key_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_curve": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "public_key_exponent": {
+                              "doc_values": false,
+                              "index": false,
+                              "type": "long"
+                            },
+                            "public_key_size": {
+                              "type": "long"
+                            },
+                            "serial_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "signature_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             },
                             "subject": {
-                              "properties": {}
+                              "properties": {
+                                "common_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "country": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "distinguished_name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "locality": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organization": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "organizational_unit": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "state_or_province": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            },
+                            "version_number": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             }
                           }
                         }
                       }
                     },
+                    "first_seen": {
+                      "type": "date"
+                    },
                     "geo": {
-                      "properties": {}
+                      "properties": {
+                        "city_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "continent_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "location": {
+                          "type": "geo_point"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "postal_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_iso_code": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "region_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "timezone": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ip": {
+                      "type": "ip"
+                    },
+                    "last_seen": {
+                      "type": "date"
                     },
                     "marking": {
-                      "properties": {}
+                      "properties": {
+                        "tlp": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlp_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "modified_at": {
+                      "type": "date"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "port": {
+                      "type": "long"
+                    },
+                    "provider": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "registry": {
                       "properties": {
                         "data": {
-                          "properties": {}
+                          "properties": {
+                            "bytes": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "strings": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "hive": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "key": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "path": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "value": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     },
+                    "scanner_stats": {
+                      "type": "long"
+                    },
+                    "sightings": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "x509": {
                       "properties": {
+                        "alternative_names": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "issuer": {
-                          "properties": {}
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "not_after": {
+                          "type": "date"
+                        },
+                        "not_before": {
+                          "type": "date"
+                        },
+                        "public_key_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_curve": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_exponent": {
+                          "doc_values": false,
+                          "index": false,
+                          "type": "long"
+                        },
+                        "public_key_size": {
+                          "type": "long"
+                        },
+                        "serial_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "signature_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "subject": {
-                          "properties": {}
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "version_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     }
                   }
                 },
                 "software": {
-                  "properties": {}
+                  "properties": {
+                    "alias": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "platforms": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "tactic": {
-                  "properties": {}
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "technique": {
                   "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "subtechnique": {
-                      "properties": {}
+                      "properties": {
+                        "id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "reference": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     }
                   }
                 }
               }
             }
           }
-        },
-        "@timestamp": {
-          "type": "date"
-        },
-        "labels": {
-          "type": "object"
-        },
-        "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
-        },
-        "tags": {
-          "ignore_above": 1024,
-          "type": "keyword"
         }
       }
     }

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -9,6 +9,7 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
@@ -21,8 +22,7 @@
           "wazuh.cluster.node",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "2s",
-        "max_docvalue_fields_search": 100
+        "refresh_interval": "2s"
       },
       "mapping.nested_fields.limit": 50,
       "mapping.total_fields.limit": 1000,

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -31,332 +31,20160 @@
     "mappings": {
       "date_detection": false,
       "dynamic": "strict_allow_templates",
-      "properties": {
-        "@timestamp": {
-          "type": "date"
+      "dynamic_templates": [
+        {
+          "wcs_agent_build_original": {
+            "path_match": "agent.build.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
+        {
+          "wcs_agent_ephemeral_id": {
+            "path_match": "agent.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_groups": {
+            "path_match": "agent.groups",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_id": {
+            "path_match": "agent.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_name": {
+            "path_match": "agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_type": {
+            "path_match": "agent.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_version": {
+            "path_match": "agent.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_cmmc": {
+            "path_match": "check.compliance.cmmc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_fedramp": {
+            "path_match": "check.compliance.fedramp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_gdpr": {
+            "path_match": "check.compliance.gdpr",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_hipaa": {
+            "path_match": "check.compliance.hipaa",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_iso_27001": {
+            "path_match": "check.compliance.iso_27001",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_nis2": {
+            "path_match": "check.compliance.nis2",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_nist_800_171": {
+            "path_match": "check.compliance.nist_800_171",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_nist_800_53": {
+            "path_match": "check.compliance.nist_800_53",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_pci_dss": {
+            "path_match": "check.compliance.pci_dss",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_tsc": {
+            "path_match": "check.compliance.tsc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_condition": {
+            "path_match": "check.condition",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_description": {
+            "path_match": "check.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_id": {
+            "path_match": "check.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_subtechnique_id": {
+            "path_match": "check.mitre.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_subtechnique_name": {
+            "path_match": "check.mitre.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_tactic_id": {
+            "path_match": "check.mitre.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_tactic_name": {
+            "path_match": "check.mitre.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_technique_id": {
+            "path_match": "check.mitre.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_technique_name": {
+            "path_match": "check.mitre.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_name": {
+            "path_match": "check.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_rationale": {
+            "path_match": "check.rationale",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_reason": {
+            "path_match": "check.reason",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_references": {
+            "path_match": "check.references",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_remediation": {
+            "path_match": "check.remediation",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_result": {
+            "path_match": "check.result",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_rules": {
+            "path_match": "check.rules",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_address": {
+            "path_match": "client.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_as_number": {
+            "path_match": "client.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_as_organization_name": {
+            "path_match": "client.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_bytes": {
+            "path_match": "client.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_domain": {
+            "path_match": "client.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_city_name": {
+            "path_match": "client.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_continent_code": {
+            "path_match": "client.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_continent_name": {
+            "path_match": "client.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_country_iso_code": {
+            "path_match": "client.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_country_name": {
+            "path_match": "client.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_location": {
+            "path_match": "client.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_name": {
+            "path_match": "client.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_postal_code": {
+            "path_match": "client.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_region_iso_code": {
+            "path_match": "client.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_region_name": {
+            "path_match": "client.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_timezone": {
+            "path_match": "client.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_ip": {
+            "path_match": "client.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_client_mac": {
+            "path_match": "client.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_nat_ip": {
+            "path_match": "client.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_client_nat_port": {
+            "path_match": "client.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_packets": {
+            "path_match": "client.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_port": {
+            "path_match": "client.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_registered_domain": {
+            "path_match": "client.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_subdomain": {
+            "path_match": "client.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_top_level_domain": {
+            "path_match": "client.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_domain": {
+            "path_match": "client.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_email": {
+            "path_match": "client.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_full_name": {
+            "path_match": "client.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_group_domain": {
+            "path_match": "client.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_group_id": {
+            "path_match": "client.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_group_name": {
+            "path_match": "client.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_hash": {
+            "path_match": "client.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_id": {
+            "path_match": "client.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_name": {
+            "path_match": "client.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_roles": {
+            "path_match": "client.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_account_id": {
+            "path_match": "cloud.account.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_account_name": {
+            "path_match": "cloud.account.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_availability_zone": {
+            "path_match": "cloud.availability_zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_instance_id": {
+            "path_match": "cloud.instance.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_instance_name": {
+            "path_match": "cloud.instance.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_machine_type": {
+            "path_match": "cloud.machine.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_account_id": {
+            "path_match": "cloud.origin.account.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_account_name": {
+            "path_match": "cloud.origin.account.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_availability_zone": {
+            "path_match": "cloud.origin.availability_zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_instance_id": {
+            "path_match": "cloud.origin.instance.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_instance_name": {
+            "path_match": "cloud.origin.instance.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_machine_type": {
+            "path_match": "cloud.origin.machine.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_project_id": {
+            "path_match": "cloud.origin.project.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_project_name": {
+            "path_match": "cloud.origin.project.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_provider": {
+            "path_match": "cloud.origin.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_region": {
+            "path_match": "cloud.origin.region",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_service_name": {
+            "path_match": "cloud.origin.service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_project_id": {
+            "path_match": "cloud.project.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_project_name": {
+            "path_match": "cloud.project.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_provider": {
+            "path_match": "cloud.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_region": {
+            "path_match": "cloud.region",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_service_name": {
+            "path_match": "cloud.service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_account_id": {
+            "path_match": "cloud.target.account.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_account_name": {
+            "path_match": "cloud.target.account.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_availability_zone": {
+            "path_match": "cloud.target.availability_zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_instance_id": {
+            "path_match": "cloud.target.instance.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_instance_name": {
+            "path_match": "cloud.target.instance.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_machine_type": {
+            "path_match": "cloud.target.machine.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_project_id": {
+            "path_match": "cloud.target.project.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_project_name": {
+            "path_match": "cloud.target.project.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_provider": {
+            "path_match": "cloud.target.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_region": {
+            "path_match": "cloud.target.region",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_service_name": {
+            "path_match": "cloud.target.service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_cmmc": {
+            "path_match": "compliance.cmmc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_fedramp": {
+            "path_match": "compliance.fedramp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_gdpr": {
+            "path_match": "compliance.gdpr",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_hipaa": {
+            "path_match": "compliance.hipaa",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_iso_27001": {
+            "path_match": "compliance.iso_27001",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_nis2": {
+            "path_match": "compliance.nis2",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_nist_800_171": {
+            "path_match": "compliance.nist_800_171",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_nist_800_53": {
+            "path_match": "compliance.nist_800_53",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_pci_dss": {
+            "path_match": "compliance.pci_dss",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_tsc": {
+            "path_match": "compliance.tsc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_cpu_usage": {
+            "path_match": "container.cpu.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_container_disk_read_bytes": {
+            "path_match": "container.disk.read.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_disk_write_bytes": {
+            "path_match": "container.disk.write.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_id": {
+            "path_match": "container.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_image_hash_all": {
+            "path_match": "container.image.hash.all",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_image_name": {
+            "path_match": "container.image.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_image_tag": {
+            "path_match": "container.image.tag",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_labels": {
+            "path_match": "container.labels",
+            "mapping": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "wcs_container_memory_usage": {
+            "path_match": "container.memory.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_container_name": {
+            "path_match": "container.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_network_egress_bytes": {
+            "path_match": "container.network.egress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_network_ingress_bytes": {
+            "path_match": "container.network.ingress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_runtime": {
+            "path_match": "container.runtime",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_security_context_privileged": {
+            "path_match": "container.security_context.privileged",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_data_stream_dataset": {
+            "path_match": "data_stream.dataset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_data_stream_namespace": {
+            "path_match": "data_stream.namespace",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_data_stream_type": {
+            "path_match": "data_stream.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_address": {
+            "path_match": "destination.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_as_number": {
+            "path_match": "destination.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_as_organization_name": {
+            "path_match": "destination.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_bytes": {
+            "path_match": "destination.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_domain": {
+            "path_match": "destination.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_city_name": {
+            "path_match": "destination.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_continent_code": {
+            "path_match": "destination.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_continent_name": {
+            "path_match": "destination.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_country_iso_code": {
+            "path_match": "destination.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_country_name": {
+            "path_match": "destination.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_location": {
+            "path_match": "destination.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_name": {
+            "path_match": "destination.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_postal_code": {
+            "path_match": "destination.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_region_iso_code": {
+            "path_match": "destination.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_region_name": {
+            "path_match": "destination.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_timezone": {
+            "path_match": "destination.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_ip": {
+            "path_match": "destination.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_destination_mac": {
+            "path_match": "destination.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_nat_ip": {
+            "path_match": "destination.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_destination_nat_port": {
+            "path_match": "destination.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_packets": {
+            "path_match": "destination.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_port": {
+            "path_match": "destination.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_registered_domain": {
+            "path_match": "destination.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_subdomain": {
+            "path_match": "destination.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_top_level_domain": {
+            "path_match": "destination.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_domain": {
+            "path_match": "destination.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_email": {
+            "path_match": "destination.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_full_name": {
+            "path_match": "destination.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_group_domain": {
+            "path_match": "destination.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_group_id": {
+            "path_match": "destination.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_group_name": {
+            "path_match": "destination.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_hash": {
+            "path_match": "destination.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_id": {
+            "path_match": "destination.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_name": {
+            "path_match": "destination.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_roles": {
+            "path_match": "destination.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_id": {
+            "path_match": "device.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_manufacturer": {
+            "path_match": "device.manufacturer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_model_identifier": {
+            "path_match": "device.model.identifier",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_model_name": {
+            "path_match": "device.model.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_serial_number": {
+            "path_match": "device.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_digest_algorithm": {
+            "path_match": "dll.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_exists": {
+            "path_match": "dll.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_flags": {
+            "path_match": "dll.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_signing_id": {
+            "path_match": "dll.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_status": {
+            "path_match": "dll.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_subject_name": {
+            "path_match": "dll.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_team_id": {
+            "path_match": "dll.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_thumbprint_sha256": {
+            "path_match": "dll.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_timestamp": {
+            "path_match": "dll.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_trusted": {
+            "path_match": "dll.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_valid": {
+            "path_match": "dll.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_cdhash": {
+            "path_match": "dll.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_md5": {
+            "path_match": "dll.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha1": {
+            "path_match": "dll.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha256": {
+            "path_match": "dll.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha384": {
+            "path_match": "dll.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha512": {
+            "path_match": "dll.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_ssdeep": {
+            "path_match": "dll.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_tlsh": {
+            "path_match": "dll.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_name": {
+            "path_match": "dll.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_origin_referrer_url": {
+            "path_match": "dll.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_origin_url": {
+            "path_match": "dll.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_path": {
+            "path_match": "dll.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_architecture": {
+            "path_match": "dll.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_company": {
+            "path_match": "dll.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_description": {
+            "path_match": "dll.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_file_version": {
+            "path_match": "dll.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_import_hash": {
+            "path_match": "dll.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_imports": {
+            "path_match": "dll.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_imports_names_entropy": {
+            "path_match": "dll.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_imports_names_var_entropy": {
+            "path_match": "dll.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_stripped": {
+            "path_match": "dll.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imphash": {
+            "path_match": "dll.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_import_hash": {
+            "path_match": "dll.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imports": {
+            "path_match": "dll.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imports_names_entropy": {
+            "path_match": "dll.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imports_names_var_entropy": {
+            "path_match": "dll.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_original_file_name": {
+            "path_match": "dll.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_pehash": {
+            "path_match": "dll.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_product": {
+            "path_match": "dll.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_entropy": {
+            "path_match": "dll.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_name": {
+            "path_match": "dll.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_physical_size": {
+            "path_match": "dll.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_var_entropy": {
+            "path_match": "dll.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_virtual_size": {
+            "path_match": "dll.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_class": {
+            "path_match": "dns.answers.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_data": {
+            "path_match": "dns.answers.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_name": {
+            "path_match": "dns.answers.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_ttl": {
+            "path_match": "dns.answers.ttl",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_type": {
+            "path_match": "dns.answers.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_header_flags": {
+            "path_match": "dns.header_flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_id": {
+            "path_match": "dns.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_op_code": {
+            "path_match": "dns.op_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_class": {
+            "path_match": "dns.question.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_name": {
+            "path_match": "dns.question.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_registered_domain": {
+            "path_match": "dns.question.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_subdomain": {
+            "path_match": "dns.question.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_top_level_domain": {
+            "path_match": "dns.question.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_type": {
+            "path_match": "dns.question.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_resolved_ip": {
+            "path_match": "dns.resolved_ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_dns_response_code": {
+            "path_match": "dns.response_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_type": {
+            "path_match": "dns.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_extension": {
+            "path_match": "email.attachments.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_cdhash": {
+            "path_match": "email.attachments.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_md5": {
+            "path_match": "email.attachments.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha1": {
+            "path_match": "email.attachments.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha256": {
+            "path_match": "email.attachments.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha384": {
+            "path_match": "email.attachments.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha512": {
+            "path_match": "email.attachments.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_ssdeep": {
+            "path_match": "email.attachments.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_tlsh": {
+            "path_match": "email.attachments.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_mime_type": {
+            "path_match": "email.attachments.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_name": {
+            "path_match": "email.attachments.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_size": {
+            "path_match": "email.attachments.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_email_bcc_address": {
+            "path_match": "email.bcc.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_cc_address": {
+            "path_match": "email.cc.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_content_type": {
+            "path_match": "email.content_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_delivery_timestamp": {
+            "path_match": "email.delivery_timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_email_direction": {
+            "path_match": "email.direction",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_from_address": {
+            "path_match": "email.from.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_local_id": {
+            "path_match": "email.local_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_message_id": {
+            "path_match": "email.message_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_origination_timestamp": {
+            "path_match": "email.origination_timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_email_reply_to_address": {
+            "path_match": "email.reply_to.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_sender_address": {
+            "path_match": "email.sender.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_subject": {
+            "path_match": "email.subject",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_to_address": {
+            "path_match": "email.to.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_x_mailer": {
+            "path_match": "email.x_mailer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_code": {
+            "path_match": "error.code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_id": {
+            "path_match": "error.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_message": {
+            "path_match": "error.message",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_stack_trace": {
+            "path_match": "error.stack_trace",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_type": {
+            "path_match": "error.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_action": {
+            "path_match": "event.action",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_agent_id_status": {
+            "path_match": "event.agent_id_status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_category": {
+            "path_match": "event.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_changed_fields": {
+            "path_match": "event.changed_fields",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_code": {
+            "path_match": "event.code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_collector": {
+            "path_match": "event.collector",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_created": {
+            "path_match": "event.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_event_dataset": {
+            "path_match": "event.dataset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_duration": {
+            "path_match": "event.duration",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_event_end": {
+            "path_match": "event.end",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_event_hash": {
+            "path_match": "event.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_id": {
+            "path_match": "event.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_ingested": {
+            "path_match": "event.ingested",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_event_kind": {
+            "path_match": "event.kind",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_module": {
+            "path_match": "event.module",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_original": {
+            "path_match": "event.original",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_outcome": {
+            "path_match": "event.outcome",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_provider": {
+            "path_match": "event.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_reason": {
+            "path_match": "event.reason",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_reference": {
+            "path_match": "event.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_risk_score": {
+            "path_match": "event.risk_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_event_risk_score_norm": {
+            "path_match": "event.risk_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_event_sequence": {
+            "path_match": "event.sequence",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_event_severity": {
+            "path_match": "event.severity",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_event_start": {
+            "path_match": "event.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_event_timezone": {
+            "path_match": "event.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_type": {
+            "path_match": "event.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_url": {
+            "path_match": "event.url",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_coldstart": {
+            "path_match": "faas.coldstart",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_faas_execution": {
+            "path_match": "faas.execution",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_id": {
+            "path_match": "faas.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_name": {
+            "path_match": "faas.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_trigger_request_id": {
+            "path_match": "faas.trigger.request_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_trigger_type": {
+            "path_match": "faas.trigger.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_version": {
+            "path_match": "faas.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_accessed": {
+            "path_match": "file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_attributes": {
+            "path_match": "file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_digest_algorithm": {
+            "path_match": "file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_exists": {
+            "path_match": "file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_flags": {
+            "path_match": "file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_signing_id": {
+            "path_match": "file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_status": {
+            "path_match": "file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_subject_name": {
+            "path_match": "file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_team_id": {
+            "path_match": "file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_thumbprint_sha256": {
+            "path_match": "file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_timestamp": {
+            "path_match": "file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_trusted": {
+            "path_match": "file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_valid": {
+            "path_match": "file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_created": {
+            "path_match": "file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_ctime": {
+            "path_match": "file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_device": {
+            "path_match": "file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_diff": {
+            "path_match": "file.diff",
+            "mapping": {
+              "type": "match_only_text"
+            }
+          }
+        },
+        {
+          "wcs_file_directory": {
+            "path_match": "file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_drive_letter": {
+            "path_match": "file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_architecture": {
+            "path_match": "file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_byte_order": {
+            "path_match": "file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_cpu_type": {
+            "path_match": "file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_creation_date": {
+            "path_match": "file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_exports": {
+            "path_match": "file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_import_hash": {
+            "path_match": "file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_imports": {
+            "path_match": "file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_imports_names_entropy": {
+            "path_match": "file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_imports_names_var_entropy": {
+            "path_match": "file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_stripped": {
+            "path_match": "file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_abi_version": {
+            "path_match": "file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_class": {
+            "path_match": "file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_data": {
+            "path_match": "file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_entrypoint": {
+            "path_match": "file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_object_version": {
+            "path_match": "file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_os_abi": {
+            "path_match": "file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_type": {
+            "path_match": "file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_version": {
+            "path_match": "file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_import_hash": {
+            "path_match": "file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_imports": {
+            "path_match": "file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_imports_names_entropy": {
+            "path_match": "file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_imports_names_var_entropy": {
+            "path_match": "file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_chi2": {
+            "path_match": "file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_entropy": {
+            "path_match": "file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_flags": {
+            "path_match": "file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_name": {
+            "path_match": "file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_physical_offset": {
+            "path_match": "file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_physical_size": {
+            "path_match": "file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_type": {
+            "path_match": "file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_var_entropy": {
+            "path_match": "file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_virtual_address": {
+            "path_match": "file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_virtual_size": {
+            "path_match": "file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_segments_sections": {
+            "path_match": "file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_segments_type": {
+            "path_match": "file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_shared_libraries": {
+            "path_match": "file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_telfhash": {
+            "path_match": "file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_extension": {
+            "path_match": "file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_fork_name": {
+            "path_match": "file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_gid": {
+            "path_match": "file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_group": {
+            "path_match": "file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_cdhash": {
+            "path_match": "file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_md5": {
+            "path_match": "file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha1": {
+            "path_match": "file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha256": {
+            "path_match": "file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha384": {
+            "path_match": "file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha512": {
+            "path_match": "file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_ssdeep": {
+            "path_match": "file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_tlsh": {
+            "path_match": "file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_inode": {
+            "path_match": "file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_import_hash": {
+            "path_match": "file.macho.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_imports": {
+            "path_match": "file.macho.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_imports_names_entropy": {
+            "path_match": "file.macho.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_imports_names_var_entropy": {
+            "path_match": "file.macho.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_stripped": {
+            "path_match": "file.macho.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_import_hash": {
+            "path_match": "file.macho.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_imports": {
+            "path_match": "file.macho.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_imports_names_entropy": {
+            "path_match": "file.macho.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_imports_names_var_entropy": {
+            "path_match": "file.macho.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_entropy": {
+            "path_match": "file.macho.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_name": {
+            "path_match": "file.macho.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_physical_size": {
+            "path_match": "file.macho.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_var_entropy": {
+            "path_match": "file.macho.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_virtual_size": {
+            "path_match": "file.macho.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_symhash": {
+            "path_match": "file.macho.symhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_mime_type": {
+            "path_match": "file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_mode": {
+            "path_match": "file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_mtime": {
+            "path_match": "file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_name": {
+            "path_match": "file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_origin_referrer_url": {
+            "path_match": "file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_origin_url": {
+            "path_match": "file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_owner": {
+            "path_match": "file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_path": {
+            "path_match": "file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_architecture": {
+            "path_match": "file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_company": {
+            "path_match": "file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_description": {
+            "path_match": "file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_file_version": {
+            "path_match": "file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_import_hash": {
+            "path_match": "file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_imports": {
+            "path_match": "file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_imports_names_entropy": {
+            "path_match": "file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_imports_names_var_entropy": {
+            "path_match": "file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_stripped": {
+            "path_match": "file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imphash": {
+            "path_match": "file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_import_hash": {
+            "path_match": "file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imports": {
+            "path_match": "file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imports_names_entropy": {
+            "path_match": "file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imports_names_var_entropy": {
+            "path_match": "file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_original_file_name": {
+            "path_match": "file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_pehash": {
+            "path_match": "file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_product": {
+            "path_match": "file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_entropy": {
+            "path_match": "file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_name": {
+            "path_match": "file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_physical_size": {
+            "path_match": "file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_var_entropy": {
+            "path_match": "file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_virtual_size": {
+            "path_match": "file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_size": {
+            "path_match": "file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_target_path": {
+            "path_match": "file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_type": {
+            "path_match": "file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_uid": {
+            "path_match": "file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_alternative_names": {
+            "path_match": "file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_common_name": {
+            "path_match": "file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_country": {
+            "path_match": "file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_distinguished_name": {
+            "path_match": "file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_locality": {
+            "path_match": "file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_organization": {
+            "path_match": "file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_organizational_unit": {
+            "path_match": "file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_state_or_province": {
+            "path_match": "file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_not_after": {
+            "path_match": "file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_not_before": {
+            "path_match": "file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_algorithm": {
+            "path_match": "file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_curve": {
+            "path_match": "file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_exponent": {
+            "path_match": "file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_size": {
+            "path_match": "file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_serial_number": {
+            "path_match": "file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_signature_algorithm": {
+            "path_match": "file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_common_name": {
+            "path_match": "file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_country": {
+            "path_match": "file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_distinguished_name": {
+            "path_match": "file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_locality": {
+            "path_match": "file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_organization": {
+            "path_match": "file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_organizational_unit": {
+            "path_match": "file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_state_or_province": {
+            "path_match": "file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_version_number": {
+            "path_match": "file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_agent_description": {
+            "path_match": "gen_ai.agent.description",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_agent_id": {
+            "path_match": "gen_ai.agent.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_agent_name": {
+            "path_match": "gen_ai.agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_operation_name": {
+            "path_match": "gen_ai.operation.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_output_type": {
+            "path_match": "gen_ai.output.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_choice_count": {
+            "path_match": "gen_ai.request.choice.count",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_encoding_formats": {
+            "path_match": "gen_ai.request.encoding_formats",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_frequency_penalty": {
+            "path_match": "gen_ai.request.frequency_penalty",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_max_tokens": {
+            "path_match": "gen_ai.request.max_tokens",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_model": {
+            "path_match": "gen_ai.request.model",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_presence_penalty": {
+            "path_match": "gen_ai.request.presence_penalty",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_seed": {
+            "path_match": "gen_ai.request.seed",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_stop_sequences": {
+            "path_match": "gen_ai.request.stop_sequences",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_temperature": {
+            "path_match": "gen_ai.request.temperature",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_top_k": {
+            "path_match": "gen_ai.request.top_k",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_top_p": {
+            "path_match": "gen_ai.request.top_p",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_response_finish_reasons": {
+            "path_match": "gen_ai.response.finish_reasons",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_response_id": {
+            "path_match": "gen_ai.response.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_response_model": {
+            "path_match": "gen_ai.response.model",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_system": {
+            "path_match": "gen_ai.system",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_token_type": {
+            "path_match": "gen_ai.token.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_tool_call_id": {
+            "path_match": "gen_ai.tool.call.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_tool_name": {
+            "path_match": "gen_ai.tool.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_tool_type": {
+            "path_match": "gen_ai.tool.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_usage_input_tokens": {
+            "path_match": "gen_ai.usage.input_tokens",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_usage_output_tokens": {
+            "path_match": "gen_ai.usage.output_tokens",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_group_domain": {
+            "path_match": "group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_group_id": {
+            "path_match": "group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_group_name": {
+            "path_match": "group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_architecture": {
+            "path_match": "host.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_boot_id": {
+            "path_match": "host.boot.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_cores": {
+            "path_match": "host.cpu.cores",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_name": {
+            "path_match": "host.cpu.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_speed": {
+            "path_match": "host.cpu.speed",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_usage": {
+            "path_match": "host.cpu.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_host_disk_read_bytes": {
+            "path_match": "host.disk.read.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_disk_write_bytes": {
+            "path_match": "host.disk.write.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_domain": {
+            "path_match": "host.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_city_name": {
+            "path_match": "host.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_continent_code": {
+            "path_match": "host.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_continent_name": {
+            "path_match": "host.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_country_iso_code": {
+            "path_match": "host.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_country_name": {
+            "path_match": "host.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_location": {
+            "path_match": "host.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_name": {
+            "path_match": "host.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_postal_code": {
+            "path_match": "host.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_region_iso_code": {
+            "path_match": "host.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_region_name": {
+            "path_match": "host.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_timezone": {
+            "path_match": "host.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_hostname": {
+            "path_match": "host.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_id": {
+            "path_match": "host.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_ip": {
+            "path_match": "host.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_host_mac": {
+            "path_match": "host.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_memory_free": {
+            "path_match": "host.memory.free",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_memory_total": {
+            "path_match": "host.memory.total",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_memory_used_percentage": {
+            "path_match": "host.memory.used.percentage",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_name": {
+            "path_match": "host.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_bytes": {
+            "path_match": "host.network.egress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_drops": {
+            "path_match": "host.network.egress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_errors": {
+            "path_match": "host.network.egress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_packets": {
+            "path_match": "host.network.egress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_queue": {
+            "path_match": "host.network.egress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_bytes": {
+            "path_match": "host.network.ingress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_drops": {
+            "path_match": "host.network.ingress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_errors": {
+            "path_match": "host.network.ingress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_packets": {
+            "path_match": "host.network.ingress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_queue": {
+            "path_match": "host.network.ingress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_os_family": {
+            "path_match": "host.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_full": {
+            "path_match": "host.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_kernel": {
+            "path_match": "host.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_name": {
+            "path_match": "host.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_platform": {
+            "path_match": "host.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_type": {
+            "path_match": "host.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_version": {
+            "path_match": "host.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_pid_ns_ino": {
+            "path_match": "host.pid_ns_ino",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_calculated_level": {
+            "path_match": "host.risk.calculated_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_calculated_score": {
+            "path_match": "host.risk.calculated_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_calculated_score_norm": {
+            "path_match": "host.risk.calculated_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_static_level": {
+            "path_match": "host.risk.static_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_static_score": {
+            "path_match": "host.risk.static_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_static_score_norm": {
+            "path_match": "host.risk.static_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_type": {
+            "path_match": "host.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_uptime": {
+            "path_match": "host.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_request_body_bytes": {
+            "path_match": "http.request.body.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_request_body_content": {
+            "path_match": "http.request.body.content",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_bytes": {
+            "path_match": "http.request.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_request_id": {
+            "path_match": "http.request.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_method": {
+            "path_match": "http.request.method",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_mime_type": {
+            "path_match": "http.request.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_referrer": {
+            "path_match": "http.request.referrer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_response_body_bytes": {
+            "path_match": "http.response.body.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_response_body_content": {
+            "path_match": "http.response.body.content",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_response_bytes": {
+            "path_match": "http.response.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_response_mime_type": {
+            "path_match": "http.response.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_response_status_code": {
+            "path_match": "http.response.status_code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_version": {
+            "path_match": "http.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_alias": {
+            "path_match": "interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_id": {
+            "path_match": "interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_mtu": {
+            "path_match": "interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_interface_name": {
+            "path_match": "interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_state": {
+            "path_match": "interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_type": {
+            "path_match": "interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_file_path": {
+            "path_match": "log.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_level": {
+            "path_match": "log.level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_logger": {
+            "path_match": "log.logger",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_origin_file_line": {
+            "path_match": "log.origin.file.line",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_origin_file_name": {
+            "path_match": "log.origin.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_origin_function": {
+            "path_match": "log.origin.function",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_appname": {
+            "path_match": "log.syslog.appname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_facility_code": {
+            "path_match": "log.syslog.facility.code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_facility_name": {
+            "path_match": "log.syslog.facility.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_hostname": {
+            "path_match": "log.syslog.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_msgid": {
+            "path_match": "log.syslog.msgid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_priority": {
+            "path_match": "log.syslog.priority",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_procid": {
+            "path_match": "log.syslog.procid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_severity_code": {
+            "path_match": "log.syslog.severity.code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_severity_name": {
+            "path_match": "log.syslog.severity.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_structured_data": {
+            "path_match": "log.syslog.structured_data",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_version": {
+            "path_match": "log.syslog.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_subtechnique_id": {
+            "path_match": "mitre.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_subtechnique_name": {
+            "path_match": "mitre.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_tactic_id": {
+            "path_match": "mitre.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_tactic_name": {
+            "path_match": "mitre.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_technique_id": {
+            "path_match": "mitre.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_technique_name": {
+            "path_match": "mitre.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_application": {
+            "path_match": "network.application",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_broadcast": {
+            "path_match": "network.broadcast",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_bytes": {
+            "path_match": "network.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_network_community_id": {
+            "path_match": "network.community_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_dhcp": {
+            "path_match": "network.dhcp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_direction": {
+            "path_match": "network.direction",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_forwarded_ip": {
+            "path_match": "network.forwarded_ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_gateway": {
+            "path_match": "network.gateway",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_iana_number": {
+            "path_match": "network.iana_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_inner_vlan_id": {
+            "path_match": "network.inner.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_inner_vlan_name": {
+            "path_match": "network.inner.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_metric": {
+            "path_match": "network.metric",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_network_name": {
+            "path_match": "network.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_netmask": {
+            "path_match": "network.netmask",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_packets": {
+            "path_match": "network.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_network_protocol": {
+            "path_match": "network.protocol",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_transport": {
+            "path_match": "network.transport",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_type": {
+            "path_match": "network.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_vlan_id": {
+            "path_match": "network.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_vlan_name": {
+            "path_match": "network.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_alias": {
+            "path_match": "observer.egress.interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_id": {
+            "path_match": "observer.egress.interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_mtu": {
+            "path_match": "observer.egress.interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_name": {
+            "path_match": "observer.egress.interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_alias": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_id": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_mtu": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_name": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_state": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_type": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_state": {
+            "path_match": "observer.egress.interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_type": {
+            "path_match": "observer.egress.interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_vlan_id": {
+            "path_match": "observer.egress.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_vlan_name": {
+            "path_match": "observer.egress.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_zone": {
+            "path_match": "observer.egress.zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_city_name": {
+            "path_match": "observer.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_continent_code": {
+            "path_match": "observer.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_continent_name": {
+            "path_match": "observer.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_country_iso_code": {
+            "path_match": "observer.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_country_name": {
+            "path_match": "observer.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_location": {
+            "path_match": "observer.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_name": {
+            "path_match": "observer.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_postal_code": {
+            "path_match": "observer.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_region_iso_code": {
+            "path_match": "observer.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_region_name": {
+            "path_match": "observer.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_timezone": {
+            "path_match": "observer.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_hostname": {
+            "path_match": "observer.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_alias": {
+            "path_match": "observer.ingress.interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_id": {
+            "path_match": "observer.ingress.interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_mtu": {
+            "path_match": "observer.ingress.interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_name": {
+            "path_match": "observer.ingress.interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_state": {
+            "path_match": "observer.ingress.interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_type": {
+            "path_match": "observer.ingress.interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_vlan_id": {
+            "path_match": "observer.ingress.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_vlan_name": {
+            "path_match": "observer.ingress.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_zone": {
+            "path_match": "observer.ingress.zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ip": {
+            "path_match": "observer.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_observer_mac": {
+            "path_match": "observer.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_name": {
+            "path_match": "observer.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_family": {
+            "path_match": "observer.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_full": {
+            "path_match": "observer.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_kernel": {
+            "path_match": "observer.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_name": {
+            "path_match": "observer.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_platform": {
+            "path_match": "observer.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_type": {
+            "path_match": "observer.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_version": {
+            "path_match": "observer.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_product": {
+            "path_match": "observer.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_serial_number": {
+            "path_match": "observer.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_type": {
+            "path_match": "observer.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_vendor": {
+            "path_match": "observer.vendor",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_version": {
+            "path_match": "observer.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_api_version": {
+            "path_match": "orchestrator.api_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_id": {
+            "path_match": "orchestrator.cluster.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_name": {
+            "path_match": "orchestrator.cluster.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_url": {
+            "path_match": "orchestrator.cluster.url",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_version": {
+            "path_match": "orchestrator.cluster.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_namespace": {
+            "path_match": "orchestrator.namespace",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_organization": {
+            "path_match": "orchestrator.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_annotation": {
+            "path_match": "orchestrator.resource.annotation",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_id": {
+            "path_match": "orchestrator.resource.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_ip": {
+            "path_match": "orchestrator.resource.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_label": {
+            "path_match": "orchestrator.resource.label",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_name": {
+            "path_match": "orchestrator.resource.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_parent_type": {
+            "path_match": "orchestrator.resource.parent.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_type": {
+            "path_match": "orchestrator.resource.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_type": {
+            "path_match": "orchestrator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_organization_id": {
+            "path_match": "organization.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_organization_name": {
+            "path_match": "organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_architecture": {
+            "path_match": "package.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_build_version": {
+            "path_match": "package.build_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_checksum": {
+            "path_match": "package.checksum",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_description": {
+            "path_match": "package.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_install_scope": {
+            "path_match": "package.install_scope",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_installed": {
+            "path_match": "package.installed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_package_license": {
+            "path_match": "package.license",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_name": {
+            "path_match": "package.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_path": {
+            "path_match": "package.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_previous_installed": {
+            "path_match": "package.previous.installed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_package_reference": {
+            "path_match": "package.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_size": {
+            "path_match": "package.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_package_type": {
+            "path_match": "package.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_version": {
+            "path_match": "package.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_description": {
+            "path_match": "policy.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_file": {
+            "path_match": "policy.file",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_id": {
+            "path_match": "policy.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_name": {
+            "path_match": "policy.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_references": {
+            "path_match": "policy.references",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_args": {
+            "path_match": "process.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_args_count": {
+            "path_match": "process.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_digest_algorithm": {
+            "path_match": "process.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_exists": {
+            "path_match": "process.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_flags": {
+            "path_match": "process.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_signing_id": {
+            "path_match": "process.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_status": {
+            "path_match": "process.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_subject_name": {
+            "path_match": "process.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_team_id": {
+            "path_match": "process.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_thumbprint_sha256": {
+            "path_match": "process.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_timestamp": {
+            "path_match": "process.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_trusted": {
+            "path_match": "process.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_valid": {
+            "path_match": "process.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_command_line": {
+            "path_match": "process.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_architecture": {
+            "path_match": "process.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_byte_order": {
+            "path_match": "process.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_cpu_type": {
+            "path_match": "process.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_creation_date": {
+            "path_match": "process.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_exports": {
+            "path_match": "process.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_import_hash": {
+            "path_match": "process.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_imports": {
+            "path_match": "process.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_imports_names_entropy": {
+            "path_match": "process.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_imports_names_var_entropy": {
+            "path_match": "process.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_stripped": {
+            "path_match": "process.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_abi_version": {
+            "path_match": "process.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_class": {
+            "path_match": "process.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_data": {
+            "path_match": "process.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_entrypoint": {
+            "path_match": "process.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_object_version": {
+            "path_match": "process.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_os_abi": {
+            "path_match": "process.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_type": {
+            "path_match": "process.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_version": {
+            "path_match": "process.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_import_hash": {
+            "path_match": "process.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_imports": {
+            "path_match": "process.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_imports_names_entropy": {
+            "path_match": "process.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_imports_names_var_entropy": {
+            "path_match": "process.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_chi2": {
+            "path_match": "process.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_entropy": {
+            "path_match": "process.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_flags": {
+            "path_match": "process.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_name": {
+            "path_match": "process.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_physical_offset": {
+            "path_match": "process.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_physical_size": {
+            "path_match": "process.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_type": {
+            "path_match": "process.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_var_entropy": {
+            "path_match": "process.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_virtual_address": {
+            "path_match": "process.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_virtual_size": {
+            "path_match": "process.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_segments_sections": {
+            "path_match": "process.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_segments_type": {
+            "path_match": "process.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_shared_libraries": {
+            "path_match": "process.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_telfhash": {
+            "path_match": "process.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_end": {
+            "path_match": "process.end",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entity_id": {
+            "path_match": "process.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_args": {
+            "path_match": "process.entry_leader.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_args_count": {
+            "path_match": "process.entry_leader.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_attested_groups_name": {
+            "path_match": "process.entry_leader.attested_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_attested_user_id": {
+            "path_match": "process.entry_leader.attested_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_attested_user_name": {
+            "path_match": "process.entry_leader.attested_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_command_line": {
+            "path_match": "process.entry_leader.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_entity_id": {
+            "path_match": "process.entry_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_entry_meta_source_ip": {
+            "path_match": "process.entry_leader.entry_meta.source.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_entry_meta_type": {
+            "path_match": "process.entry_leader.entry_meta.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_executable": {
+            "path_match": "process.entry_leader.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_group_id": {
+            "path_match": "process.entry_leader.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_group_name": {
+            "path_match": "process.entry_leader.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_interactive": {
+            "path_match": "process.entry_leader.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_name": {
+            "path_match": "process.entry_leader.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_entity_id": {
+            "path_match": "process.entry_leader.parent.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_pid": {
+            "path_match": "process.entry_leader.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_entity_id": {
+            "path_match": "process.entry_leader.parent.session_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_pid": {
+            "path_match": "process.entry_leader.parent.session_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_start": {
+            "path_match": "process.entry_leader.parent.session_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_vpid": {
+            "path_match": "process.entry_leader.parent.session_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_start": {
+            "path_match": "process.entry_leader.parent.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_vpid": {
+            "path_match": "process.entry_leader.parent.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_pid": {
+            "path_match": "process.entry_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_group_id": {
+            "path_match": "process.entry_leader.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_group_name": {
+            "path_match": "process.entry_leader.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_user_id": {
+            "path_match": "process.entry_leader.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_user_name": {
+            "path_match": "process.entry_leader.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_same_as_process": {
+            "path_match": "process.entry_leader.same_as_process",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_group_id": {
+            "path_match": "process.entry_leader.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_group_name": {
+            "path_match": "process.entry_leader.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_user_id": {
+            "path_match": "process.entry_leader.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_user_name": {
+            "path_match": "process.entry_leader.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_start": {
+            "path_match": "process.entry_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_supplemental_groups_id": {
+            "path_match": "process.entry_leader.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_supplemental_groups_name": {
+            "path_match": "process.entry_leader.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_tty_char_device_major": {
+            "path_match": "process.entry_leader.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_tty_char_device_minor": {
+            "path_match": "process.entry_leader.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_user_id": {
+            "path_match": "process.entry_leader.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_user_name": {
+            "path_match": "process.entry_leader.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_vpid": {
+            "path_match": "process.entry_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_working_directory": {
+            "path_match": "process.entry_leader.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_env_vars": {
+            "path_match": "process.env_vars",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_executable": {
+            "path_match": "process.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_exit_code": {
+            "path_match": "process.exit_code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_id": {
+            "path_match": "process.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_args": {
+            "path_match": "process.group_leader.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_args_count": {
+            "path_match": "process.group_leader.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_command_line": {
+            "path_match": "process.group_leader.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_entity_id": {
+            "path_match": "process.group_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_executable": {
+            "path_match": "process.group_leader.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_group_id": {
+            "path_match": "process.group_leader.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_group_name": {
+            "path_match": "process.group_leader.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_interactive": {
+            "path_match": "process.group_leader.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_name": {
+            "path_match": "process.group_leader.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_pid": {
+            "path_match": "process.group_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_group_id": {
+            "path_match": "process.group_leader.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_group_name": {
+            "path_match": "process.group_leader.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_user_id": {
+            "path_match": "process.group_leader.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_user_name": {
+            "path_match": "process.group_leader.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_same_as_process": {
+            "path_match": "process.group_leader.same_as_process",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_group_id": {
+            "path_match": "process.group_leader.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_group_name": {
+            "path_match": "process.group_leader.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_user_id": {
+            "path_match": "process.group_leader.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_user_name": {
+            "path_match": "process.group_leader.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_start": {
+            "path_match": "process.group_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_supplemental_groups_id": {
+            "path_match": "process.group_leader.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_supplemental_groups_name": {
+            "path_match": "process.group_leader.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_tty_char_device_major": {
+            "path_match": "process.group_leader.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_tty_char_device_minor": {
+            "path_match": "process.group_leader.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_user_id": {
+            "path_match": "process.group_leader.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_user_name": {
+            "path_match": "process.group_leader.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_vpid": {
+            "path_match": "process.group_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_working_directory": {
+            "path_match": "process.group_leader.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_name": {
+            "path_match": "process.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_cdhash": {
+            "path_match": "process.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_md5": {
+            "path_match": "process.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha1": {
+            "path_match": "process.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha256": {
+            "path_match": "process.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha384": {
+            "path_match": "process.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha512": {
+            "path_match": "process.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_ssdeep": {
+            "path_match": "process.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_tlsh": {
+            "path_match": "process.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_interactive": {
+            "path_match": "process.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_io_bytes_skipped_length": {
+            "path_match": "process.io.bytes_skipped.length",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_bytes_skipped_offset": {
+            "path_match": "process.io.bytes_skipped.offset",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_max_bytes_per_process_exceeded": {
+            "path_match": "process.io.max_bytes_per_process_exceeded",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_io_text": {
+            "path_match": "process.io.text",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_io_total_bytes_captured": {
+            "path_match": "process.io.total_bytes_captured",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_total_bytes_skipped": {
+            "path_match": "process.io.total_bytes_skipped",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_type": {
+            "path_match": "process.io.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_import_hash": {
+            "path_match": "process.macho.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_imports": {
+            "path_match": "process.macho.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_imports_names_entropy": {
+            "path_match": "process.macho.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_imports_names_var_entropy": {
+            "path_match": "process.macho.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_stripped": {
+            "path_match": "process.macho.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_import_hash": {
+            "path_match": "process.macho.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_imports": {
+            "path_match": "process.macho.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_imports_names_entropy": {
+            "path_match": "process.macho.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_imports_names_var_entropy": {
+            "path_match": "process.macho.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_entropy": {
+            "path_match": "process.macho.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_name": {
+            "path_match": "process.macho.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_physical_size": {
+            "path_match": "process.macho.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_var_entropy": {
+            "path_match": "process.macho.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_virtual_size": {
+            "path_match": "process.macho.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_symhash": {
+            "path_match": "process.macho.symhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_name": {
+            "path_match": "process.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_args": {
+            "path_match": "process.parent.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_args_count": {
+            "path_match": "process.parent.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_digest_algorithm": {
+            "path_match": "process.parent.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_exists": {
+            "path_match": "process.parent.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_flags": {
+            "path_match": "process.parent.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_signing_id": {
+            "path_match": "process.parent.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_status": {
+            "path_match": "process.parent.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_subject_name": {
+            "path_match": "process.parent.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_team_id": {
+            "path_match": "process.parent.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_thumbprint_sha256": {
+            "path_match": "process.parent.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_timestamp": {
+            "path_match": "process.parent.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_trusted": {
+            "path_match": "process.parent.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_valid": {
+            "path_match": "process.parent.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_command_line": {
+            "path_match": "process.parent.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_architecture": {
+            "path_match": "process.parent.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_byte_order": {
+            "path_match": "process.parent.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_cpu_type": {
+            "path_match": "process.parent.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_creation_date": {
+            "path_match": "process.parent.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_exports": {
+            "path_match": "process.parent.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_import_hash": {
+            "path_match": "process.parent.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_imports": {
+            "path_match": "process.parent.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_imports_names_entropy": {
+            "path_match": "process.parent.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_imports_names_var_entropy": {
+            "path_match": "process.parent.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_stripped": {
+            "path_match": "process.parent.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_abi_version": {
+            "path_match": "process.parent.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_class": {
+            "path_match": "process.parent.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_data": {
+            "path_match": "process.parent.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_entrypoint": {
+            "path_match": "process.parent.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_object_version": {
+            "path_match": "process.parent.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_os_abi": {
+            "path_match": "process.parent.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_type": {
+            "path_match": "process.parent.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_version": {
+            "path_match": "process.parent.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_import_hash": {
+            "path_match": "process.parent.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_imports": {
+            "path_match": "process.parent.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_imports_names_entropy": {
+            "path_match": "process.parent.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_imports_names_var_entropy": {
+            "path_match": "process.parent.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_chi2": {
+            "path_match": "process.parent.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_entropy": {
+            "path_match": "process.parent.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_flags": {
+            "path_match": "process.parent.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_name": {
+            "path_match": "process.parent.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_physical_offset": {
+            "path_match": "process.parent.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_physical_size": {
+            "path_match": "process.parent.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_type": {
+            "path_match": "process.parent.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_var_entropy": {
+            "path_match": "process.parent.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_virtual_address": {
+            "path_match": "process.parent.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_virtual_size": {
+            "path_match": "process.parent.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_segments_sections": {
+            "path_match": "process.parent.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_segments_type": {
+            "path_match": "process.parent.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_shared_libraries": {
+            "path_match": "process.parent.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_telfhash": {
+            "path_match": "process.parent.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_end": {
+            "path_match": "process.parent.end",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_entity_id": {
+            "path_match": "process.parent.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_executable": {
+            "path_match": "process.parent.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_exit_code": {
+            "path_match": "process.parent.exit_code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_id": {
+            "path_match": "process.parent.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_entity_id": {
+            "path_match": "process.parent.group_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_pid": {
+            "path_match": "process.parent.group_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_start": {
+            "path_match": "process.parent.group_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_vpid": {
+            "path_match": "process.parent.group_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_name": {
+            "path_match": "process.parent.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_cdhash": {
+            "path_match": "process.parent.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_md5": {
+            "path_match": "process.parent.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha1": {
+            "path_match": "process.parent.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha256": {
+            "path_match": "process.parent.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha384": {
+            "path_match": "process.parent.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha512": {
+            "path_match": "process.parent.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_ssdeep": {
+            "path_match": "process.parent.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_tlsh": {
+            "path_match": "process.parent.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_interactive": {
+            "path_match": "process.parent.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_import_hash": {
+            "path_match": "process.parent.macho.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_imports": {
+            "path_match": "process.parent.macho.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_imports_names_entropy": {
+            "path_match": "process.parent.macho.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_imports_names_var_entropy": {
+            "path_match": "process.parent.macho.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_stripped": {
+            "path_match": "process.parent.macho.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_import_hash": {
+            "path_match": "process.parent.macho.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_imports": {
+            "path_match": "process.parent.macho.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_imports_names_entropy": {
+            "path_match": "process.parent.macho.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_imports_names_var_entropy": {
+            "path_match": "process.parent.macho.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_entropy": {
+            "path_match": "process.parent.macho.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_name": {
+            "path_match": "process.parent.macho.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_physical_size": {
+            "path_match": "process.parent.macho.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_var_entropy": {
+            "path_match": "process.parent.macho.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_virtual_size": {
+            "path_match": "process.parent.macho.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_symhash": {
+            "path_match": "process.parent.macho.symhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_name": {
+            "path_match": "process.parent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_architecture": {
+            "path_match": "process.parent.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_company": {
+            "path_match": "process.parent.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_description": {
+            "path_match": "process.parent.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_file_version": {
+            "path_match": "process.parent.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_import_hash": {
+            "path_match": "process.parent.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_imports": {
+            "path_match": "process.parent.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_imports_names_entropy": {
+            "path_match": "process.parent.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_imports_names_var_entropy": {
+            "path_match": "process.parent.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_stripped": {
+            "path_match": "process.parent.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imphash": {
+            "path_match": "process.parent.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_import_hash": {
+            "path_match": "process.parent.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imports": {
+            "path_match": "process.parent.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imports_names_entropy": {
+            "path_match": "process.parent.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imports_names_var_entropy": {
+            "path_match": "process.parent.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_original_file_name": {
+            "path_match": "process.parent.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_pehash": {
+            "path_match": "process.parent.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_product": {
+            "path_match": "process.parent.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_entropy": {
+            "path_match": "process.parent.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_name": {
+            "path_match": "process.parent.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_physical_size": {
+            "path_match": "process.parent.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_var_entropy": {
+            "path_match": "process.parent.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_virtual_size": {
+            "path_match": "process.parent.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pid": {
+            "path_match": "process.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_group_id": {
+            "path_match": "process.parent.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_group_name": {
+            "path_match": "process.parent.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_user_id": {
+            "path_match": "process.parent.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_user_name": {
+            "path_match": "process.parent.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_group_id": {
+            "path_match": "process.parent.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_group_name": {
+            "path_match": "process.parent.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_user_id": {
+            "path_match": "process.parent.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_user_name": {
+            "path_match": "process.parent.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_start": {
+            "path_match": "process.parent.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_supplemental_groups_id": {
+            "path_match": "process.parent.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_supplemental_groups_name": {
+            "path_match": "process.parent.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_capabilities_effective": {
+            "path_match": "process.parent.thread.capabilities.effective",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_capabilities_permitted": {
+            "path_match": "process.parent.thread.capabilities.permitted",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_id": {
+            "path_match": "process.parent.thread.id",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_name": {
+            "path_match": "process.parent.thread.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_title": {
+            "path_match": "process.parent.title",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_tty_char_device_major": {
+            "path_match": "process.parent.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_tty_char_device_minor": {
+            "path_match": "process.parent.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_uptime": {
+            "path_match": "process.parent.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_user_id": {
+            "path_match": "process.parent.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_user_name": {
+            "path_match": "process.parent.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_vpid": {
+            "path_match": "process.parent.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_working_directory": {
+            "path_match": "process.parent.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_architecture": {
+            "path_match": "process.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_company": {
+            "path_match": "process.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_description": {
+            "path_match": "process.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_file_version": {
+            "path_match": "process.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_import_hash": {
+            "path_match": "process.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_imports": {
+            "path_match": "process.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_imports_names_entropy": {
+            "path_match": "process.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_imports_names_var_entropy": {
+            "path_match": "process.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_stripped": {
+            "path_match": "process.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imphash": {
+            "path_match": "process.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_import_hash": {
+            "path_match": "process.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imports": {
+            "path_match": "process.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imports_names_entropy": {
+            "path_match": "process.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imports_names_var_entropy": {
+            "path_match": "process.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_original_file_name": {
+            "path_match": "process.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_pehash": {
+            "path_match": "process.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_product": {
+            "path_match": "process.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_entropy": {
+            "path_match": "process.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_name": {
+            "path_match": "process.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_physical_size": {
+            "path_match": "process.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_var_entropy": {
+            "path_match": "process.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_virtual_size": {
+            "path_match": "process.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pid": {
+            "path_match": "process.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_args": {
+            "path_match": "process.previous.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_args_count": {
+            "path_match": "process.previous.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_command_line": {
+            "path_match": "process.previous.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_executable": {
+            "path_match": "process.previous.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_name": {
+            "path_match": "process.previous.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_parent_pid": {
+            "path_match": "process.previous.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_pid": {
+            "path_match": "process.previous.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_state": {
+            "path_match": "process.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_group_id": {
+            "path_match": "process.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_group_name": {
+            "path_match": "process.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_user_id": {
+            "path_match": "process.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_user_name": {
+            "path_match": "process.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_group_id": {
+            "path_match": "process.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_group_name": {
+            "path_match": "process.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_user_id": {
+            "path_match": "process.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_user_name": {
+            "path_match": "process.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_args": {
+            "path_match": "process.session_leader.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_args_count": {
+            "path_match": "process.session_leader.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_command_line": {
+            "path_match": "process.session_leader.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_entity_id": {
+            "path_match": "process.session_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_executable": {
+            "path_match": "process.session_leader.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_group_id": {
+            "path_match": "process.session_leader.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_group_name": {
+            "path_match": "process.session_leader.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_interactive": {
+            "path_match": "process.session_leader.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_name": {
+            "path_match": "process.session_leader.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_entity_id": {
+            "path_match": "process.session_leader.parent.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_pid": {
+            "path_match": "process.session_leader.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_entity_id": {
+            "path_match": "process.session_leader.parent.session_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_pid": {
+            "path_match": "process.session_leader.parent.session_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_start": {
+            "path_match": "process.session_leader.parent.session_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_vpid": {
+            "path_match": "process.session_leader.parent.session_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_start": {
+            "path_match": "process.session_leader.parent.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_vpid": {
+            "path_match": "process.session_leader.parent.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_pid": {
+            "path_match": "process.session_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_group_id": {
+            "path_match": "process.session_leader.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_group_name": {
+            "path_match": "process.session_leader.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_user_id": {
+            "path_match": "process.session_leader.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_user_name": {
+            "path_match": "process.session_leader.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_same_as_process": {
+            "path_match": "process.session_leader.same_as_process",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_group_id": {
+            "path_match": "process.session_leader.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_group_name": {
+            "path_match": "process.session_leader.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_user_id": {
+            "path_match": "process.session_leader.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_user_name": {
+            "path_match": "process.session_leader.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_start": {
+            "path_match": "process.session_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_supplemental_groups_id": {
+            "path_match": "process.session_leader.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_supplemental_groups_name": {
+            "path_match": "process.session_leader.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_tty_char_device_major": {
+            "path_match": "process.session_leader.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_tty_char_device_minor": {
+            "path_match": "process.session_leader.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_user_id": {
+            "path_match": "process.session_leader.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_user_name": {
+            "path_match": "process.session_leader.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_vpid": {
+            "path_match": "process.session_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_working_directory": {
+            "path_match": "process.session_leader.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_start": {
+            "path_match": "process.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_state": {
+            "path_match": "process.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_supplemental_groups_id": {
+            "path_match": "process.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_supplemental_groups_name": {
+            "path_match": "process.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_capabilities_effective": {
+            "path_match": "process.thread.capabilities.effective",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_capabilities_permitted": {
+            "path_match": "process.thread.capabilities.permitted",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_id": {
+            "path_match": "process.thread.id",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_name": {
+            "path_match": "process.thread.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_title": {
+            "path_match": "process.title",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_char_device_major": {
+            "path_match": "process.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_char_device_minor": {
+            "path_match": "process.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_columns": {
+            "path_match": "process.tty.columns",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_rows": {
+            "path_match": "process.tty.rows",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_uptime": {
+            "path_match": "process.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_user_id": {
+            "path_match": "process.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_user_name": {
+            "path_match": "process.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_vpid": {
+            "path_match": "process.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_working_directory": {
+            "path_match": "process.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_data_bytes": {
+            "path_match": "registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_data_strings": {
+            "path_match": "registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_data_type": {
+            "path_match": "registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_hive": {
+            "path_match": "registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_key": {
+            "path_match": "registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_path": {
+            "path_match": "registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_value": {
+            "path_match": "registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_related_hash": {
+            "path_match": "related.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_related_hosts": {
+            "path_match": "related.hosts",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_related_ip": {
+            "path_match": "related.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_related_user": {
+            "path_match": "related.user",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_author": {
+            "path_match": "rule.author",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_category": {
+            "path_match": "rule.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_cmmc": {
+            "path_match": "rule.compliance.cmmc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_fedramp": {
+            "path_match": "rule.compliance.fedramp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_gdpr": {
+            "path_match": "rule.compliance.gdpr",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_hipaa": {
+            "path_match": "rule.compliance.hipaa",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_iso_27001": {
+            "path_match": "rule.compliance.iso_27001",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_nis2": {
+            "path_match": "rule.compliance.nis2",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_nist_800_171": {
+            "path_match": "rule.compliance.nist_800_171",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_nist_800_53": {
+            "path_match": "rule.compliance.nist_800_53",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_pci_dss": {
+            "path_match": "rule.compliance.pci_dss",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_tsc": {
+            "path_match": "rule.compliance.tsc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_description": {
+            "path_match": "rule.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_id": {
+            "path_match": "rule.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_level": {
+            "path_match": "rule.level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_license": {
+            "path_match": "rule.license",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_subtechnique_id": {
+            "path_match": "rule.mitre.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_subtechnique_name": {
+            "path_match": "rule.mitre.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_tactic_id": {
+            "path_match": "rule.mitre.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_tactic_name": {
+            "path_match": "rule.mitre.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_technique_id": {
+            "path_match": "rule.mitre.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_technique_name": {
+            "path_match": "rule.mitre.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_name": {
+            "path_match": "rule.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_reference": {
+            "path_match": "rule.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_ruleset": {
+            "path_match": "rule.ruleset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_sigma_id": {
+            "path_match": "rule.sigma_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_status": {
+            "path_match": "rule.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_tags": {
+            "path_match": "rule.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_title": {
+            "path_match": "rule.title",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_uuid": {
+            "path_match": "rule.uuid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_version": {
+            "path_match": "rule.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_address": {
+            "path_match": "server.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_as_number": {
+            "path_match": "server.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_as_organization_name": {
+            "path_match": "server.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_bytes": {
+            "path_match": "server.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_domain": {
+            "path_match": "server.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_city_name": {
+            "path_match": "server.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_continent_code": {
+            "path_match": "server.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_continent_name": {
+            "path_match": "server.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_country_iso_code": {
+            "path_match": "server.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_country_name": {
+            "path_match": "server.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_location": {
+            "path_match": "server.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_name": {
+            "path_match": "server.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_postal_code": {
+            "path_match": "server.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_region_iso_code": {
+            "path_match": "server.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_region_name": {
+            "path_match": "server.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_timezone": {
+            "path_match": "server.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_ip": {
+            "path_match": "server.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_server_mac": {
+            "path_match": "server.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_nat_ip": {
+            "path_match": "server.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_server_nat_port": {
+            "path_match": "server.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_packets": {
+            "path_match": "server.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_port": {
+            "path_match": "server.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_registered_domain": {
+            "path_match": "server.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_subdomain": {
+            "path_match": "server.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_top_level_domain": {
+            "path_match": "server.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_domain": {
+            "path_match": "server.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_email": {
+            "path_match": "server.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_full_name": {
+            "path_match": "server.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_group_domain": {
+            "path_match": "server.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_group_id": {
+            "path_match": "server.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_group_name": {
+            "path_match": "server.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_hash": {
+            "path_match": "server.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_id": {
+            "path_match": "server.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_name": {
+            "path_match": "server.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_roles": {
+            "path_match": "server.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_address": {
+            "path_match": "service.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_environment": {
+            "path_match": "service.environment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_ephemeral_id": {
+            "path_match": "service.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_id": {
+            "path_match": "service.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_name": {
+            "path_match": "service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_node_name": {
+            "path_match": "service.node.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_node_role": {
+            "path_match": "service.node.role",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_node_roles": {
+            "path_match": "service.node.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_address": {
+            "path_match": "service.origin.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_environment": {
+            "path_match": "service.origin.environment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_ephemeral_id": {
+            "path_match": "service.origin.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_id": {
+            "path_match": "service.origin.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_name": {
+            "path_match": "service.origin.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_node_name": {
+            "path_match": "service.origin.node.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_node_role": {
+            "path_match": "service.origin.node.role",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_node_roles": {
+            "path_match": "service.origin.node.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_previous_state": {
+            "path_match": "service.origin.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_state": {
+            "path_match": "service.origin.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_type": {
+            "path_match": "service.origin.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_version": {
+            "path_match": "service.origin.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_previous_state": {
+            "path_match": "service.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_state": {
+            "path_match": "service.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_address": {
+            "path_match": "service.target.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_environment": {
+            "path_match": "service.target.environment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_ephemeral_id": {
+            "path_match": "service.target.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_id": {
+            "path_match": "service.target.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_name": {
+            "path_match": "service.target.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_node_name": {
+            "path_match": "service.target.node.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_node_role": {
+            "path_match": "service.target.node.role",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_node_roles": {
+            "path_match": "service.target.node.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_previous_state": {
+            "path_match": "service.target.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_state": {
+            "path_match": "service.target.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_type": {
+            "path_match": "service.target.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_version": {
+            "path_match": "service.target.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_type": {
+            "path_match": "service.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_version": {
+            "path_match": "service.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_address": {
+            "path_match": "source.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_as_number": {
+            "path_match": "source.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_as_organization_name": {
+            "path_match": "source.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_bytes": {
+            "path_match": "source.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_domain": {
+            "path_match": "source.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_city_name": {
+            "path_match": "source.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_continent_code": {
+            "path_match": "source.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_continent_name": {
+            "path_match": "source.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_country_iso_code": {
+            "path_match": "source.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_country_name": {
+            "path_match": "source.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_location": {
+            "path_match": "source.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_name": {
+            "path_match": "source.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_postal_code": {
+            "path_match": "source.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_region_iso_code": {
+            "path_match": "source.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_region_name": {
+            "path_match": "source.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_timezone": {
+            "path_match": "source.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_ip": {
+            "path_match": "source.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_source_mac": {
+            "path_match": "source.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_nat_ip": {
+            "path_match": "source.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_source_nat_port": {
+            "path_match": "source.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_packets": {
+            "path_match": "source.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_port": {
+            "path_match": "source.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_registered_domain": {
+            "path_match": "source.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_subdomain": {
+            "path_match": "source.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_top_level_domain": {
+            "path_match": "source.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_domain": {
+            "path_match": "source.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_email": {
+            "path_match": "source.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_full_name": {
+            "path_match": "source.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_group_domain": {
+            "path_match": "source.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_group_id": {
+            "path_match": "source.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_group_name": {
+            "path_match": "source.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_hash": {
+            "path_match": "source.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_id": {
+            "path_match": "source.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_name": {
+            "path_match": "source.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_roles": {
+            "path_match": "source.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_span_id": {
+            "path_match": "span.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_as_number": {
+            "path_match": "threat.enrichments.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_as_organization_name": {
+            "path_match": "threat.enrichments.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_confidence": {
+            "path_match": "threat.enrichments.indicator.confidence",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_description": {
+            "path_match": "threat.enrichments.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_email_address": {
+            "path_match": "threat.enrichments.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_feed_name": {
+            "path_match": "threat.enrichments.indicator.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_accessed": {
+            "path_match": "threat.enrichments.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_attributes": {
+            "path_match": "threat.enrichments.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_exists": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_flags": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_signing_id": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_status": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_subject_name": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_team_id": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_timestamp": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_trusted": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_valid": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_created": {
+            "path_match": "threat.enrichments.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_ctime": {
+            "path_match": "threat.enrichments.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_device": {
+            "path_match": "threat.enrichments.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_directory": {
+            "path_match": "threat.enrichments.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_drive_letter": {
+            "path_match": "threat.enrichments.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_architecture": {
+            "path_match": "threat.enrichments.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_byte_order": {
+            "path_match": "threat.enrichments.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_cpu_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_creation_date": {
+            "path_match": "threat.enrichments.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_exports": {
+            "path_match": "threat.enrichments.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_imports": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_stripped": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_abi_version": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_class": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_data": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_entrypoint": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_object_version": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_os_abi": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_version": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_imports": {
+            "path_match": "threat.enrichments.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_chi2": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_flags": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_name": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_physical_offset": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_physical_size": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_virtual_address": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_virtual_size": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_segments_sections": {
+            "path_match": "threat.enrichments.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_segments_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_shared_libraries": {
+            "path_match": "threat.enrichments.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_telfhash": {
+            "path_match": "threat.enrichments.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_extension": {
+            "path_match": "threat.enrichments.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_fork_name": {
+            "path_match": "threat.enrichments.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_gid": {
+            "path_match": "threat.enrichments.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_group": {
+            "path_match": "threat.enrichments.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_cdhash": {
+            "path_match": "threat.enrichments.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_md5": {
+            "path_match": "threat.enrichments.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha1": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha256": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha384": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha512": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_ssdeep": {
+            "path_match": "threat.enrichments.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_tlsh": {
+            "path_match": "threat.enrichments.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_inode": {
+            "path_match": "threat.enrichments.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_mime_type": {
+            "path_match": "threat.enrichments.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_mode": {
+            "path_match": "threat.enrichments.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_mtime": {
+            "path_match": "threat.enrichments.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_name": {
+            "path_match": "threat.enrichments.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_origin_referrer_url": {
+            "path_match": "threat.enrichments.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_origin_url": {
+            "path_match": "threat.enrichments.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_owner": {
+            "path_match": "threat.enrichments.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_path": {
+            "path_match": "threat.enrichments.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_architecture": {
+            "path_match": "threat.enrichments.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_company": {
+            "path_match": "threat.enrichments.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_description": {
+            "path_match": "threat.enrichments.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_file_version": {
+            "path_match": "threat.enrichments.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_imports": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_stripped": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imphash": {
+            "path_match": "threat.enrichments.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imports": {
+            "path_match": "threat.enrichments.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_original_file_name": {
+            "path_match": "threat.enrichments.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_pehash": {
+            "path_match": "threat.enrichments.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_product": {
+            "path_match": "threat.enrichments.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_name": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_physical_size": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_virtual_size": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_size": {
+            "path_match": "threat.enrichments.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_target_path": {
+            "path_match": "threat.enrichments.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_type": {
+            "path_match": "threat.enrichments.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_uid": {
+            "path_match": "threat.enrichments.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_alternative_names": {
+            "path_match": "threat.enrichments.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_common_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_country": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_locality": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_organization": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_not_after": {
+            "path_match": "threat.enrichments.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_not_before": {
+            "path_match": "threat.enrichments.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_algorithm": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_curve": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_exponent": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_size": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_serial_number": {
+            "path_match": "threat.enrichments.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_signature_algorithm": {
+            "path_match": "threat.enrichments.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_common_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_country": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_locality": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_organization": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_state_or_province": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_version_number": {
+            "path_match": "threat.enrichments.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_first_seen": {
+            "path_match": "threat.enrichments.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_city_name": {
+            "path_match": "threat.enrichments.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_continent_code": {
+            "path_match": "threat.enrichments.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_continent_name": {
+            "path_match": "threat.enrichments.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_country_iso_code": {
+            "path_match": "threat.enrichments.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_country_name": {
+            "path_match": "threat.enrichments.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_location": {
+            "path_match": "threat.enrichments.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_name": {
+            "path_match": "threat.enrichments.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_postal_code": {
+            "path_match": "threat.enrichments.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_region_iso_code": {
+            "path_match": "threat.enrichments.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_region_name": {
+            "path_match": "threat.enrichments.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_timezone": {
+            "path_match": "threat.enrichments.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_id": {
+            "path_match": "threat.enrichments.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_ip": {
+            "path_match": "threat.enrichments.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_last_seen": {
+            "path_match": "threat.enrichments.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_marking_tlp": {
+            "path_match": "threat.enrichments.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_marking_tlp_version": {
+            "path_match": "threat.enrichments.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_modified_at": {
+            "path_match": "threat.enrichments.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_name": {
+            "path_match": "threat.enrichments.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_port": {
+            "path_match": "threat.enrichments.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_provider": {
+            "path_match": "threat.enrichments.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_reference": {
+            "path_match": "threat.enrichments.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_data_bytes": {
+            "path_match": "threat.enrichments.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_data_strings": {
+            "path_match": "threat.enrichments.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_data_type": {
+            "path_match": "threat.enrichments.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_hive": {
+            "path_match": "threat.enrichments.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_key": {
+            "path_match": "threat.enrichments.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_path": {
+            "path_match": "threat.enrichments.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_value": {
+            "path_match": "threat.enrichments.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_scanner_stats": {
+            "path_match": "threat.enrichments.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_sightings": {
+            "path_match": "threat.enrichments.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_software_alias": {
+            "path_match": "threat.enrichments.indicator.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_software_name": {
+            "path_match": "threat.enrichments.indicator.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_software_type": {
+            "path_match": "threat.enrichments.indicator.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_tags": {
+            "path_match": "threat.enrichments.indicator.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_type": {
+            "path_match": "threat.enrichments.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_domain": {
+            "path_match": "threat.enrichments.indicator.url.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_extension": {
+            "path_match": "threat.enrichments.indicator.url.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_fragment": {
+            "path_match": "threat.enrichments.indicator.url.fragment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_full": {
+            "path_match": "threat.enrichments.indicator.url.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_original": {
+            "path_match": "threat.enrichments.indicator.url.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_password": {
+            "path_match": "threat.enrichments.indicator.url.password",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_path": {
+            "path_match": "threat.enrichments.indicator.url.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_port": {
+            "path_match": "threat.enrichments.indicator.url.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_query": {
+            "path_match": "threat.enrichments.indicator.url.query",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_registered_domain": {
+            "path_match": "threat.enrichments.indicator.url.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_scheme": {
+            "path_match": "threat.enrichments.indicator.url.scheme",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_subdomain": {
+            "path_match": "threat.enrichments.indicator.url.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_top_level_domain": {
+            "path_match": "threat.enrichments.indicator.url.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_username": {
+            "path_match": "threat.enrichments.indicator.url.username",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_alternative_names": {
+            "path_match": "threat.enrichments.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_common_name": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_country": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_locality": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_organization": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_state_or_province": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_not_after": {
+            "path_match": "threat.enrichments.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_not_before": {
+            "path_match": "threat.enrichments.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_algorithm": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_curve": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_exponent": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_size": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_serial_number": {
+            "path_match": "threat.enrichments.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_signature_algorithm": {
+            "path_match": "threat.enrichments.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_common_name": {
+            "path_match": "threat.enrichments.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_country": {
+            "path_match": "threat.enrichments.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_locality": {
+            "path_match": "threat.enrichments.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_organization": {
+            "path_match": "threat.enrichments.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_state_or_province": {
+            "path_match": "threat.enrichments.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_version_number": {
+            "path_match": "threat.enrichments.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_atomic": {
+            "path_match": "threat.enrichments.matched.atomic",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_field": {
+            "path_match": "threat.enrichments.matched.field",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_id": {
+            "path_match": "threat.enrichments.matched.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_index": {
+            "path_match": "threat.enrichments.matched.index",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_occurred": {
+            "path_match": "threat.enrichments.matched.occurred",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_type": {
+            "path_match": "threat.enrichments.matched.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_dashboard_id": {
+            "path_match": "threat.feed.dashboard_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_description": {
+            "path_match": "threat.feed.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_name": {
+            "path_match": "threat.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_reference": {
+            "path_match": "threat.feed.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_framework": {
+            "path_match": "threat.framework",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_alias": {
+            "path_match": "threat.group.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_id": {
+            "path_match": "threat.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_name": {
+            "path_match": "threat.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_reference": {
+            "path_match": "threat.group.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_as_number": {
+            "path_match": "threat.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_as_organization_name": {
+            "path_match": "threat.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_confidence": {
+            "path_match": "threat.indicator.confidence",
+            "mapping": {
+              "type": "short"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_description": {
+            "path_match": "threat.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_email_address": {
+            "path_match": "threat.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_accessed": {
+            "path_match": "threat.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_attributes": {
+            "path_match": "threat.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "threat.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_exists": {
+            "path_match": "threat.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_flags": {
+            "path_match": "threat.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_signing_id": {
+            "path_match": "threat.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_status": {
+            "path_match": "threat.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_subject_name": {
+            "path_match": "threat.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_team_id": {
+            "path_match": "threat.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "threat.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_timestamp": {
+            "path_match": "threat.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_trusted": {
+            "path_match": "threat.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_valid": {
+            "path_match": "threat.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_created": {
+            "path_match": "threat.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_ctime": {
+            "path_match": "threat.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_device": {
+            "path_match": "threat.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_directory": {
+            "path_match": "threat.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_drive_letter": {
+            "path_match": "threat.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_architecture": {
+            "path_match": "threat.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_byte_order": {
+            "path_match": "threat.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_cpu_type": {
+            "path_match": "threat.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_creation_date": {
+            "path_match": "threat.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_exports": {
+            "path_match": "threat.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_import_hash": {
+            "path_match": "threat.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_imports": {
+            "path_match": "threat.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "threat.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_stripped": {
+            "path_match": "threat.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_abi_version": {
+            "path_match": "threat.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_class": {
+            "path_match": "threat.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_data": {
+            "path_match": "threat.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_entrypoint": {
+            "path_match": "threat.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_object_version": {
+            "path_match": "threat.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_os_abi": {
+            "path_match": "threat.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_type": {
+            "path_match": "threat.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_version": {
+            "path_match": "threat.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_import_hash": {
+            "path_match": "threat.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_imports": {
+            "path_match": "threat.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_imports_names_entropy": {
+            "path_match": "threat.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_chi2": {
+            "path_match": "threat.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_entropy": {
+            "path_match": "threat.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_flags": {
+            "path_match": "threat.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_name": {
+            "path_match": "threat.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_physical_offset": {
+            "path_match": "threat.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_physical_size": {
+            "path_match": "threat.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_type": {
+            "path_match": "threat.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_var_entropy": {
+            "path_match": "threat.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_virtual_address": {
+            "path_match": "threat.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_virtual_size": {
+            "path_match": "threat.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_segments_sections": {
+            "path_match": "threat.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_segments_type": {
+            "path_match": "threat.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_shared_libraries": {
+            "path_match": "threat.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_telfhash": {
+            "path_match": "threat.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_extension": {
+            "path_match": "threat.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_fork_name": {
+            "path_match": "threat.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_gid": {
+            "path_match": "threat.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_group": {
+            "path_match": "threat.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_cdhash": {
+            "path_match": "threat.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_md5": {
+            "path_match": "threat.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha1": {
+            "path_match": "threat.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha256": {
+            "path_match": "threat.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha384": {
+            "path_match": "threat.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha512": {
+            "path_match": "threat.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_ssdeep": {
+            "path_match": "threat.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_tlsh": {
+            "path_match": "threat.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_inode": {
+            "path_match": "threat.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_mime_type": {
+            "path_match": "threat.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_mode": {
+            "path_match": "threat.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_mtime": {
+            "path_match": "threat.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_name": {
+            "path_match": "threat.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_origin_referrer_url": {
+            "path_match": "threat.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_origin_url": {
+            "path_match": "threat.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_owner": {
+            "path_match": "threat.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_path": {
+            "path_match": "threat.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_architecture": {
+            "path_match": "threat.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_company": {
+            "path_match": "threat.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_description": {
+            "path_match": "threat.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_file_version": {
+            "path_match": "threat.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_import_hash": {
+            "path_match": "threat.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_imports": {
+            "path_match": "threat.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "threat.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_stripped": {
+            "path_match": "threat.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imphash": {
+            "path_match": "threat.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_import_hash": {
+            "path_match": "threat.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imports": {
+            "path_match": "threat.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imports_names_entropy": {
+            "path_match": "threat.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_original_file_name": {
+            "path_match": "threat.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_pehash": {
+            "path_match": "threat.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_product": {
+            "path_match": "threat.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_entropy": {
+            "path_match": "threat.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_name": {
+            "path_match": "threat.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_physical_size": {
+            "path_match": "threat.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_var_entropy": {
+            "path_match": "threat.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_virtual_size": {
+            "path_match": "threat.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_size": {
+            "path_match": "threat.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_target_path": {
+            "path_match": "threat.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_type": {
+            "path_match": "threat.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_uid": {
+            "path_match": "threat.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_alternative_names": {
+            "path_match": "threat.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_common_name": {
+            "path_match": "threat.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_country": {
+            "path_match": "threat.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "threat.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_locality": {
+            "path_match": "threat.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_organization": {
+            "path_match": "threat.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "threat.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "threat.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_not_after": {
+            "path_match": "threat.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_not_before": {
+            "path_match": "threat.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_algorithm": {
+            "path_match": "threat.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_curve": {
+            "path_match": "threat.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_exponent": {
+            "path_match": "threat.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_size": {
+            "path_match": "threat.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_serial_number": {
+            "path_match": "threat.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_signature_algorithm": {
+            "path_match": "threat.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_common_name": {
+            "path_match": "threat.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_country": {
+            "path_match": "threat.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "threat.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_locality": {
+            "path_match": "threat.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_organization": {
+            "path_match": "threat.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "threat.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_state_or_province": {
+            "path_match": "threat.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_version_number": {
+            "path_match": "threat.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_first_seen": {
+            "path_match": "threat.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_city_name": {
+            "path_match": "threat.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_continent_code": {
+            "path_match": "threat.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_continent_name": {
+            "path_match": "threat.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_country_iso_code": {
+            "path_match": "threat.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_country_name": {
+            "path_match": "threat.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_location": {
+            "path_match": "threat.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_name": {
+            "path_match": "threat.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_postal_code": {
+            "path_match": "threat.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_region_iso_code": {
+            "path_match": "threat.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_region_name": {
+            "path_match": "threat.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_timezone": {
+            "path_match": "threat.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_id": {
+            "path_match": "threat.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_ip": {
+            "path_match": "threat.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_last_seen": {
+            "path_match": "threat.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_marking_tlp": {
+            "path_match": "threat.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_marking_tlp_version": {
+            "path_match": "threat.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_modified_at": {
+            "path_match": "threat.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_name": {
+            "path_match": "threat.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_port": {
+            "path_match": "threat.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_provider": {
+            "path_match": "threat.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_reference": {
+            "path_match": "threat.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_data_bytes": {
+            "path_match": "threat.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_data_strings": {
+            "path_match": "threat.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_data_type": {
+            "path_match": "threat.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_hive": {
+            "path_match": "threat.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_key": {
+            "path_match": "threat.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_path": {
+            "path_match": "threat.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_value": {
+            "path_match": "threat.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_scanner_stats": {
+            "path_match": "threat.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_sightings": {
+            "path_match": "threat.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_type": {
+            "path_match": "threat.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_domain": {
+            "path_match": "threat.indicator.url.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_extension": {
+            "path_match": "threat.indicator.url.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_fragment": {
+            "path_match": "threat.indicator.url.fragment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_full": {
+            "path_match": "threat.indicator.url.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_original": {
+            "path_match": "threat.indicator.url.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_password": {
+            "path_match": "threat.indicator.url.password",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_path": {
+            "path_match": "threat.indicator.url.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_port": {
+            "path_match": "threat.indicator.url.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_query": {
+            "path_match": "threat.indicator.url.query",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_registered_domain": {
+            "path_match": "threat.indicator.url.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_scheme": {
+            "path_match": "threat.indicator.url.scheme",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_subdomain": {
+            "path_match": "threat.indicator.url.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_top_level_domain": {
+            "path_match": "threat.indicator.url.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_username": {
+            "path_match": "threat.indicator.url.username",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_alternative_names": {
+            "path_match": "threat.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_common_name": {
+            "path_match": "threat.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_country": {
+            "path_match": "threat.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_distinguished_name": {
+            "path_match": "threat.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_locality": {
+            "path_match": "threat.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_organization": {
+            "path_match": "threat.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_organizational_unit": {
+            "path_match": "threat.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_state_or_province": {
+            "path_match": "threat.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_not_after": {
+            "path_match": "threat.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_not_before": {
+            "path_match": "threat.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_algorithm": {
+            "path_match": "threat.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_curve": {
+            "path_match": "threat.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_exponent": {
+            "path_match": "threat.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_size": {
+            "path_match": "threat.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_serial_number": {
+            "path_match": "threat.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_signature_algorithm": {
+            "path_match": "threat.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_common_name": {
+            "path_match": "threat.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_country": {
+            "path_match": "threat.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_distinguished_name": {
+            "path_match": "threat.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_locality": {
+            "path_match": "threat.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_organization": {
+            "path_match": "threat.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_organizational_unit": {
+            "path_match": "threat.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_state_or_province": {
+            "path_match": "threat.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_version_number": {
+            "path_match": "threat.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_alias": {
+            "path_match": "threat.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_id": {
+            "path_match": "threat.software.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_name": {
+            "path_match": "threat.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_platforms": {
+            "path_match": "threat.software.platforms",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_reference": {
+            "path_match": "threat.software.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_type": {
+            "path_match": "threat.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_tactic_id": {
+            "path_match": "threat.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_tactic_name": {
+            "path_match": "threat.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_tactic_reference": {
+            "path_match": "threat.tactic.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_id": {
+            "path_match": "threat.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_name": {
+            "path_match": "threat.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_reference": {
+            "path_match": "threat.technique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_subtechnique_id": {
+            "path_match": "threat.technique.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_subtechnique_name": {
+            "path_match": "threat.technique.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_subtechnique_reference": {
+            "path_match": "threat.technique.subtechnique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_cipher": {
+            "path_match": "tls.cipher",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_certificate": {
+            "path_match": "tls.client.certificate",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_certificate_chain": {
+            "path_match": "tls.client.certificate_chain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_hash_md5": {
+            "path_match": "tls.client.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_hash_sha1": {
+            "path_match": "tls.client.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_hash_sha256": {
+            "path_match": "tls.client.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_issuer": {
+            "path_match": "tls.client.issuer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_ja3": {
+            "path_match": "tls.client.ja3",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_not_after": {
+            "path_match": "tls.client.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_not_before": {
+            "path_match": "tls.client.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_server_name": {
+            "path_match": "tls.client.server_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_subject": {
+            "path_match": "tls.client.subject",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_supported_ciphers": {
+            "path_match": "tls.client.supported_ciphers",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_alternative_names": {
+            "path_match": "tls.client.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_common_name": {
+            "path_match": "tls.client.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_country": {
+            "path_match": "tls.client.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_distinguished_name": {
+            "path_match": "tls.client.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_locality": {
+            "path_match": "tls.client.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_organization": {
+            "path_match": "tls.client.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_organizational_unit": {
+            "path_match": "tls.client.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_state_or_province": {
+            "path_match": "tls.client.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_not_after": {
+            "path_match": "tls.client.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_not_before": {
+            "path_match": "tls.client.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_algorithm": {
+            "path_match": "tls.client.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_curve": {
+            "path_match": "tls.client.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_exponent": {
+            "path_match": "tls.client.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_size": {
+            "path_match": "tls.client.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_serial_number": {
+            "path_match": "tls.client.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_signature_algorithm": {
+            "path_match": "tls.client.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_common_name": {
+            "path_match": "tls.client.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_country": {
+            "path_match": "tls.client.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_distinguished_name": {
+            "path_match": "tls.client.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_locality": {
+            "path_match": "tls.client.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_organization": {
+            "path_match": "tls.client.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_organizational_unit": {
+            "path_match": "tls.client.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_state_or_province": {
+            "path_match": "tls.client.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_version_number": {
+            "path_match": "tls.client.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_curve": {
+            "path_match": "tls.curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_established": {
+            "path_match": "tls.established",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_tls_next_protocol": {
+            "path_match": "tls.next_protocol",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_resumed": {
+            "path_match": "tls.resumed",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_certificate": {
+            "path_match": "tls.server.certificate",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_certificate_chain": {
+            "path_match": "tls.server.certificate_chain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_hash_md5": {
+            "path_match": "tls.server.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_hash_sha1": {
+            "path_match": "tls.server.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_hash_sha256": {
+            "path_match": "tls.server.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_issuer": {
+            "path_match": "tls.server.issuer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_ja3s": {
+            "path_match": "tls.server.ja3s",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_not_after": {
+            "path_match": "tls.server.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_not_before": {
+            "path_match": "tls.server.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_subject": {
+            "path_match": "tls.server.subject",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_alternative_names": {
+            "path_match": "tls.server.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_common_name": {
+            "path_match": "tls.server.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_country": {
+            "path_match": "tls.server.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_distinguished_name": {
+            "path_match": "tls.server.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_locality": {
+            "path_match": "tls.server.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_organization": {
+            "path_match": "tls.server.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_organizational_unit": {
+            "path_match": "tls.server.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_state_or_province": {
+            "path_match": "tls.server.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_not_after": {
+            "path_match": "tls.server.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_not_before": {
+            "path_match": "tls.server.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_algorithm": {
+            "path_match": "tls.server.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_curve": {
+            "path_match": "tls.server.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_exponent": {
+            "path_match": "tls.server.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_size": {
+            "path_match": "tls.server.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_serial_number": {
+            "path_match": "tls.server.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_signature_algorithm": {
+            "path_match": "tls.server.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_common_name": {
+            "path_match": "tls.server.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_country": {
+            "path_match": "tls.server.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_distinguished_name": {
+            "path_match": "tls.server.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_locality": {
+            "path_match": "tls.server.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_organization": {
+            "path_match": "tls.server.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_organizational_unit": {
+            "path_match": "tls.server.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_state_or_province": {
+            "path_match": "tls.server.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_version_number": {
+            "path_match": "tls.server.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_version": {
+            "path_match": "tls.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_version_protocol": {
+            "path_match": "tls.version_protocol",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_trace_id": {
+            "path_match": "trace.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_transaction_id": {
+            "path_match": "transaction.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_domain": {
+            "path_match": "url.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_extension": {
+            "path_match": "url.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_fragment": {
+            "path_match": "url.fragment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_full": {
+            "path_match": "url.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_original": {
+            "path_match": "url.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_password": {
+            "path_match": "url.password",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_path": {
+            "path_match": "url.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_port": {
+            "path_match": "url.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_url_query": {
+            "path_match": "url.query",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_registered_domain": {
+            "path_match": "url.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_scheme": {
+            "path_match": "url.scheme",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_subdomain": {
+            "path_match": "url.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_top_level_domain": {
+            "path_match": "url.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_username": {
+            "path_match": "url.username",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_device_name": {
+            "path_match": "user_agent.device.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_name": {
+            "path_match": "user_agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_original": {
+            "path_match": "user_agent.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_family": {
+            "path_match": "user_agent.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_full": {
+            "path_match": "user_agent.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_kernel": {
+            "path_match": "user_agent.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_name": {
+            "path_match": "user_agent.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_platform": {
+            "path_match": "user_agent.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_type": {
+            "path_match": "user_agent.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_version": {
+            "path_match": "user_agent.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_version": {
+            "path_match": "user_agent.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_domain": {
+            "path_match": "user.changes.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_email": {
+            "path_match": "user.changes.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_full_name": {
+            "path_match": "user.changes.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_group_domain": {
+            "path_match": "user.changes.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_group_id": {
+            "path_match": "user.changes.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_group_name": {
+            "path_match": "user.changes.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_hash": {
+            "path_match": "user.changes.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_id": {
+            "path_match": "user.changes.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_name": {
+            "path_match": "user.changes.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_roles": {
+            "path_match": "user.changes.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_domain": {
+            "path_match": "user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_domain": {
+            "path_match": "user.effective.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_email": {
+            "path_match": "user.effective.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_full_name": {
+            "path_match": "user.effective.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_group_domain": {
+            "path_match": "user.effective.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_group_id": {
+            "path_match": "user.effective.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_group_name": {
+            "path_match": "user.effective.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_hash": {
+            "path_match": "user.effective.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_id": {
+            "path_match": "user.effective.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_name": {
+            "path_match": "user.effective.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_roles": {
+            "path_match": "user.effective.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_email": {
+            "path_match": "user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_full_name": {
+            "path_match": "user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_group_domain": {
+            "path_match": "user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_group_id": {
+            "path_match": "user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_group_name": {
+            "path_match": "user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_hash": {
+            "path_match": "user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_id": {
+            "path_match": "user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_name": {
+            "path_match": "user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_calculated_level": {
+            "path_match": "user.risk.calculated_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_calculated_score": {
+            "path_match": "user.risk.calculated_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_calculated_score_norm": {
+            "path_match": "user.risk.calculated_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_static_level": {
+            "path_match": "user.risk.static_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_static_score": {
+            "path_match": "user.risk.static_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_static_score_norm": {
+            "path_match": "user.risk.static_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_roles": {
+            "path_match": "user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_domain": {
+            "path_match": "user.target.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_email": {
+            "path_match": "user.target.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_full_name": {
+            "path_match": "user.target.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_group_domain": {
+            "path_match": "user.target.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_group_id": {
+            "path_match": "user.target.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_group_name": {
+            "path_match": "user.target.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_hash": {
+            "path_match": "user.target.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_id": {
+            "path_match": "user.target.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_name": {
+            "path_match": "user.target.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_roles": {
+            "path_match": "user.target.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_bus_type": {
+            "path_match": "volume.bus_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_default_access": {
+            "path_match": "volume.default_access",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_device_name": {
+            "path_match": "volume.device_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_device_type": {
+            "path_match": "volume.device_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_dos_name": {
+            "path_match": "volume.dos_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_file_system_type": {
+            "path_match": "volume.file_system_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_mount_name": {
+            "path_match": "volume.mount_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_nt_name": {
+            "path_match": "volume.nt_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_product_id": {
+            "path_match": "volume.product_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_product_name": {
+            "path_match": "volume.product_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_removable": {
+            "path_match": "volume.removable",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_volume_serial_number": {
+            "path_match": "volume.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_size": {
+            "path_match": "volume.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_volume_vendor_id": {
+            "path_match": "volume.vendor_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_vendor_name": {
+            "path_match": "volume.vendor_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_writable": {
+            "path_match": "volume.writable",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_category": {
+            "path_match": "vulnerability.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_classification": {
+            "path_match": "vulnerability.classification",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_description": {
+            "path_match": "vulnerability.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_detected_at": {
+            "path_match": "vulnerability.detected_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_enumeration": {
+            "path_match": "vulnerability.enumeration",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_id": {
+            "path_match": "vulnerability.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_published_at": {
+            "path_match": "vulnerability.published_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_report_id": {
+            "path_match": "vulnerability.report_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_condition": {
+            "path_match": "vulnerability.scanner.condition",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_reference": {
+            "path_match": "vulnerability.scanner.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_source": {
+            "path_match": "vulnerability.scanner.source",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_vendor": {
+            "path_match": "vulnerability.scanner.vendor",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_base": {
+            "path_match": "vulnerability.score.base",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_environmental": {
+            "path_match": "vulnerability.score.environmental",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_temporal": {
+            "path_match": "vulnerability.score.temporal",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_version": {
+            "path_match": "vulnerability.score.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_severity": {
+            "path_match": "vulnerability.severity",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_under_evaluation": {
+            "path_match": "vulnerability.under_evaluation",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_build_original": {
+            "path_match": "wazuh.agent.build.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_ephemeral_id": {
+            "path_match": "wazuh.agent.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_groups": {
+            "path_match": "wazuh.agent.groups",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_architecture": {
+            "path_match": "wazuh.agent.host.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_boot_id": {
+            "path_match": "wazuh.agent.host.boot.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_cores": {
+            "path_match": "wazuh.agent.host.cpu.cores",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_name": {
+            "path_match": "wazuh.agent.host.cpu.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_speed": {
+            "path_match": "wazuh.agent.host.cpu.speed",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_usage": {
+            "path_match": "wazuh.agent.host.cpu.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_disk_read_bytes": {
+            "path_match": "wazuh.agent.host.disk.read.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_disk_write_bytes": {
+            "path_match": "wazuh.agent.host.disk.write.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_domain": {
+            "path_match": "wazuh.agent.host.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_city_name": {
+            "path_match": "wazuh.agent.host.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_continent_code": {
+            "path_match": "wazuh.agent.host.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_continent_name": {
+            "path_match": "wazuh.agent.host.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_country_iso_code": {
+            "path_match": "wazuh.agent.host.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_country_name": {
+            "path_match": "wazuh.agent.host.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_location": {
+            "path_match": "wazuh.agent.host.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_name": {
+            "path_match": "wazuh.agent.host.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_postal_code": {
+            "path_match": "wazuh.agent.host.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_region_iso_code": {
+            "path_match": "wazuh.agent.host.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_region_name": {
+            "path_match": "wazuh.agent.host.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_timezone": {
+            "path_match": "wazuh.agent.host.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_hostname": {
+            "path_match": "wazuh.agent.host.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_id": {
+            "path_match": "wazuh.agent.host.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_ip": {
+            "path_match": "wazuh.agent.host.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_mac": {
+            "path_match": "wazuh.agent.host.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_memory_free": {
+            "path_match": "wazuh.agent.host.memory.free",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_memory_total": {
+            "path_match": "wazuh.agent.host.memory.total",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_memory_used_percentage": {
+            "path_match": "wazuh.agent.host.memory.used.percentage",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_name": {
+            "path_match": "wazuh.agent.host.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_bytes": {
+            "path_match": "wazuh.agent.host.network.egress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_drops": {
+            "path_match": "wazuh.agent.host.network.egress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_errors": {
+            "path_match": "wazuh.agent.host.network.egress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_packets": {
+            "path_match": "wazuh.agent.host.network.egress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_queue": {
+            "path_match": "wazuh.agent.host.network.egress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_bytes": {
+            "path_match": "wazuh.agent.host.network.ingress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_drops": {
+            "path_match": "wazuh.agent.host.network.ingress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_errors": {
+            "path_match": "wazuh.agent.host.network.ingress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_packets": {
+            "path_match": "wazuh.agent.host.network.ingress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_queue": {
+            "path_match": "wazuh.agent.host.network.ingress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_family": {
+            "path_match": "wazuh.agent.host.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_full": {
+            "path_match": "wazuh.agent.host.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_kernel": {
+            "path_match": "wazuh.agent.host.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_name": {
+            "path_match": "wazuh.agent.host.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_platform": {
+            "path_match": "wazuh.agent.host.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_type": {
+            "path_match": "wazuh.agent.host.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_version": {
+            "path_match": "wazuh.agent.host.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_pid_ns_ino": {
+            "path_match": "wazuh.agent.host.pid_ns_ino",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_calculated_level": {
+            "path_match": "wazuh.agent.host.risk.calculated_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_calculated_score": {
+            "path_match": "wazuh.agent.host.risk.calculated_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_calculated_score_norm": {
+            "path_match": "wazuh.agent.host.risk.calculated_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_static_level": {
+            "path_match": "wazuh.agent.host.risk.static_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_static_score": {
+            "path_match": "wazuh.agent.host.risk.static_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_static_score_norm": {
+            "path_match": "wazuh.agent.host.risk.static_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_type": {
+            "path_match": "wazuh.agent.host.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_uptime": {
+            "path_match": "wazuh.agent.host.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_id": {
+            "path_match": "wazuh.agent.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_name": {
+            "path_match": "wazuh.agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_type": {
+            "path_match": "wazuh.agent.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_version": {
+            "path_match": "wazuh.agent.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_cluster_name": {
+            "path_match": "wazuh.cluster.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_cluster_node": {
+            "path_match": "wazuh.cluster.node",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_event_id": {
+            "path_match": "wazuh.event.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_category": {
+            "path_match": "wazuh.integration.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_decoders": {
+            "path_match": "wazuh.integration.decoders",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_name": {
+            "path_match": "wazuh.integration.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_rules": {
+            "path_match": "wazuh.integration.rules",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_protocol_location": {
+            "path_match": "wazuh.protocol.location",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_protocol_queue": {
+            "path_match": "wazuh.protocol.queue",
+            "mapping": {
+              "type": "byte"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_schema_version": {
+            "path_match": "wazuh.schema.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_space_event_discarded": {
+            "path_match": "wazuh.space.event_discarded",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_space_name": {
+            "path_match": "wazuh.space.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_as_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_as_organization_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_confidence": {
+            "path_match": "wazuh.threat.enrichments.indicator.confidence",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_description": {
+            "path_match": "wazuh.threat.enrichments.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_email_address": {
+            "path_match": "wazuh.threat.enrichments.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_feed_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_accessed": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_attributes": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_exists": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_flags": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_signing_id": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_status": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_subject_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_team_id": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_timestamp": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_trusted": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_valid": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_created": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_ctime": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_device": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_directory": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_drive_letter": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_architecture": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_byte_order": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_cpu_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_creation_date": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_exports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_stripped": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_abi_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_class": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_data": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_entrypoint": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_object_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_os_abi": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_chi2": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_flags": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_physical_offset": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_physical_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_virtual_address": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_virtual_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_segments_sections": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_segments_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_shared_libraries": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_telfhash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_extension": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_fork_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_gid": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_group": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_cdhash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_md5": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha1": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha256": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha384": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha512": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_ssdeep": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_tlsh": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_inode": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_mime_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_mode": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_mtime": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_origin_referrer_url": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_origin_url": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_owner": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_path": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_architecture": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_company": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_description": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_file_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_stripped": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imphash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_original_file_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_pehash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_product": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_physical_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_virtual_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_target_path": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_uid": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_alternative_names": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_not_after": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_not_before": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_curve": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_serial_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_version_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_first_seen": {
+            "path_match": "wazuh.threat.enrichments.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_city_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_continent_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_continent_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_country_iso_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_country_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_location": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_postal_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_region_iso_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_region_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_timezone": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_id": {
+            "path_match": "wazuh.threat.enrichments.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_ip": {
+            "path_match": "wazuh.threat.enrichments.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_last_seen": {
+            "path_match": "wazuh.threat.enrichments.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_marking_tlp": {
+            "path_match": "wazuh.threat.enrichments.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_marking_tlp_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_modified_at": {
+            "path_match": "wazuh.threat.enrichments.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_port": {
+            "path_match": "wazuh.threat.enrichments.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_provider": {
+            "path_match": "wazuh.threat.enrichments.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_reference": {
+            "path_match": "wazuh.threat.enrichments.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_data_bytes": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_data_strings": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_data_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_hive": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_key": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_path": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_value": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_scanner_stats": {
+            "path_match": "wazuh.threat.enrichments.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_sightings": {
+            "path_match": "wazuh.threat.enrichments.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_software_alias": {
+            "path_match": "wazuh.threat.enrichments.indicator.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_software_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_software_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_tags": {
+            "path_match": "wazuh.threat.enrichments.indicator.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_alternative_names": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_not_after": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_not_before": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_curve": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_serial_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_version_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_atomic": {
+            "path_match": "wazuh.threat.enrichments.matched.atomic",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_field": {
+            "path_match": "wazuh.threat.enrichments.matched.field",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_id": {
+            "path_match": "wazuh.threat.enrichments.matched.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_index": {
+            "path_match": "wazuh.threat.enrichments.matched.index",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_occurred": {
+            "path_match": "wazuh.threat.enrichments.matched.occurred",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_type": {
+            "path_match": "wazuh.threat.enrichments.matched.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_dashboard_id": {
+            "path_match": "wazuh.threat.feed.dashboard_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_description": {
+            "path_match": "wazuh.threat.feed.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_name": {
+            "path_match": "wazuh.threat.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_reference": {
+            "path_match": "wazuh.threat.feed.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_framework": {
+            "path_match": "wazuh.threat.framework",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_alias": {
+            "path_match": "wazuh.threat.group.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_id": {
+            "path_match": "wazuh.threat.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_name": {
+            "path_match": "wazuh.threat.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_reference": {
+            "path_match": "wazuh.threat.group.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_as_number": {
+            "path_match": "wazuh.threat.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_as_organization_name": {
+            "path_match": "wazuh.threat.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_confidence": {
+            "path_match": "wazuh.threat.indicator.confidence",
+            "mapping": {
+              "type": "short"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_description": {
+            "path_match": "wazuh.threat.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_email_address": {
+            "path_match": "wazuh.threat.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_accessed": {
+            "path_match": "wazuh.threat.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_attributes": {
+            "path_match": "wazuh.threat.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_exists": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_flags": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_signing_id": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_status": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_subject_name": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_team_id": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_timestamp": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_trusted": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_valid": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_created": {
+            "path_match": "wazuh.threat.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_ctime": {
+            "path_match": "wazuh.threat.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_device": {
+            "path_match": "wazuh.threat.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_directory": {
+            "path_match": "wazuh.threat.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_drive_letter": {
+            "path_match": "wazuh.threat.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_architecture": {
+            "path_match": "wazuh.threat.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_byte_order": {
+            "path_match": "wazuh.threat.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_cpu_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_creation_date": {
+            "path_match": "wazuh.threat.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_exports": {
+            "path_match": "wazuh.threat.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_imports": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_stripped": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_abi_version": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_class": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_data": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_entrypoint": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_object_version": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_os_abi": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_version": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_imports": {
+            "path_match": "wazuh.threat.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_chi2": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_flags": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_name": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_physical_offset": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_physical_size": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_virtual_address": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_virtual_size": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_segments_sections": {
+            "path_match": "wazuh.threat.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_segments_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_shared_libraries": {
+            "path_match": "wazuh.threat.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_telfhash": {
+            "path_match": "wazuh.threat.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_extension": {
+            "path_match": "wazuh.threat.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_fork_name": {
+            "path_match": "wazuh.threat.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_gid": {
+            "path_match": "wazuh.threat.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_group": {
+            "path_match": "wazuh.threat.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_cdhash": {
+            "path_match": "wazuh.threat.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_md5": {
+            "path_match": "wazuh.threat.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha1": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha256": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha384": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha512": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_ssdeep": {
+            "path_match": "wazuh.threat.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_tlsh": {
+            "path_match": "wazuh.threat.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_inode": {
+            "path_match": "wazuh.threat.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_mime_type": {
+            "path_match": "wazuh.threat.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_mode": {
+            "path_match": "wazuh.threat.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_mtime": {
+            "path_match": "wazuh.threat.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_name": {
+            "path_match": "wazuh.threat.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_origin_referrer_url": {
+            "path_match": "wazuh.threat.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_origin_url": {
+            "path_match": "wazuh.threat.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_owner": {
+            "path_match": "wazuh.threat.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_path": {
+            "path_match": "wazuh.threat.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_architecture": {
+            "path_match": "wazuh.threat.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_company": {
+            "path_match": "wazuh.threat.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_description": {
+            "path_match": "wazuh.threat.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_file_version": {
+            "path_match": "wazuh.threat.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_imports": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_stripped": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imphash": {
+            "path_match": "wazuh.threat.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imports": {
+            "path_match": "wazuh.threat.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_original_file_name": {
+            "path_match": "wazuh.threat.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_pehash": {
+            "path_match": "wazuh.threat.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_product": {
+            "path_match": "wazuh.threat.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_name": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_physical_size": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_virtual_size": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_size": {
+            "path_match": "wazuh.threat.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_target_path": {
+            "path_match": "wazuh.threat.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_type": {
+            "path_match": "wazuh.threat.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_uid": {
+            "path_match": "wazuh.threat.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_alternative_names": {
+            "path_match": "wazuh.threat.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_country": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_locality": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_organization": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_not_after": {
+            "path_match": "wazuh.threat.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_not_before": {
+            "path_match": "wazuh.threat.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_curve": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_size": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_serial_number": {
+            "path_match": "wazuh.threat.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_common_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_country": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_locality": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_organization": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_version_number": {
+            "path_match": "wazuh.threat.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_first_seen": {
+            "path_match": "wazuh.threat.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_city_name": {
+            "path_match": "wazuh.threat.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_continent_code": {
+            "path_match": "wazuh.threat.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_continent_name": {
+            "path_match": "wazuh.threat.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_country_iso_code": {
+            "path_match": "wazuh.threat.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_country_name": {
+            "path_match": "wazuh.threat.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_location": {
+            "path_match": "wazuh.threat.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_name": {
+            "path_match": "wazuh.threat.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_postal_code": {
+            "path_match": "wazuh.threat.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_region_iso_code": {
+            "path_match": "wazuh.threat.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_region_name": {
+            "path_match": "wazuh.threat.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_timezone": {
+            "path_match": "wazuh.threat.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_id": {
+            "path_match": "wazuh.threat.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_ip": {
+            "path_match": "wazuh.threat.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_last_seen": {
+            "path_match": "wazuh.threat.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_marking_tlp": {
+            "path_match": "wazuh.threat.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_marking_tlp_version": {
+            "path_match": "wazuh.threat.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_modified_at": {
+            "path_match": "wazuh.threat.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_name": {
+            "path_match": "wazuh.threat.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_port": {
+            "path_match": "wazuh.threat.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_provider": {
+            "path_match": "wazuh.threat.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_reference": {
+            "path_match": "wazuh.threat.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_data_bytes": {
+            "path_match": "wazuh.threat.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_data_strings": {
+            "path_match": "wazuh.threat.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_data_type": {
+            "path_match": "wazuh.threat.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_hive": {
+            "path_match": "wazuh.threat.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_key": {
+            "path_match": "wazuh.threat.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_path": {
+            "path_match": "wazuh.threat.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_value": {
+            "path_match": "wazuh.threat.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_scanner_stats": {
+            "path_match": "wazuh.threat.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_sightings": {
+            "path_match": "wazuh.threat.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_type": {
+            "path_match": "wazuh.threat.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_alternative_names": {
+            "path_match": "wazuh.threat.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_country": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_locality": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_organization": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_not_after": {
+            "path_match": "wazuh.threat.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_not_before": {
+            "path_match": "wazuh.threat.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_curve": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_size": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_serial_number": {
+            "path_match": "wazuh.threat.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_common_name": {
+            "path_match": "wazuh.threat.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_country": {
+            "path_match": "wazuh.threat.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_locality": {
+            "path_match": "wazuh.threat.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_organization": {
+            "path_match": "wazuh.threat.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_version_number": {
+            "path_match": "wazuh.threat.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_alias": {
+            "path_match": "wazuh.threat.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_id": {
+            "path_match": "wazuh.threat.software.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_name": {
+            "path_match": "wazuh.threat.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_platforms": {
+            "path_match": "wazuh.threat.software.platforms",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_reference": {
+            "path_match": "wazuh.threat.software.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_type": {
+            "path_match": "wazuh.threat.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_tactic_id": {
+            "path_match": "wazuh.threat.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_tactic_name": {
+            "path_match": "wazuh.threat.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_tactic_reference": {
+            "path_match": "wazuh.threat.tactic.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_id": {
+            "path_match": "wazuh.threat.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_name": {
+            "path_match": "wazuh.threat.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_reference": {
+            "path_match": "wazuh.threat.technique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_subtechnique_id": {
+            "path_match": "wazuh.threat.technique.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_subtechnique_name": {
+            "path_match": "wazuh.threat.technique.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_subtechnique_reference": {
+            "path_match": "wazuh.threat.technique.subtechnique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      ],
+      "properties": {
         "agent": {
           "properties": {
             "build": {
-              "properties": {
-                "original": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ephemeral_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "groups": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "check": {
           "properties": {
             "compliance": {
-              "properties": {
-                "cmmc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "fedramp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "gdpr": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "hipaa": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "iso_27001": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nis2": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_171": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_53": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pci_dss": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tsc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "condition": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "mitre": {
               "properties": {
                 "subtechnique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "tactic": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "technique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 }
               }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "rationale": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reason": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "references": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "remediation": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "result": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "rules": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "client": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -365,520 +20193,125 @@
         "cloud": {
           "properties": {
             "account": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "availability_zone": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "instance": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "machine": {
-              "properties": {
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "origin": {
               "properties": {
                 "account": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "availability_zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "instance": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "machine": {
-                  "properties": {
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "project": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "provider": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "service": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             },
             "project": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "provider": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "region": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "service": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "target": {
               "properties": {
                 "account": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "availability_zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "instance": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "machine": {
-                  "properties": {
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "project": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "provider": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "service": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             }
           }
         },
         "compliance": {
-          "properties": {
-            "cmmc": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "fedramp": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "gdpr": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "hipaa": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "iso_27001": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nis2": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nist_800_171": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nist_800_53": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "pci_dss": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "tsc": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "container": {
           "properties": {
             "cpu": {
-              "properties": {
-                "usage": {
-                  "scaling_factor": 1000,
-                  "type": "scaled_float"
-                }
-              }
+              "properties": {}
             },
             "disk": {
               "properties": {
                 "read": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "write": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "image": {
               "properties": {
                 "hash": {
-                  "properties": {
-                    "all": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tag": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "labels": {
-              "type": "object"
             },
             "memory": {
-              "properties": {
-                "usage": {
-                  "scaling_factor": 1000,
-                  "type": "scaled_float"
-                }
-              }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "network": {
               "properties": {
                 "egress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "ingress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "runtime": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "security_context": {
-              "properties": {
-                "privileged": {
-                  "type": "boolean"
-                }
-              }
+              "properties": {}
             }
           }
         },
         "data_stream": {
-          "properties": {
-            "dataset": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "namespace": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "destination": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -886,213 +20319,23 @@
         },
         "device": {
           "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "manufacturer": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "model": {
-              "properties": {
-                "identifier": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "dll": {
           "properties": {
             "code_signature": {
-              "properties": {
-                "digest_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exists": {
-                  "type": "boolean"
-                },
-                "flags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signing_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "team_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "thumbprint_sha256": {
-                  "ignore_above": 64,
-                  "type": "keyword"
-                },
-                "timestamp": {
-                  "type": "date"
-                },
-                "trusted": {
-                  "type": "boolean"
-                },
-                "valid": {
-                  "type": "boolean"
-                }
-              }
+              "properties": {}
             },
             "hash": {
-              "properties": {
-                "cdhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "md5": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha1": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha256": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha384": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha512": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ssdeep": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tlsh": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "origin_referrer_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "origin_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "pe": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "company": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "file_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "imphash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pehash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "product": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 }
               }
             }
@@ -1101,79 +20344,10 @@
         "dns": {
           "properties": {
             "answers": {
-              "properties": {
-                "class": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "data": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ttl": {
-                  "type": "long"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "header_flags": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "op_code": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "question": {
-              "properties": {
-                "class": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "registered_domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subdomain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "top_level_domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "resolved_ip": {
-              "type": "ip"
-            },
-            "response_code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
@@ -1183,878 +20357,88 @@
               "properties": {
                 "file": {
                   "properties": {
-                    "extension": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "hash": {
-                      "properties": {
-                        "cdhash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "md5": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha1": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha256": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha384": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha512": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "ssdeep": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlsh": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "mime_type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "size": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
                 }
-              },
-              "type": "nested"
+              }
             },
             "bcc": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "cc": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "content_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "delivery_timestamp": {
-              "type": "date"
-            },
-            "direction": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "from": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "local_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "message_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "origination_timestamp": {
-              "type": "date"
+              "properties": {}
             },
             "reply_to": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "sender": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "subject": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "to": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "x_mailer": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "error": {
-          "properties": {
-            "code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "message": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "stack_trace": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "event": {
-          "properties": {
-            "action": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "agent_id_status": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "changed_fields": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "collector": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "created": {
-              "type": "date"
-            },
-            "dataset": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "duration": {
-              "type": "long"
-            },
-            "end": {
-              "type": "date"
-            },
-            "hash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ingested": {
-              "type": "date"
-            },
-            "kind": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "module": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            },
-            "outcome": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "provider": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reason": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reference": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "risk_score": {
-              "type": "float"
-            },
-            "risk_score_norm": {
-              "type": "float"
-            },
-            "sequence": {
-              "type": "long"
-            },
-            "severity": {
-              "type": "long"
-            },
-            "start": {
-              "type": "date"
-            },
-            "timezone": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "url": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "faas": {
           "properties": {
-            "coldstart": {
-              "type": "boolean"
-            },
-            "execution": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "trigger": {
-              "properties": {
-                "request_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "file": {
           "properties": {
-            "accessed": {
-              "type": "date"
-            },
-            "attributes": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "code_signature": {
-              "properties": {
-                "digest_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exists": {
-                  "type": "boolean"
-                },
-                "flags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signing_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "team_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "thumbprint_sha256": {
-                  "ignore_above": 64,
-                  "type": "keyword"
-                },
-                "timestamp": {
-                  "type": "date"
-                },
-                "trusted": {
-                  "type": "boolean"
-                },
-                "valid": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "created": {
-              "type": "date"
-            },
-            "ctime": {
-              "type": "date"
-            },
-            "device": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "diff": {
-              "type": "match_only_text"
-            },
-            "directory": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "drive_letter": {
-              "ignore_above": 1,
-              "type": "keyword"
+              "properties": {}
             },
             "elf": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "byte_order": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "cpu_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "creation_date": {
-                  "type": "date"
-                },
-                "exports": {
-                  "type": "flat_object"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
                 "header": {
-                  "properties": {
-                    "abi_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "class": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "data": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "entrypoint": {
-                      "type": "long"
-                    },
-                    "object_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os_abi": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
+                  "properties": {}
                 },
                 "sections": {
-                  "properties": {
-                    "chi2": {
-                      "type": "long"
-                    },
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "flags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_offset": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_address": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 },
                 "segments": {
-                  "properties": {
-                    "sections": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "shared_libraries": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "telfhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "extension": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "fork_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "gid": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "group": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "hash": {
-              "properties": {
-                "cdhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "md5": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha1": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha256": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha384": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha512": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ssdeep": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tlsh": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "inode": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "macho": {
               "properties": {
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "symhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "mime_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mode": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mtime": {
-              "type": "date"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "origin_referrer_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "origin_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "owner": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "pe": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "company": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "file_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "imphash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pehash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "product": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 }
               }
             },
-            "size": {
-              "type": "long"
-            },
-            "target_path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "uid": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "x509": {
               "properties": {
-                "alternative_names": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "issuer": {
-                  "properties": {
-                    "common_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "distinguished_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "locality": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organization": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organizational_unit": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "state_or_province": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "not_after": {
-                  "type": "date"
-                },
-                "not_before": {
-                  "type": "date"
-                },
-                "public_key_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "public_key_curve": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "public_key_exponent": {
-                  "doc_values": false,
-                  "index": false,
-                  "type": "long"
-                },
-                "public_key_size": {
-                  "type": "long"
-                },
-                "serial_number": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signature_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "subject": {
-                  "properties": {
-                    "common_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "distinguished_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "locality": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organization": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organizational_unit": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "state_or_province": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "version_number": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -2063,406 +20447,85 @@
         "gen_ai": {
           "properties": {
             "agent": {
-              "properties": {
-                "description": {
-                  "doc_values": false,
-                  "index": false,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "operation": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "output": {
-              "properties": {
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "request": {
               "properties": {
                 "choice": {
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    }
-                  }
-                },
-                "encoding_formats": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "frequency_penalty": {
-                  "type": "double"
-                },
-                "max_tokens": {
-                  "type": "integer"
-                },
-                "model": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "presence_penalty": {
-                  "type": "double"
-                },
-                "seed": {
-                  "type": "integer"
-                },
-                "stop_sequences": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "temperature": {
-                  "type": "double"
-                },
-                "top_k": {
-                  "type": "double"
-                },
-                "top_p": {
-                  "type": "double"
+                  "properties": {}
                 }
               }
             },
             "response": {
-              "properties": {
-                "finish_reasons": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "model": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "system": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "token": {
-              "properties": {
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "tool": {
               "properties": {
                 "call": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "usage": {
-              "properties": {
-                "input_tokens": {
-                  "type": "integer"
-                },
-                "output_tokens": {
-                  "type": "integer"
-                }
-              }
+              "properties": {}
             }
           }
         },
         "group": {
-          "properties": {
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "host": {
           "properties": {
-            "architecture": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "boot": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "cpu": {
-              "properties": {
-                "cores": {
-                  "type": "long"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "speed": {
-                  "type": "long"
-                },
-                "usage": {
-                  "scaling_factor": 1000,
-                  "type": "scaled_float"
-                }
-              },
-              "type": "object"
+              "properties": {}
             },
             "disk": {
               "properties": {
                 "read": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "write": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "memory": {
               "properties": {
-                "free": {
-                  "type": "long"
-                },
-                "total": {
-                  "type": "long"
-                },
                 "used": {
-                  "properties": {
-                    "percentage": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 }
-              },
-              "type": "object"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              }
             },
             "network": {
               "properties": {
                 "egress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "drops": {
-                      "type": "long"
-                    },
-                    "errors": {
-                      "type": "long"
-                    },
-                    "packets": {
-                      "type": "long"
-                    },
-                    "queue": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "ingress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "drops": {
-                      "type": "long"
-                    },
-                    "errors": {
-                      "type": "long"
-                    },
-                    "packets": {
-                      "type": "long"
-                    },
-                    "queue": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             },
             "os": {
-              "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "kernel": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platform": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "pid_ns_ino": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "risk": {
-              "properties": {
-                "calculated_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "calculated_score": {
-                  "type": "float"
-                },
-                "calculated_score_norm": {
-                  "type": "float"
-                },
-                "static_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "static_score": {
-                  "type": "float"
-                },
-                "static_score_norm": {
-                  "type": "float"
-                }
-              }
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "uptime": {
-              "type": "long"
+              "properties": {}
             }
           }
         },
@@ -2471,324 +20534,70 @@
             "request": {
               "properties": {
                 "body": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "content": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "bytes": {
-                  "type": "long"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "method": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "mime_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "referrer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "response": {
               "properties": {
                 "body": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "content": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "bytes": {
-                  "type": "long"
-                },
-                "mime_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status_code": {
-                  "type": "long"
+                  "properties": {}
                 }
               }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "interface": {
-          "properties": {
-            "alias": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mtu": {
-              "type": "long"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "labels": {
-          "type": "object"
+          "properties": {}
         },
         "log": {
           "properties": {
             "file": {
-              "properties": {
-                "path": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "level": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "logger": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "origin": {
               "properties": {
                 "file": {
-                  "properties": {
-                    "line": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "function": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "syslog": {
               "properties": {
-                "appname": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "facility": {
-                  "properties": {
-                    "code": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hostname": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "msgid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "priority": {
-                  "type": "long"
-                },
-                "procid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "severity": {
-                  "properties": {
-                    "code": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "structured_data": {
-                  "type": "flat_object"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
-              },
-              "type": "object"
+              }
             }
           }
-        },
-        "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
         },
         "mitre": {
           "properties": {
             "subtechnique": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
+              "properties": {}
             },
             "tactic": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
+              "properties": {}
             },
             "technique": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
+              "properties": {}
             }
           }
         },
         "network": {
           "properties": {
-            "application": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "broadcast": {
-              "type": "ip"
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "community_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "dhcp": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "direction": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "forwarded_ip": {
-              "type": "ip"
-            },
-            "gateway": {
-              "type": "ip"
-            },
-            "iana_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "inner": {
               "properties": {
                 "vlan": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                }
-              },
-              "type": "object"
-            },
-            "metric": {
-              "type": "long"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "netmask": {
-              "type": "ip"
-            },
-            "packets": {
-              "type": "long"
-            },
-            "protocol": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "transport": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "vlan": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
+            },
+            "vlan": {
+              "properties": {}
             }
           }
         },
@@ -2798,2517 +20607,402 @@
               "properties": {
                 "interface": {
                   "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mtu": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "observer": {
                       "properties": {
                         "ingress": {
                           "properties": {
                             "interface": {
-                              "properties": {
-                                "alias": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "id": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "mtu": {
-                                  "type": "long"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
+                              "properties": {}
                             }
                           }
                         }
                       }
-                    },
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     }
                   }
                 },
                 "vlan": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "geo": {
+              "properties": {}
             },
             "ingress": {
               "properties": {
                 "interface": {
-                  "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mtu": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "vlan": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "os": {
-              "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "kernel": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platform": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "product": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "vendor": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "os": {
+              "properties": {}
             }
           }
         },
         "orchestrator": {
           "properties": {
-            "api_version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "cluster": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "url": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "namespace": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "organization": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "resource": {
               "properties": {
-                "annotation": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ip": {
-                  "type": "ip"
-                },
-                "label": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "parent": {
-                  "properties": {
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "organization": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "package": {
           "properties": {
-            "architecture": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "build_version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "checksum": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "install_scope": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "installed": {
-              "type": "date"
-            },
-            "license": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "previous": {
-              "properties": {
-                "installed": {
-                  "type": "date"
-                }
-              }
-            },
-            "reference": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "size": {
-              "type": "long"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "policy": {
-          "properties": {
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "file": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "references": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "process": {
           "properties": {
-            "args": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "args_count": {
-              "type": "long"
-            },
             "code_signature": {
-              "properties": {
-                "digest_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exists": {
-                  "type": "boolean"
-                },
-                "flags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signing_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "team_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "thumbprint_sha256": {
-                  "ignore_above": 64,
-                  "type": "keyword"
-                },
-                "timestamp": {
-                  "type": "date"
-                },
-                "trusted": {
-                  "type": "boolean"
-                },
-                "valid": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "command_line": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "elf": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "byte_order": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "cpu_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "creation_date": {
-                  "type": "date"
-                },
-                "exports": {
-                  "type": "flat_object"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
                 "header": {
-                  "properties": {
-                    "abi_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "class": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "data": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "entrypoint": {
-                      "type": "long"
-                    },
-                    "object_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os_abi": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
+                  "properties": {}
                 },
                 "sections": {
-                  "properties": {
-                    "chi2": {
-                      "type": "long"
-                    },
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "flags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_offset": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_address": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 },
                 "segments": {
-                  "properties": {
-                    "sections": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "shared_libraries": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "telfhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "end": {
-              "type": "date"
-            },
-            "entity_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "entry_leader": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
                 "attested_groups": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "attested_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "entry_meta": {
                   "properties": {
                     "source": {
-                      "properties": {
-                        "ip": {
-                          "type": "ip"
-                        }
-                      }
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "parent": {
                   "properties": {
-                    "entity_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pid": {
-                      "type": "long"
-                    },
                     "session_leader": {
-                      "properties": {
-                        "entity_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "pid": {
-                          "type": "long"
-                        },
-                        "start": {
-                          "type": "date"
-                        },
-                        "vpid": {
-                          "type": "long"
-                        }
-                      }
-                    },
-                    "start": {
-                      "type": "date"
-                    },
-                    "vpid": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
-                },
-                "pid": {
-                  "type": "long"
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "same_as_process": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
-            },
-            "env_vars": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "executable": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "exit_code": {
-              "type": "long"
             },
             "group": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "group_leader": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pid": {
-                  "type": "long"
+                  "properties": {}
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "same_as_process": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
             },
             "hash": {
-              "properties": {
-                "cdhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "md5": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha1": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha256": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha384": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha512": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ssdeep": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tlsh": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "interactive": {
-              "type": "boolean"
+              "properties": {}
             },
             "io": {
               "properties": {
                 "bytes_skipped": {
-                  "properties": {
-                    "length": {
-                      "type": "long"
-                    },
-                    "offset": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "object"
-                },
-                "max_bytes_per_process_exceeded": {
-                  "type": "boolean"
-                },
-                "text": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "total_bytes_captured": {
-                  "type": "long"
-                },
-                "total_bytes_skipped": {
-                  "type": "long"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "macho": {
-              "properties": {
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "symhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "macho": {
+              "properties": {
+                "sections": {
+                  "properties": {}
+                }
+              }
             },
             "parent": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
                 "code_signature": {
-                  "properties": {
-                    "digest_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "exists": {
-                      "type": "boolean"
-                    },
-                    "flags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signing_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "status": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "subject_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "team_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "thumbprint_sha256": {
-                      "ignore_above": 64,
-                      "type": "keyword"
-                    },
-                    "timestamp": {
-                      "type": "date"
-                    },
-                    "trusted": {
-                      "type": "boolean"
-                    },
-                    "valid": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "elf": {
                   "properties": {
-                    "architecture": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "byte_order": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "cpu_type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "creation_date": {
-                      "type": "date"
-                    },
-                    "exports": {
-                      "type": "flat_object"
-                    },
-                    "go_import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_imports": {
-                      "type": "flat_object"
-                    },
-                    "go_imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "go_imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "go_stripped": {
-                      "type": "boolean"
-                    },
                     "header": {
-                      "properties": {
-                        "abi_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "class": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "data": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "entrypoint": {
-                          "type": "long"
-                        },
-                        "object_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "os_abi": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "imports": {
-                      "type": "flat_object"
-                    },
-                    "imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "imports_names_var_entropy": {
-                      "type": "long"
+                      "properties": {}
                     },
                     "sections": {
-                      "properties": {
-                        "chi2": {
-                          "type": "long"
-                        },
-                        "entropy": {
-                          "type": "long"
-                        },
-                        "flags": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_offset": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_size": {
-                          "type": "long"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "var_entropy": {
-                          "type": "long"
-                        },
-                        "virtual_address": {
-                          "type": "long"
-                        },
-                        "virtual_size": {
-                          "type": "long"
-                        }
-                      },
-                      "type": "nested"
+                      "properties": {}
                     },
                     "segments": {
-                      "properties": {
-                        "sections": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "nested"
-                    },
-                    "shared_libraries": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "telfhash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "end": {
-                  "type": "date"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exit_code": {
-                  "type": "long"
                 },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "group_leader": {
-                  "properties": {
-                    "entity_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pid": {
-                      "type": "long"
-                    },
-                    "start": {
-                      "type": "date"
-                    },
-                    "vpid": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "hash": {
-                  "properties": {
-                    "cdhash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "md5": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha1": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha256": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha384": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha512": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ssdeep": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "tlsh": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "macho": {
                   "properties": {
-                    "go_import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_imports": {
-                      "type": "flat_object"
-                    },
-                    "go_imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "go_imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "go_stripped": {
-                      "type": "boolean"
-                    },
-                    "import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "imports": {
-                      "type": "flat_object"
-                    },
-                    "imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "imports_names_var_entropy": {
-                      "type": "long"
-                    },
                     "sections": {
-                      "properties": {
-                        "entropy": {
-                          "type": "long"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_size": {
-                          "type": "long"
-                        },
-                        "var_entropy": {
-                          "type": "long"
-                        },
-                        "virtual_size": {
-                          "type": "long"
-                        }
-                      },
-                      "type": "nested"
-                    },
-                    "symhash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "pe": {
                   "properties": {
-                    "architecture": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "company": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "file_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_imports": {
-                      "type": "flat_object"
-                    },
-                    "go_imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "go_imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "go_stripped": {
-                      "type": "boolean"
-                    },
-                    "imphash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "imports": {
-                      "type": "flat_object"
-                    },
-                    "imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "original_file_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pehash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "product": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "sections": {
-                      "properties": {
-                        "entropy": {
-                          "type": "long"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_size": {
-                          "type": "long"
-                        },
-                        "var_entropy": {
-                          "type": "long"
-                        },
-                        "virtual_size": {
-                          "type": "long"
-                        }
-                      },
-                      "type": "nested"
+                      "properties": {}
                     }
                   }
-                },
-                "pid": {
-                  "type": "long"
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "thread": {
                   "properties": {
                     "capabilities": {
-                      "properties": {
-                        "effective": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "permitted": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "id": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "title": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "uptime": {
-                  "type": "long"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
             },
             "pe": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "company": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "file_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "imphash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pehash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "product": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 }
               }
             },
-            "pid": {
-              "type": "long"
-            },
             "previous": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "parent": {
-                  "properties": {
-                    "pid": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "pid": {
-                  "type": "long"
-                },
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "real_group": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "real_user": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "saved_group": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "saved_user": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "session_leader": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "parent": {
                   "properties": {
-                    "entity_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pid": {
-                      "type": "long"
-                    },
                     "session_leader": {
-                      "properties": {
-                        "entity_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "pid": {
-                          "type": "long"
-                        },
-                        "start": {
-                          "type": "date"
-                        },
-                        "vpid": {
-                          "type": "long"
-                        }
-                      }
-                    },
-                    "start": {
-                      "type": "date"
-                    },
-                    "vpid": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
-                },
-                "pid": {
-                  "type": "long"
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "same_as_process": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
-            },
-            "start": {
-              "type": "date"
-            },
-            "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "supplemental_groups": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "thread": {
               "properties": {
                 "capabilities": {
-                  "properties": {
-                    "effective": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "permitted": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "id": {
-                  "type": "long"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "title": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "tty": {
               "properties": {
                 "char_device": {
-                  "properties": {
-                    "major": {
-                      "type": "long"
-                    },
-                    "minor": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "columns": {
-                  "type": "long"
-                },
-                "rows": {
-                  "type": "long"
-                }
-              },
-              "type": "object"
-            },
-            "uptime": {
-              "type": "long"
-            },
-            "user": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "vpid": {
-              "type": "long"
-            },
-            "working_directory": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "user": {
+              "properties": {}
             }
           }
         },
         "registry": {
           "properties": {
             "data": {
-              "properties": {
-                "bytes": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "strings": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "hive": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "key": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "value": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "related": {
-          "properties": {
-            "hash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "hosts": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "user": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "rule": {
           "properties": {
-            "author": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "compliance": {
-              "properties": {
-                "cmmc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "fedramp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "gdpr": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "hipaa": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "iso_27001": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nis2": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_171": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_53": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pci_dss": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tsc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "level": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "license": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "mitre": {
               "properties": {
                 "subtechnique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "tactic": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "technique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 }
               }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reference": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ruleset": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "sigma_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "status": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "tags": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "title": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "uuid": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "server": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -5316,355 +21010,60 @@
         },
         "service": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "environment": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ephemeral_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "node": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "role": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "origin": {
               "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "environment": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ephemeral_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "node": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "role": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "roles": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "previous": {
-                  "properties": {
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "previous": {
-              "properties": {
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "target": {
               "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "environment": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ephemeral_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "node": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "role": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "roles": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "previous": {
-                  "properties": {
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "source": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
           }
         },
         "span": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "tags": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "properties": {}
         },
         "threat": {
           "properties": {
@@ -5674,1876 +21073,189 @@
                   "properties": {
                     "as": {
                       "properties": {
-                        "number": {
-                          "type": "long"
-                        },
                         "organization": {
-                          "properties": {
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
-                    },
-                    "confidence": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "email": {
-                      "properties": {
-                        "address": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "feed": {
-                      "properties": {
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "file": {
                       "properties": {
-                        "accessed": {
-                          "type": "date"
-                        },
-                        "attributes": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "code_signature": {
-                          "properties": {
-                            "digest_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "exists": {
-                              "type": "boolean"
-                            },
-                            "flags": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signing_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "status": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "subject_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "team_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "thumbprint_sha256": {
-                              "ignore_above": 64,
-                              "type": "keyword"
-                            },
-                            "timestamp": {
-                              "type": "date"
-                            },
-                            "trusted": {
-                              "type": "boolean"
-                            },
-                            "valid": {
-                              "type": "boolean"
-                            }
-                          }
-                        },
-                        "created": {
-                          "type": "date"
-                        },
-                        "ctime": {
-                          "type": "date"
-                        },
-                        "device": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "directory": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "drive_letter": {
-                          "ignore_above": 1,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "elf": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "byte_order": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "cpu_type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "creation_date": {
-                              "type": "date"
-                            },
-                            "exports": {
-                              "type": "flat_object"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
                             "header": {
-                              "properties": {
-                                "abi_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "class": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "data": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "entrypoint": {
-                                  "type": "long"
-                                },
-                                "object_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "os_abi": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
+                              "properties": {}
                             },
                             "sections": {
-                              "properties": {
-                                "chi2": {
-                                  "type": "long"
-                                },
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "flags": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_offset": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_address": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             },
                             "segments": {
-                              "properties": {
-                                "sections": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "nested"
-                            },
-                            "shared_libraries": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "telfhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
-                        },
-                        "extension": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "fork_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "gid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "group": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "hash": {
-                          "properties": {
-                            "cdhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "md5": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha1": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha256": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha384": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha512": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "ssdeep": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "tlsh": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "inode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mime_type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mtime": {
-                          "type": "date"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "origin_referrer_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "origin_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "owner": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "pe": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "company": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "description": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "file_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
-                            "imphash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "original_file_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "pehash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "product": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "sections": {
-                              "properties": {
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             }
                           }
-                        },
-                        "size": {
-                          "type": "long"
-                        },
-                        "target_path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "uid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "x509": {
                           "properties": {
-                            "alternative_names": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "issuer": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "not_after": {
-                              "type": "date"
-                            },
-                            "not_before": {
-                              "type": "date"
-                            },
-                            "public_key_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_curve": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_exponent": {
-                              "doc_values": false,
-                              "index": false,
-                              "type": "long"
-                            },
-                            "public_key_size": {
-                              "type": "long"
-                            },
-                            "serial_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signature_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "subject": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "version_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         }
                       }
                     },
-                    "first_seen": {
-                      "type": "date"
-                    },
                     "geo": {
-                      "properties": {
-                        "city_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "location": {
-                          "type": "geo_point"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "postal_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "timezone": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ip": {
-                      "type": "ip"
-                    },
-                    "last_seen": {
-                      "type": "date"
+                      "properties": {}
                     },
                     "marking": {
-                      "properties": {
-                        "tlp": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlp_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "modified_at": {
-                      "type": "date"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "port": {
-                      "type": "long"
-                    },
-                    "provider": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "registry": {
                       "properties": {
                         "data": {
-                          "properties": {
-                            "bytes": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "strings": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "hive": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "key": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "value": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
-                    },
-                    "scanner_stats": {
-                      "type": "long"
-                    },
-                    "sightings": {
-                      "type": "long"
                     },
                     "software": {
-                      "properties": {
-                        "alias": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "tags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "url": {
-                      "properties": {
-                        "domain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "extension": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "fragment": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "full": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "original": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "password": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "port": {
-                          "type": "long"
-                        },
-                        "query": {
-                          "ignore_above": 2083,
-                          "type": "keyword"
-                        },
-                        "registered_domain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "scheme": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "subdomain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "top_level_domain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "username": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "x509": {
                       "properties": {
-                        "alternative_names": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "issuer": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "not_after": {
-                          "type": "date"
-                        },
-                        "not_before": {
-                          "type": "date"
-                        },
-                        "public_key_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_curve": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_exponent": {
-                          "doc_values": false,
-                          "index": false,
-                          "type": "long"
-                        },
-                        "public_key_size": {
-                          "type": "long"
-                        },
-                        "serial_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signature_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "subject": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "version_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     }
-                  },
-                  "type": "object"
+                  }
                 },
                 "matched": {
-                  "properties": {
-                    "atomic": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "field": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "index": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "occurred": {
-                      "type": "date"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
-              },
-              "type": "object"
+              }
             },
             "feed": {
-              "properties": {
-                "dashboard_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "framework": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "group": {
-              "properties": {
-                "alias": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "indicator": {
               "properties": {
                 "as": {
                   "properties": {
-                    "number": {
-                      "type": "long"
-                    },
                     "organization": {
-                      "properties": {
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     }
                   }
-                },
-                "confidence": {
-                  "type": "short"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "email": {
-                  "properties": {
-                    "address": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "file": {
                   "properties": {
-                    "accessed": {
-                      "type": "date"
-                    },
-                    "attributes": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "code_signature": {
-                      "properties": {
-                        "digest_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "exists": {
-                          "type": "boolean"
-                        },
-                        "flags": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signing_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "status": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "subject_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "team_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "thumbprint_sha256": {
-                          "ignore_above": 64,
-                          "type": "keyword"
-                        },
-                        "timestamp": {
-                          "type": "date"
-                        },
-                        "trusted": {
-                          "type": "boolean"
-                        },
-                        "valid": {
-                          "type": "boolean"
-                        }
-                      }
-                    },
-                    "created": {
-                      "type": "date"
-                    },
-                    "ctime": {
-                      "type": "date"
-                    },
-                    "device": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "directory": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "drive_letter": {
-                      "ignore_above": 1,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "elf": {
                       "properties": {
-                        "architecture": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "byte_order": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "cpu_type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "creation_date": {
-                          "type": "date"
-                        },
-                        "exports": {
-                          "type": "flat_object"
-                        },
-                        "go_import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "go_imports": {
-                          "type": "flat_object"
-                        },
-                        "go_imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "go_imports_names_var_entropy": {
-                          "type": "long"
-                        },
-                        "go_stripped": {
-                          "type": "boolean"
-                        },
                         "header": {
-                          "properties": {
-                            "abi_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "class": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "data": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "entrypoint": {
-                              "type": "long"
-                            },
-                            "object_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "os_abi": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "imports": {
-                          "type": "flat_object"
-                        },
-                        "imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "imports_names_var_entropy": {
-                          "type": "long"
+                          "properties": {}
                         },
                         "sections": {
-                          "properties": {
-                            "chi2": {
-                              "type": "long"
-                            },
-                            "entropy": {
-                              "type": "long"
-                            },
-                            "flags": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "physical_offset": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "physical_size": {
-                              "type": "long"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "var_entropy": {
-                              "type": "long"
-                            },
-                            "virtual_address": {
-                              "type": "long"
-                            },
-                            "virtual_size": {
-                              "type": "long"
-                            }
-                          },
-                          "type": "nested"
+                          "properties": {}
                         },
                         "segments": {
-                          "properties": {
-                            "sections": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "nested"
-                        },
-                        "shared_libraries": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "telfhash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
-                    },
-                    "extension": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "fork_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "gid": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "group": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "hash": {
-                      "properties": {
-                        "cdhash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "md5": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha1": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha256": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha384": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha512": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "ssdeep": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlsh": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "inode": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mime_type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mode": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mtime": {
-                      "type": "date"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "origin_referrer_url": {
-                      "ignore_above": 8192,
-                      "type": "keyword"
-                    },
-                    "origin_url": {
-                      "ignore_above": 8192,
-                      "type": "keyword"
-                    },
-                    "owner": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "pe": {
                       "properties": {
-                        "architecture": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "company": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "description": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "file_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "go_import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "go_imports": {
-                          "type": "flat_object"
-                        },
-                        "go_imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "go_imports_names_var_entropy": {
-                          "type": "long"
-                        },
-                        "go_stripped": {
-                          "type": "boolean"
-                        },
-                        "imphash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "imports": {
-                          "type": "flat_object"
-                        },
-                        "imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "imports_names_var_entropy": {
-                          "type": "long"
-                        },
-                        "original_file_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "pehash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "product": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "sections": {
-                          "properties": {
-                            "entropy": {
-                              "type": "long"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "physical_size": {
-                              "type": "long"
-                            },
-                            "var_entropy": {
-                              "type": "long"
-                            },
-                            "virtual_size": {
-                              "type": "long"
-                            }
-                          },
-                          "type": "nested"
+                          "properties": {}
                         }
                       }
-                    },
-                    "size": {
-                      "type": "long"
-                    },
-                    "target_path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "uid": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "x509": {
                       "properties": {
-                        "alternative_names": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "issuer": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "not_after": {
-                          "type": "date"
-                        },
-                        "not_before": {
-                          "type": "date"
-                        },
-                        "public_key_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_curve": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_exponent": {
-                          "doc_values": false,
-                          "index": false,
-                          "type": "long"
-                        },
-                        "public_key_size": {
-                          "type": "long"
-                        },
-                        "serial_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signature_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "subject": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "version_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     }
                   }
                 },
-                "first_seen": {
-                  "type": "date"
-                },
                 "geo": {
-                  "properties": {
-                    "city_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "continent_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "continent_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country_iso_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "location": {
-                      "type": "geo_point"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "postal_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "region_iso_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "region_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "timezone": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ip": {
-                  "type": "ip"
-                },
-                "last_seen": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "marking": {
-                  "properties": {
-                    "tlp": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "tlp_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "modified_at": {
-                  "type": "date"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "port": {
-                  "type": "long"
-                },
-                "provider": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "registry": {
                   "properties": {
                     "data": {
-                      "properties": {
-                        "bytes": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "strings": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "hive": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "key": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "value": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "scanner_stats": {
-                  "type": "long"
-                },
-                "sightings": {
-                  "type": "long"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "url": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "extension": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "fragment": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "full": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "original": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "password": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "port": {
-                      "type": "long"
-                    },
-                    "query": {
-                      "ignore_above": 2083,
-                      "type": "keyword"
-                    },
-                    "registered_domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "scheme": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "subdomain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "top_level_domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "username": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "x509": {
                   "properties": {
-                    "alternative_names": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "issuer": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "not_after": {
-                      "type": "date"
-                    },
-                    "not_before": {
-                      "type": "date"
-                    },
-                    "public_key_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_curve": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_exponent": {
-                      "doc_values": false,
-                      "index": false,
-                      "type": "long"
-                    },
-                    "public_key_size": {
-                      "type": "long"
-                    },
-                    "serial_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signature_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "subject": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "version_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 }
               }
             },
             "software": {
-              "properties": {
-                "alias": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platforms": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "tactic": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "technique": {
               "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "subtechnique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             }
@@ -7551,632 +21263,77 @@
         },
         "tls": {
           "properties": {
-            "cipher": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "client": {
               "properties": {
-                "certificate": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "certificate_chain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "hash": {
-                  "properties": {
-                    "md5": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha1": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha256": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "issuer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ja3": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "not_after": {
-                  "type": "date"
-                },
-                "not_before": {
-                  "type": "date"
-                },
-                "server_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "supported_ciphers": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "x509": {
                   "properties": {
-                    "alternative_names": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "issuer": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "not_after": {
-                      "type": "date"
-                    },
-                    "not_before": {
-                      "type": "date"
-                    },
-                    "public_key_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_curve": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_exponent": {
-                      "doc_values": false,
-                      "index": false,
-                      "type": "long"
-                    },
-                    "public_key_size": {
-                      "type": "long"
-                    },
-                    "serial_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signature_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "subject": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "version_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 }
               }
-            },
-            "curve": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "established": {
-              "type": "boolean"
-            },
-            "next_protocol": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "resumed": {
-              "type": "boolean"
             },
             "server": {
               "properties": {
-                "certificate": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "certificate_chain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "hash": {
-                  "properties": {
-                    "md5": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha1": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha256": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "issuer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ja3s": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "not_after": {
-                  "type": "date"
-                },
-                "not_before": {
-                  "type": "date"
-                },
-                "subject": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "x509": {
                   "properties": {
-                    "alternative_names": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "issuer": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "not_after": {
-                      "type": "date"
-                    },
-                    "not_before": {
-                      "type": "date"
-                    },
-                    "public_key_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_curve": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_exponent": {
-                      "doc_values": false,
-                      "index": false,
-                      "type": "long"
-                    },
-                    "public_key_size": {
-                      "type": "long"
-                    },
-                    "serial_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signature_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "subject": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "version_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 }
               }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version_protocol": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "trace": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "transaction": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "url": {
-          "properties": {
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "extension": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "fragment": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "full": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "password": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "port": {
-              "type": "long"
-            },
-            "query": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "scheme": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "username": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "user": {
           "properties": {
             "changes": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "effective": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "email": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "full_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "group": {
-              "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "hash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "risk": {
-              "properties": {
-                "calculated_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "calculated_score": {
-                  "type": "float"
-                },
-                "calculated_score_norm": {
-                  "type": "float"
-                },
-                "static_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "static_score": {
-                  "type": "float"
-                },
-                "static_score_norm": {
-                  "type": "float"
-                }
-              }
-            },
-            "roles": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "target": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -8185,199 +21342,23 @@
         "user_agent": {
           "properties": {
             "device": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "os": {
-              "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "kernel": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platform": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "volume": {
-          "properties": {
-            "bus_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "default_access": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "device_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "device_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "dos_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "file_system_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mount_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nt_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "product_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "product_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "removable": {
-              "type": "boolean"
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "size": {
-              "type": "long"
-            },
-            "vendor_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "vendor_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "writable": {
-              "type": "boolean"
-            }
-          }
+          "properties": {}
         },
         "vulnerability": {
           "properties": {
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "classification": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "detected_at": {
-              "type": "date"
-            },
-            "enumeration": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "published_at": {
-              "type": "date"
-            },
-            "report_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "scanner": {
-              "properties": {
-                "condition": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "source": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "vendor": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "score": {
-              "properties": {
-                "base": {
-                  "type": "float"
-                },
-                "environmental": {
-                  "type": "float"
-                },
-                "temporal": {
-                  "type": "float"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "severity": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "under_evaluation": {
-              "type": "boolean"
+              "properties": {}
             }
           }
         },
@@ -8386,359 +21367,73 @@
             "agent": {
               "properties": {
                 "build": {
-                  "properties": {
-                    "original": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "ephemeral_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "groups": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "host": {
                   "properties": {
-                    "architecture": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "boot": {
-                      "properties": {
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "cpu": {
-                      "properties": {
-                        "cores": {
-                          "type": "long"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "speed": {
-                          "type": "long"
-                        },
-                        "usage": {
-                          "scaling_factor": 1000,
-                          "type": "scaled_float"
-                        }
-                      },
-                      "type": "object"
+                      "properties": {}
                     },
                     "disk": {
                       "properties": {
                         "read": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         },
                         "write": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
-                    },
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "geo": {
-                      "properties": {
-                        "city_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "location": {
-                          "type": "geo_point"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "postal_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "timezone": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "hostname": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ip": {
-                      "type": "ip"
-                    },
-                    "mac": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "memory": {
                       "properties": {
-                        "free": {
-                          "type": "long"
-                        },
-                        "total": {
-                          "type": "long"
-                        },
                         "used": {
-                          "properties": {
-                            "percentage": {
-                              "type": "long"
-                            }
-                          },
-                          "type": "object"
+                          "properties": {}
                         }
-                      },
-                      "type": "object"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      }
                     },
                     "network": {
                       "properties": {
                         "egress": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            },
-                            "drops": {
-                              "type": "long"
-                            },
-                            "errors": {
-                              "type": "long"
-                            },
-                            "packets": {
-                              "type": "long"
-                            },
-                            "queue": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         },
                         "ingress": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            },
-                            "drops": {
-                              "type": "long"
-                            },
-                            "errors": {
-                              "type": "long"
-                            },
-                            "packets": {
-                              "type": "long"
-                            },
-                            "queue": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
                     },
                     "os": {
-                      "properties": {
-                        "family": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "full": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "kernel": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "platform": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "pid_ns_ino": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "risk": {
-                      "properties": {
-                        "calculated_level": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "calculated_score": {
-                          "type": "float"
-                        },
-                        "calculated_score_norm": {
-                          "type": "float"
-                        },
-                        "static_level": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "static_score": {
-                          "type": "float"
-                        },
-                        "static_score_norm": {
-                          "type": "float"
-                        }
-                      }
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "uptime": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 }
               }
             },
             "cluster": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "node": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "event": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "integration": {
-              "properties": {
-                "category": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "decoders": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "rules": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "protocol": {
-              "properties": {
-                "location": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "queue": {
-                  "type": "byte"
-                }
-              }
+              "properties": {}
             },
             "schema": {
-              "properties": {
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "space": {
-              "properties": {
-                "event_discarded": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "threat": {
               "properties": {
@@ -8748,1764 +21443,203 @@
                       "properties": {
                         "as": {
                           "properties": {
-                            "number": {
-                              "type": "long"
-                            },
                             "organization": {
-                              "properties": {
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
+                              "properties": {}
                             }
                           }
-                        },
-                        "confidence": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "description": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "email": {
-                          "properties": {
-                            "address": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         },
                         "feed": {
-                          "properties": {
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         },
                         "file": {
                           "properties": {
-                            "accessed": {
-                              "type": "date"
-                            },
-                            "attributes": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "code_signature": {
-                              "properties": {
-                                "digest_algorithm": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "exists": {
-                                  "type": "boolean"
-                                },
-                                "flags": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "signing_id": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "status": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "subject_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "team_id": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "thumbprint_sha256": {
-                                  "ignore_above": 64,
-                                  "type": "keyword"
-                                },
-                                "timestamp": {
-                                  "type": "date"
-                                },
-                                "trusted": {
-                                  "type": "boolean"
-                                },
-                                "valid": {
-                                  "type": "boolean"
-                                }
-                              }
-                            },
-                            "created": {
-                              "type": "date"
-                            },
-                            "ctime": {
-                              "type": "date"
-                            },
-                            "device": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "directory": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "drive_letter": {
-                              "ignore_above": 1,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "elf": {
                               "properties": {
-                                "architecture": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "byte_order": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "cpu_type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "creation_date": {
-                                  "type": "date"
-                                },
-                                "exports": {
-                                  "type": "flat_object"
-                                },
-                                "go_import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "go_imports": {
-                                  "type": "flat_object"
-                                },
-                                "go_imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "go_imports_names_var_entropy": {
-                                  "type": "long"
-                                },
-                                "go_stripped": {
-                                  "type": "boolean"
-                                },
                                 "header": {
-                                  "properties": {
-                                    "abi_version": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "class": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "data": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "entrypoint": {
-                                      "type": "long"
-                                    },
-                                    "object_version": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "os_abi": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "type": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "version": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  }
-                                },
-                                "import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "imports": {
-                                  "type": "flat_object"
-                                },
-                                "imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "imports_names_var_entropy": {
-                                  "type": "long"
+                                  "properties": {}
                                 },
                                 "sections": {
-                                  "properties": {
-                                    "chi2": {
-                                      "type": "long"
-                                    },
-                                    "entropy": {
-                                      "type": "long"
-                                    },
-                                    "flags": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "physical_offset": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "physical_size": {
-                                      "type": "long"
-                                    },
-                                    "type": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "var_entropy": {
-                                      "type": "long"
-                                    },
-                                    "virtual_address": {
-                                      "type": "long"
-                                    },
-                                    "virtual_size": {
-                                      "type": "long"
-                                    }
-                                  },
-                                  "type": "nested"
+                                  "properties": {}
                                 },
                                 "segments": {
-                                  "properties": {
-                                    "sections": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "type": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "nested"
-                                },
-                                "shared_libraries": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "telfhash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
+                                  "properties": {}
                                 }
                               }
-                            },
-                            "extension": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "fork_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "gid": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "group": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
                             },
                             "hash": {
-                              "properties": {
-                                "cdhash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "md5": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha1": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha256": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha384": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha512": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "ssdeep": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "tlsh": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "inode": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "mime_type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "mode": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "mtime": {
-                              "type": "date"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "origin_referrer_url": {
-                              "ignore_above": 8192,
-                              "type": "keyword"
-                            },
-                            "origin_url": {
-                              "ignore_above": 8192,
-                              "type": "keyword"
-                            },
-                            "owner": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "path": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "pe": {
                               "properties": {
-                                "architecture": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "company": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "description": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "file_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "go_import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "go_imports": {
-                                  "type": "flat_object"
-                                },
-                                "go_imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "go_imports_names_var_entropy": {
-                                  "type": "long"
-                                },
-                                "go_stripped": {
-                                  "type": "boolean"
-                                },
-                                "imphash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "imports": {
-                                  "type": "flat_object"
-                                },
-                                "imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "imports_names_var_entropy": {
-                                  "type": "long"
-                                },
-                                "original_file_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "pehash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "product": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
                                 "sections": {
-                                  "properties": {
-                                    "entropy": {
-                                      "type": "long"
-                                    },
-                                    "name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "physical_size": {
-                                      "type": "long"
-                                    },
-                                    "var_entropy": {
-                                      "type": "long"
-                                    },
-                                    "virtual_size": {
-                                      "type": "long"
-                                    }
-                                  },
-                                  "type": "nested"
+                                  "properties": {}
                                 }
                               }
-                            },
-                            "size": {
-                              "type": "long"
-                            },
-                            "target_path": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "uid": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
                             },
                             "x509": {
                               "properties": {
-                                "alternative_names": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
                                 "issuer": {
-                                  "properties": {
-                                    "common_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "country": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "distinguished_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "locality": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organization": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organizational_unit": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "state_or_province": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  }
-                                },
-                                "not_after": {
-                                  "type": "date"
-                                },
-                                "not_before": {
-                                  "type": "date"
-                                },
-                                "public_key_algorithm": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "public_key_curve": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "public_key_exponent": {
-                                  "doc_values": false,
-                                  "index": false,
-                                  "type": "long"
-                                },
-                                "public_key_size": {
-                                  "type": "long"
-                                },
-                                "serial_number": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "signature_algorithm": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
+                                  "properties": {}
                                 },
                                 "subject": {
-                                  "properties": {
-                                    "common_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "country": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "distinguished_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "locality": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organization": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organizational_unit": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "state_or_province": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  }
-                                },
-                                "version_number": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
+                                  "properties": {}
                                 }
                               }
                             }
                           }
                         },
-                        "first_seen": {
-                          "type": "date"
-                        },
                         "geo": {
-                          "properties": {
-                            "city_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "continent_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "continent_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country_iso_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "location": {
-                              "type": "geo_point"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "postal_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "region_iso_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "region_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "timezone": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "ip": {
-                          "type": "ip"
-                        },
-                        "last_seen": {
-                          "type": "date"
+                          "properties": {}
                         },
                         "marking": {
-                          "properties": {
-                            "tlp": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "tlp_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "modified_at": {
-                          "type": "date"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "port": {
-                          "type": "long"
-                        },
-                        "provider": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "reference": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "registry": {
                           "properties": {
                             "data": {
-                              "properties": {
-                                "bytes": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "strings": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "hive": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "key": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "path": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "value": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         },
-                        "scanner_stats": {
-                          "type": "long"
-                        },
-                        "sightings": {
-                          "type": "long"
-                        },
                         "software": {
-                          "properties": {
-                            "alias": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "tags": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "x509": {
                           "properties": {
-                            "alternative_names": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "issuer": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "not_after": {
-                              "type": "date"
-                            },
-                            "not_before": {
-                              "type": "date"
-                            },
-                            "public_key_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_curve": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_exponent": {
-                              "doc_values": false,
-                              "index": false,
-                              "type": "long"
-                            },
-                            "public_key_size": {
-                              "type": "long"
-                            },
-                            "serial_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signature_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "subject": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "version_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         }
-                      },
-                      "type": "object"
+                      }
                     },
                     "matched": {
-                      "properties": {
-                        "atomic": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "field": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "index": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "occurred": {
-                          "type": "date"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     }
-                  },
-                  "type": "object"
+                  }
                 },
                 "feed": {
-                  "properties": {
-                    "dashboard_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "framework": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "group": {
-                  "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "indicator": {
                   "properties": {
                     "as": {
                       "properties": {
-                        "number": {
-                          "type": "long"
-                        },
                         "organization": {
-                          "properties": {
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
-                    },
-                    "confidence": {
-                      "type": "short"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "email": {
-                      "properties": {
-                        "address": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "file": {
                       "properties": {
-                        "accessed": {
-                          "type": "date"
-                        },
-                        "attributes": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "code_signature": {
-                          "properties": {
-                            "digest_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "exists": {
-                              "type": "boolean"
-                            },
-                            "flags": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signing_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "status": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "subject_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "team_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "thumbprint_sha256": {
-                              "ignore_above": 64,
-                              "type": "keyword"
-                            },
-                            "timestamp": {
-                              "type": "date"
-                            },
-                            "trusted": {
-                              "type": "boolean"
-                            },
-                            "valid": {
-                              "type": "boolean"
-                            }
-                          }
-                        },
-                        "created": {
-                          "type": "date"
-                        },
-                        "ctime": {
-                          "type": "date"
-                        },
-                        "device": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "directory": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "drive_letter": {
-                          "ignore_above": 1,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "elf": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "byte_order": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "cpu_type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "creation_date": {
-                              "type": "date"
-                            },
-                            "exports": {
-                              "type": "flat_object"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
                             "header": {
-                              "properties": {
-                                "abi_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "class": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "data": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "entrypoint": {
-                                  "type": "long"
-                                },
-                                "object_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "os_abi": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
+                              "properties": {}
                             },
                             "sections": {
-                              "properties": {
-                                "chi2": {
-                                  "type": "long"
-                                },
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "flags": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_offset": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_address": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             },
                             "segments": {
-                              "properties": {
-                                "sections": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "nested"
-                            },
-                            "shared_libraries": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "telfhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
-                        },
-                        "extension": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "fork_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "gid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "group": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "hash": {
-                          "properties": {
-                            "cdhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "md5": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha1": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha256": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha384": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha512": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "ssdeep": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "tlsh": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "inode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mime_type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mtime": {
-                          "type": "date"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "origin_referrer_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "origin_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "owner": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "pe": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "company": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "description": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "file_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
-                            "imphash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "original_file_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "pehash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "product": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "sections": {
-                              "properties": {
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             }
                           }
-                        },
-                        "size": {
-                          "type": "long"
-                        },
-                        "target_path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "uid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "x509": {
                           "properties": {
-                            "alternative_names": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "issuer": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "not_after": {
-                              "type": "date"
-                            },
-                            "not_before": {
-                              "type": "date"
-                            },
-                            "public_key_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_curve": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_exponent": {
-                              "doc_values": false,
-                              "index": false,
-                              "type": "long"
-                            },
-                            "public_key_size": {
-                              "type": "long"
-                            },
-                            "serial_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signature_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "subject": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "version_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         }
                       }
                     },
-                    "first_seen": {
-                      "type": "date"
-                    },
                     "geo": {
-                      "properties": {
-                        "city_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "location": {
-                          "type": "geo_point"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "postal_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "timezone": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ip": {
-                      "type": "ip"
-                    },
-                    "last_seen": {
-                      "type": "date"
+                      "properties": {}
                     },
                     "marking": {
-                      "properties": {
-                        "tlp": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlp_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "modified_at": {
-                      "type": "date"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "port": {
-                      "type": "long"
-                    },
-                    "provider": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "registry": {
                       "properties": {
                         "data": {
-                          "properties": {
-                            "bytes": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "strings": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "hive": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "key": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "value": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     },
-                    "scanner_stats": {
-                      "type": "long"
-                    },
-                    "sightings": {
-                      "type": "long"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "x509": {
                       "properties": {
-                        "alternative_names": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "issuer": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "not_after": {
-                          "type": "date"
-                        },
-                        "not_before": {
-                          "type": "date"
-                        },
-                        "public_key_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_curve": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_exponent": {
-                          "doc_values": false,
-                          "index": false,
-                          "type": "long"
-                        },
-                        "public_key_size": {
-                          "type": "long"
-                        },
-                        "serial_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signature_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "subject": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "version_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     }
                   }
                 },
                 "software": {
-                  "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "platforms": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tactic": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "technique": {
                   "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "subtechnique": {
-                      "properties": {
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "reference": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     }
                   }
                 }
               }
             }
           }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "message": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
         }
       }
     }

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -25,13 +25,13 @@
         "refresh_interval": "2s"
       },
       "mapping.nested_fields.limit": 50,
-      "mapping.total_fields.limit": 3000,
+      "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-findings-policy",
       "plugins.index_state_management.rollover_alias": "wazuh-findings-v5"
     },
     "mappings": {
       "date_detection": false,
-      "dynamic": "strict",
+      "dynamic": "strict_allow_templates",
       "dynamic_templates": [
         {
           "wcs_agent_build_original": {

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -32,332 +32,20568 @@
     "mappings": {
       "date_detection": false,
       "dynamic": "strict",
-      "properties": {
-        "@timestamp": {
-          "type": "date"
+      "dynamic_templates": [
+        {
+          "wcs_agent_build_original": {
+            "path_match": "agent.build.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
         },
+        {
+          "wcs_agent_ephemeral_id": {
+            "path_match": "agent.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_groups": {
+            "path_match": "agent.groups",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_id": {
+            "path_match": "agent.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_name": {
+            "path_match": "agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_type": {
+            "path_match": "agent.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_agent_version": {
+            "path_match": "agent.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_cmmc": {
+            "path_match": "check.compliance.cmmc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_fedramp": {
+            "path_match": "check.compliance.fedramp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_gdpr": {
+            "path_match": "check.compliance.gdpr",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_hipaa": {
+            "path_match": "check.compliance.hipaa",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_iso_27001": {
+            "path_match": "check.compliance.iso_27001",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_nis2": {
+            "path_match": "check.compliance.nis2",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_nist_800_171": {
+            "path_match": "check.compliance.nist_800_171",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_nist_800_53": {
+            "path_match": "check.compliance.nist_800_53",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_pci_dss": {
+            "path_match": "check.compliance.pci_dss",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_compliance_tsc": {
+            "path_match": "check.compliance.tsc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_condition": {
+            "path_match": "check.condition",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_description": {
+            "path_match": "check.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_id": {
+            "path_match": "check.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_subtechnique_id": {
+            "path_match": "check.mitre.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_subtechnique_name": {
+            "path_match": "check.mitre.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_tactic_id": {
+            "path_match": "check.mitre.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_tactic_name": {
+            "path_match": "check.mitre.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_technique_id": {
+            "path_match": "check.mitre.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_mitre_technique_name": {
+            "path_match": "check.mitre.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_name": {
+            "path_match": "check.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_rationale": {
+            "path_match": "check.rationale",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_reason": {
+            "path_match": "check.reason",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_references": {
+            "path_match": "check.references",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_remediation": {
+            "path_match": "check.remediation",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_result": {
+            "path_match": "check.result",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_check_rules": {
+            "path_match": "check.rules",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_address": {
+            "path_match": "client.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_as_number": {
+            "path_match": "client.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_as_organization_name": {
+            "path_match": "client.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_bytes": {
+            "path_match": "client.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_domain": {
+            "path_match": "client.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_city_name": {
+            "path_match": "client.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_continent_code": {
+            "path_match": "client.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_continent_name": {
+            "path_match": "client.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_country_iso_code": {
+            "path_match": "client.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_country_name": {
+            "path_match": "client.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_location": {
+            "path_match": "client.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_name": {
+            "path_match": "client.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_postal_code": {
+            "path_match": "client.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_region_iso_code": {
+            "path_match": "client.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_region_name": {
+            "path_match": "client.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_geo_timezone": {
+            "path_match": "client.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_ip": {
+            "path_match": "client.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_client_mac": {
+            "path_match": "client.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_nat_ip": {
+            "path_match": "client.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_client_nat_port": {
+            "path_match": "client.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_packets": {
+            "path_match": "client.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_port": {
+            "path_match": "client.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_client_registered_domain": {
+            "path_match": "client.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_subdomain": {
+            "path_match": "client.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_top_level_domain": {
+            "path_match": "client.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_domain": {
+            "path_match": "client.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_email": {
+            "path_match": "client.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_full_name": {
+            "path_match": "client.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_group_domain": {
+            "path_match": "client.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_group_id": {
+            "path_match": "client.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_group_name": {
+            "path_match": "client.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_hash": {
+            "path_match": "client.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_id": {
+            "path_match": "client.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_name": {
+            "path_match": "client.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_client_user_roles": {
+            "path_match": "client.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_account_id": {
+            "path_match": "cloud.account.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_account_name": {
+            "path_match": "cloud.account.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_availability_zone": {
+            "path_match": "cloud.availability_zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_instance_id": {
+            "path_match": "cloud.instance.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_instance_name": {
+            "path_match": "cloud.instance.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_machine_type": {
+            "path_match": "cloud.machine.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_account_id": {
+            "path_match": "cloud.origin.account.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_account_name": {
+            "path_match": "cloud.origin.account.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_availability_zone": {
+            "path_match": "cloud.origin.availability_zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_instance_id": {
+            "path_match": "cloud.origin.instance.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_instance_name": {
+            "path_match": "cloud.origin.instance.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_machine_type": {
+            "path_match": "cloud.origin.machine.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_project_id": {
+            "path_match": "cloud.origin.project.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_project_name": {
+            "path_match": "cloud.origin.project.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_provider": {
+            "path_match": "cloud.origin.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_region": {
+            "path_match": "cloud.origin.region",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_origin_service_name": {
+            "path_match": "cloud.origin.service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_project_id": {
+            "path_match": "cloud.project.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_project_name": {
+            "path_match": "cloud.project.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_provider": {
+            "path_match": "cloud.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_region": {
+            "path_match": "cloud.region",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_service_name": {
+            "path_match": "cloud.service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_account_id": {
+            "path_match": "cloud.target.account.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_account_name": {
+            "path_match": "cloud.target.account.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_availability_zone": {
+            "path_match": "cloud.target.availability_zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_instance_id": {
+            "path_match": "cloud.target.instance.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_instance_name": {
+            "path_match": "cloud.target.instance.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_machine_type": {
+            "path_match": "cloud.target.machine.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_project_id": {
+            "path_match": "cloud.target.project.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_project_name": {
+            "path_match": "cloud.target.project.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_provider": {
+            "path_match": "cloud.target.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_region": {
+            "path_match": "cloud.target.region",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_cloud_target_service_name": {
+            "path_match": "cloud.target.service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_cmmc": {
+            "path_match": "compliance.cmmc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_fedramp": {
+            "path_match": "compliance.fedramp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_gdpr": {
+            "path_match": "compliance.gdpr",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_hipaa": {
+            "path_match": "compliance.hipaa",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_iso_27001": {
+            "path_match": "compliance.iso_27001",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_nis2": {
+            "path_match": "compliance.nis2",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_nist_800_171": {
+            "path_match": "compliance.nist_800_171",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_nist_800_53": {
+            "path_match": "compliance.nist_800_53",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_pci_dss": {
+            "path_match": "compliance.pci_dss",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_compliance_tsc": {
+            "path_match": "compliance.tsc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_cpu_usage": {
+            "path_match": "container.cpu.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_container_disk_read_bytes": {
+            "path_match": "container.disk.read.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_disk_write_bytes": {
+            "path_match": "container.disk.write.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_id": {
+            "path_match": "container.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_image_hash_all": {
+            "path_match": "container.image.hash.all",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_image_name": {
+            "path_match": "container.image.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_image_tag": {
+            "path_match": "container.image.tag",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_labels": {
+            "path_match": "container.labels",
+            "mapping": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "wcs_container_memory_usage": {
+            "path_match": "container.memory.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_container_name": {
+            "path_match": "container.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_network_egress_bytes": {
+            "path_match": "container.network.egress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_network_ingress_bytes": {
+            "path_match": "container.network.ingress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_container_runtime": {
+            "path_match": "container.runtime",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_container_security_context_privileged": {
+            "path_match": "container.security_context.privileged",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_data_stream_dataset": {
+            "path_match": "data_stream.dataset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_data_stream_namespace": {
+            "path_match": "data_stream.namespace",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_data_stream_type": {
+            "path_match": "data_stream.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_address": {
+            "path_match": "destination.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_as_number": {
+            "path_match": "destination.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_as_organization_name": {
+            "path_match": "destination.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_bytes": {
+            "path_match": "destination.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_domain": {
+            "path_match": "destination.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_city_name": {
+            "path_match": "destination.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_continent_code": {
+            "path_match": "destination.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_continent_name": {
+            "path_match": "destination.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_country_iso_code": {
+            "path_match": "destination.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_country_name": {
+            "path_match": "destination.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_location": {
+            "path_match": "destination.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_name": {
+            "path_match": "destination.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_postal_code": {
+            "path_match": "destination.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_region_iso_code": {
+            "path_match": "destination.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_region_name": {
+            "path_match": "destination.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_geo_timezone": {
+            "path_match": "destination.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_ip": {
+            "path_match": "destination.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_destination_mac": {
+            "path_match": "destination.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_nat_ip": {
+            "path_match": "destination.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_destination_nat_port": {
+            "path_match": "destination.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_packets": {
+            "path_match": "destination.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_port": {
+            "path_match": "destination.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_destination_registered_domain": {
+            "path_match": "destination.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_subdomain": {
+            "path_match": "destination.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_top_level_domain": {
+            "path_match": "destination.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_domain": {
+            "path_match": "destination.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_email": {
+            "path_match": "destination.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_full_name": {
+            "path_match": "destination.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_group_domain": {
+            "path_match": "destination.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_group_id": {
+            "path_match": "destination.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_group_name": {
+            "path_match": "destination.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_hash": {
+            "path_match": "destination.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_id": {
+            "path_match": "destination.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_name": {
+            "path_match": "destination.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_destination_user_roles": {
+            "path_match": "destination.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_id": {
+            "path_match": "device.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_manufacturer": {
+            "path_match": "device.manufacturer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_model_identifier": {
+            "path_match": "device.model.identifier",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_model_name": {
+            "path_match": "device.model.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_device_serial_number": {
+            "path_match": "device.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_digest_algorithm": {
+            "path_match": "dll.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_exists": {
+            "path_match": "dll.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_flags": {
+            "path_match": "dll.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_signing_id": {
+            "path_match": "dll.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_status": {
+            "path_match": "dll.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_subject_name": {
+            "path_match": "dll.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_team_id": {
+            "path_match": "dll.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_thumbprint_sha256": {
+            "path_match": "dll.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_timestamp": {
+            "path_match": "dll.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_trusted": {
+            "path_match": "dll.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_code_signature_valid": {
+            "path_match": "dll.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_cdhash": {
+            "path_match": "dll.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_md5": {
+            "path_match": "dll.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha1": {
+            "path_match": "dll.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha256": {
+            "path_match": "dll.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha384": {
+            "path_match": "dll.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_sha512": {
+            "path_match": "dll.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_ssdeep": {
+            "path_match": "dll.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_hash_tlsh": {
+            "path_match": "dll.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_name": {
+            "path_match": "dll.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_origin_referrer_url": {
+            "path_match": "dll.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_origin_url": {
+            "path_match": "dll.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_path": {
+            "path_match": "dll.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_architecture": {
+            "path_match": "dll.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_company": {
+            "path_match": "dll.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_description": {
+            "path_match": "dll.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_file_version": {
+            "path_match": "dll.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_import_hash": {
+            "path_match": "dll.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_imports": {
+            "path_match": "dll.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_imports_names_entropy": {
+            "path_match": "dll.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_imports_names_var_entropy": {
+            "path_match": "dll.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_go_stripped": {
+            "path_match": "dll.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imphash": {
+            "path_match": "dll.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_import_hash": {
+            "path_match": "dll.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imports": {
+            "path_match": "dll.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imports_names_entropy": {
+            "path_match": "dll.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_imports_names_var_entropy": {
+            "path_match": "dll.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_original_file_name": {
+            "path_match": "dll.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_pehash": {
+            "path_match": "dll.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_product": {
+            "path_match": "dll.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_entropy": {
+            "path_match": "dll.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_name": {
+            "path_match": "dll.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_physical_size": {
+            "path_match": "dll.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_var_entropy": {
+            "path_match": "dll.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dll_pe_sections_virtual_size": {
+            "path_match": "dll.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_class": {
+            "path_match": "dns.answers.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_data": {
+            "path_match": "dns.answers.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_name": {
+            "path_match": "dns.answers.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_ttl": {
+            "path_match": "dns.answers.ttl",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_dns_answers_type": {
+            "path_match": "dns.answers.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_header_flags": {
+            "path_match": "dns.header_flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_id": {
+            "path_match": "dns.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_op_code": {
+            "path_match": "dns.op_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_class": {
+            "path_match": "dns.question.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_name": {
+            "path_match": "dns.question.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_registered_domain": {
+            "path_match": "dns.question.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_subdomain": {
+            "path_match": "dns.question.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_top_level_domain": {
+            "path_match": "dns.question.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_question_type": {
+            "path_match": "dns.question.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_resolved_ip": {
+            "path_match": "dns.resolved_ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_dns_response_code": {
+            "path_match": "dns.response_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_dns_type": {
+            "path_match": "dns.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_extension": {
+            "path_match": "email.attachments.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_cdhash": {
+            "path_match": "email.attachments.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_md5": {
+            "path_match": "email.attachments.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha1": {
+            "path_match": "email.attachments.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha256": {
+            "path_match": "email.attachments.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha384": {
+            "path_match": "email.attachments.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_sha512": {
+            "path_match": "email.attachments.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_ssdeep": {
+            "path_match": "email.attachments.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_hash_tlsh": {
+            "path_match": "email.attachments.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_mime_type": {
+            "path_match": "email.attachments.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_name": {
+            "path_match": "email.attachments.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_attachments_file_size": {
+            "path_match": "email.attachments.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_email_bcc_address": {
+            "path_match": "email.bcc.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_cc_address": {
+            "path_match": "email.cc.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_content_type": {
+            "path_match": "email.content_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_delivery_timestamp": {
+            "path_match": "email.delivery_timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_email_direction": {
+            "path_match": "email.direction",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_from_address": {
+            "path_match": "email.from.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_local_id": {
+            "path_match": "email.local_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_message_id": {
+            "path_match": "email.message_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_origination_timestamp": {
+            "path_match": "email.origination_timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_email_reply_to_address": {
+            "path_match": "email.reply_to.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_sender_address": {
+            "path_match": "email.sender.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_subject": {
+            "path_match": "email.subject",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_to_address": {
+            "path_match": "email.to.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_email_x_mailer": {
+            "path_match": "email.x_mailer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_code": {
+            "path_match": "error.code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_id": {
+            "path_match": "error.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_message": {
+            "path_match": "error.message",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_stack_trace": {
+            "path_match": "error.stack_trace",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_error_type": {
+            "path_match": "error.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_action": {
+            "path_match": "event.action",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_agent_id_status": {
+            "path_match": "event.agent_id_status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_category": {
+            "path_match": "event.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_changed_fields": {
+            "path_match": "event.changed_fields",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_code": {
+            "path_match": "event.code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_collector": {
+            "path_match": "event.collector",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_created": {
+            "path_match": "event.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_event_dataset": {
+            "path_match": "event.dataset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_doc_id": {
+            "path_match": "event.doc_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_duration": {
+            "path_match": "event.duration",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_event_end": {
+            "path_match": "event.end",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_event_hash": {
+            "path_match": "event.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_id": {
+            "path_match": "event.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_index": {
+            "path_match": "event.index",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_kind": {
+            "path_match": "event.kind",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_module": {
+            "path_match": "event.module",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_original": {
+            "path_match": "event.original",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_outcome": {
+            "path_match": "event.outcome",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_provider": {
+            "path_match": "event.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_reason": {
+            "path_match": "event.reason",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_reference": {
+            "path_match": "event.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_risk_score": {
+            "path_match": "event.risk_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_event_risk_score_norm": {
+            "path_match": "event.risk_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_event_sequence": {
+            "path_match": "event.sequence",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_event_severity": {
+            "path_match": "event.severity",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_event_start": {
+            "path_match": "event.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_event_timezone": {
+            "path_match": "event.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_type": {
+            "path_match": "event.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_event_url": {
+            "path_match": "event.url",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_coldstart": {
+            "path_match": "faas.coldstart",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_faas_execution": {
+            "path_match": "faas.execution",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_id": {
+            "path_match": "faas.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_name": {
+            "path_match": "faas.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_trigger_request_id": {
+            "path_match": "faas.trigger.request_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_trigger_type": {
+            "path_match": "faas.trigger.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_faas_version": {
+            "path_match": "faas.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_accessed": {
+            "path_match": "file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_attributes": {
+            "path_match": "file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_digest_algorithm": {
+            "path_match": "file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_exists": {
+            "path_match": "file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_flags": {
+            "path_match": "file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_signing_id": {
+            "path_match": "file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_status": {
+            "path_match": "file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_subject_name": {
+            "path_match": "file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_team_id": {
+            "path_match": "file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_thumbprint_sha256": {
+            "path_match": "file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_timestamp": {
+            "path_match": "file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_trusted": {
+            "path_match": "file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_code_signature_valid": {
+            "path_match": "file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_created": {
+            "path_match": "file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_ctime": {
+            "path_match": "file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_device": {
+            "path_match": "file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_diff": {
+            "path_match": "file.diff",
+            "mapping": {
+              "type": "match_only_text"
+            }
+          }
+        },
+        {
+          "wcs_file_directory": {
+            "path_match": "file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_drive_letter": {
+            "path_match": "file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_architecture": {
+            "path_match": "file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_byte_order": {
+            "path_match": "file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_cpu_type": {
+            "path_match": "file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_creation_date": {
+            "path_match": "file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_exports": {
+            "path_match": "file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_import_hash": {
+            "path_match": "file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_imports": {
+            "path_match": "file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_imports_names_entropy": {
+            "path_match": "file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_imports_names_var_entropy": {
+            "path_match": "file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_go_stripped": {
+            "path_match": "file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_abi_version": {
+            "path_match": "file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_class": {
+            "path_match": "file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_data": {
+            "path_match": "file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_entrypoint": {
+            "path_match": "file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_object_version": {
+            "path_match": "file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_os_abi": {
+            "path_match": "file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_type": {
+            "path_match": "file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_header_version": {
+            "path_match": "file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_import_hash": {
+            "path_match": "file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_imports": {
+            "path_match": "file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_imports_names_entropy": {
+            "path_match": "file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_imports_names_var_entropy": {
+            "path_match": "file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_chi2": {
+            "path_match": "file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_entropy": {
+            "path_match": "file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_flags": {
+            "path_match": "file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_name": {
+            "path_match": "file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_physical_offset": {
+            "path_match": "file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_physical_size": {
+            "path_match": "file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_type": {
+            "path_match": "file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_var_entropy": {
+            "path_match": "file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_virtual_address": {
+            "path_match": "file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_sections_virtual_size": {
+            "path_match": "file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_segments_sections": {
+            "path_match": "file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_segments_type": {
+            "path_match": "file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_shared_libraries": {
+            "path_match": "file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_elf_telfhash": {
+            "path_match": "file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_extension": {
+            "path_match": "file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_fork_name": {
+            "path_match": "file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_gid": {
+            "path_match": "file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_group": {
+            "path_match": "file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_cdhash": {
+            "path_match": "file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_md5": {
+            "path_match": "file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha1": {
+            "path_match": "file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha256": {
+            "path_match": "file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha384": {
+            "path_match": "file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_sha512": {
+            "path_match": "file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_ssdeep": {
+            "path_match": "file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_hash_tlsh": {
+            "path_match": "file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_inode": {
+            "path_match": "file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_import_hash": {
+            "path_match": "file.macho.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_imports": {
+            "path_match": "file.macho.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_imports_names_entropy": {
+            "path_match": "file.macho.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_imports_names_var_entropy": {
+            "path_match": "file.macho.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_go_stripped": {
+            "path_match": "file.macho.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_import_hash": {
+            "path_match": "file.macho.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_imports": {
+            "path_match": "file.macho.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_imports_names_entropy": {
+            "path_match": "file.macho.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_imports_names_var_entropy": {
+            "path_match": "file.macho.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_entropy": {
+            "path_match": "file.macho.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_name": {
+            "path_match": "file.macho.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_physical_size": {
+            "path_match": "file.macho.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_var_entropy": {
+            "path_match": "file.macho.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_sections_virtual_size": {
+            "path_match": "file.macho.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_macho_symhash": {
+            "path_match": "file.macho.symhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_mime_type": {
+            "path_match": "file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_mode": {
+            "path_match": "file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_mtime": {
+            "path_match": "file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_name": {
+            "path_match": "file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_origin_referrer_url": {
+            "path_match": "file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_origin_url": {
+            "path_match": "file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_owner": {
+            "path_match": "file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_path": {
+            "path_match": "file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_architecture": {
+            "path_match": "file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_company": {
+            "path_match": "file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_description": {
+            "path_match": "file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_file_version": {
+            "path_match": "file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_import_hash": {
+            "path_match": "file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_imports": {
+            "path_match": "file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_imports_names_entropy": {
+            "path_match": "file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_imports_names_var_entropy": {
+            "path_match": "file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_go_stripped": {
+            "path_match": "file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imphash": {
+            "path_match": "file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_import_hash": {
+            "path_match": "file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imports": {
+            "path_match": "file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imports_names_entropy": {
+            "path_match": "file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_imports_names_var_entropy": {
+            "path_match": "file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_original_file_name": {
+            "path_match": "file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_pehash": {
+            "path_match": "file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_product": {
+            "path_match": "file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_entropy": {
+            "path_match": "file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_name": {
+            "path_match": "file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_physical_size": {
+            "path_match": "file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_var_entropy": {
+            "path_match": "file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_pe_sections_virtual_size": {
+            "path_match": "file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_size": {
+            "path_match": "file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_target_path": {
+            "path_match": "file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_type": {
+            "path_match": "file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_uid": {
+            "path_match": "file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_alternative_names": {
+            "path_match": "file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_common_name": {
+            "path_match": "file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_country": {
+            "path_match": "file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_distinguished_name": {
+            "path_match": "file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_locality": {
+            "path_match": "file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_organization": {
+            "path_match": "file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_organizational_unit": {
+            "path_match": "file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_issuer_state_or_province": {
+            "path_match": "file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_not_after": {
+            "path_match": "file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_not_before": {
+            "path_match": "file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_algorithm": {
+            "path_match": "file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_curve": {
+            "path_match": "file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_exponent": {
+            "path_match": "file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_public_key_size": {
+            "path_match": "file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_serial_number": {
+            "path_match": "file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_signature_algorithm": {
+            "path_match": "file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_common_name": {
+            "path_match": "file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_country": {
+            "path_match": "file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_distinguished_name": {
+            "path_match": "file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_locality": {
+            "path_match": "file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_organization": {
+            "path_match": "file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_organizational_unit": {
+            "path_match": "file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_subject_state_or_province": {
+            "path_match": "file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_file_x509_version_number": {
+            "path_match": "file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_agent_description": {
+            "path_match": "gen_ai.agent.description",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_agent_id": {
+            "path_match": "gen_ai.agent.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_agent_name": {
+            "path_match": "gen_ai.agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_operation_name": {
+            "path_match": "gen_ai.operation.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_output_type": {
+            "path_match": "gen_ai.output.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_choice_count": {
+            "path_match": "gen_ai.request.choice.count",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_encoding_formats": {
+            "path_match": "gen_ai.request.encoding_formats",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_frequency_penalty": {
+            "path_match": "gen_ai.request.frequency_penalty",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_max_tokens": {
+            "path_match": "gen_ai.request.max_tokens",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_model": {
+            "path_match": "gen_ai.request.model",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_presence_penalty": {
+            "path_match": "gen_ai.request.presence_penalty",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_seed": {
+            "path_match": "gen_ai.request.seed",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_stop_sequences": {
+            "path_match": "gen_ai.request.stop_sequences",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_temperature": {
+            "path_match": "gen_ai.request.temperature",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_top_k": {
+            "path_match": "gen_ai.request.top_k",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_request_top_p": {
+            "path_match": "gen_ai.request.top_p",
+            "mapping": {
+              "type": "double"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_response_finish_reasons": {
+            "path_match": "gen_ai.response.finish_reasons",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_response_id": {
+            "path_match": "gen_ai.response.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_response_model": {
+            "path_match": "gen_ai.response.model",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_system": {
+            "path_match": "gen_ai.system",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_token_type": {
+            "path_match": "gen_ai.token.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_tool_call_id": {
+            "path_match": "gen_ai.tool.call.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_tool_name": {
+            "path_match": "gen_ai.tool.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_tool_type": {
+            "path_match": "gen_ai.tool.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_usage_input_tokens": {
+            "path_match": "gen_ai.usage.input_tokens",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_gen_ai_usage_output_tokens": {
+            "path_match": "gen_ai.usage.output_tokens",
+            "mapping": {
+              "type": "integer"
+            }
+          }
+        },
+        {
+          "wcs_group_domain": {
+            "path_match": "group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_group_id": {
+            "path_match": "group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_group_name": {
+            "path_match": "group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_architecture": {
+            "path_match": "host.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_boot_id": {
+            "path_match": "host.boot.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_cores": {
+            "path_match": "host.cpu.cores",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_name": {
+            "path_match": "host.cpu.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_speed": {
+            "path_match": "host.cpu.speed",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_cpu_usage": {
+            "path_match": "host.cpu.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_host_disk_read_bytes": {
+            "path_match": "host.disk.read.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_disk_write_bytes": {
+            "path_match": "host.disk.write.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_domain": {
+            "path_match": "host.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_city_name": {
+            "path_match": "host.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_continent_code": {
+            "path_match": "host.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_continent_name": {
+            "path_match": "host.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_country_iso_code": {
+            "path_match": "host.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_country_name": {
+            "path_match": "host.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_location": {
+            "path_match": "host.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_name": {
+            "path_match": "host.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_postal_code": {
+            "path_match": "host.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_region_iso_code": {
+            "path_match": "host.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_region_name": {
+            "path_match": "host.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_geo_timezone": {
+            "path_match": "host.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_hostname": {
+            "path_match": "host.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_id": {
+            "path_match": "host.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_ip": {
+            "path_match": "host.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_host_mac": {
+            "path_match": "host.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_memory_free": {
+            "path_match": "host.memory.free",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_memory_total": {
+            "path_match": "host.memory.total",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_memory_used_percentage": {
+            "path_match": "host.memory.used.percentage",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_name": {
+            "path_match": "host.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_bytes": {
+            "path_match": "host.network.egress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_drops": {
+            "path_match": "host.network.egress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_errors": {
+            "path_match": "host.network.egress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_packets": {
+            "path_match": "host.network.egress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_egress_queue": {
+            "path_match": "host.network.egress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_bytes": {
+            "path_match": "host.network.ingress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_drops": {
+            "path_match": "host.network.ingress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_errors": {
+            "path_match": "host.network.ingress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_packets": {
+            "path_match": "host.network.ingress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_network_ingress_queue": {
+            "path_match": "host.network.ingress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_host_os_family": {
+            "path_match": "host.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_full": {
+            "path_match": "host.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_kernel": {
+            "path_match": "host.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_name": {
+            "path_match": "host.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_platform": {
+            "path_match": "host.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_type": {
+            "path_match": "host.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_os_version": {
+            "path_match": "host.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_pid_ns_ino": {
+            "path_match": "host.pid_ns_ino",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_calculated_level": {
+            "path_match": "host.risk.calculated_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_calculated_score": {
+            "path_match": "host.risk.calculated_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_calculated_score_norm": {
+            "path_match": "host.risk.calculated_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_static_level": {
+            "path_match": "host.risk.static_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_static_score": {
+            "path_match": "host.risk.static_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_risk_static_score_norm": {
+            "path_match": "host.risk.static_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_host_type": {
+            "path_match": "host.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_host_uptime": {
+            "path_match": "host.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_request_body_bytes": {
+            "path_match": "http.request.body.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_request_body_content": {
+            "path_match": "http.request.body.content",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_bytes": {
+            "path_match": "http.request.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_request_id": {
+            "path_match": "http.request.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_method": {
+            "path_match": "http.request.method",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_mime_type": {
+            "path_match": "http.request.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_request_referrer": {
+            "path_match": "http.request.referrer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_response_body_bytes": {
+            "path_match": "http.response.body.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_response_body_content": {
+            "path_match": "http.response.body.content",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_response_bytes": {
+            "path_match": "http.response.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_response_mime_type": {
+            "path_match": "http.response.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_http_response_status_code": {
+            "path_match": "http.response.status_code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_http_version": {
+            "path_match": "http.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_alias": {
+            "path_match": "interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_id": {
+            "path_match": "interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_mtu": {
+            "path_match": "interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_interface_name": {
+            "path_match": "interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_state": {
+            "path_match": "interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_interface_type": {
+            "path_match": "interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_file_path": {
+            "path_match": "log.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_level": {
+            "path_match": "log.level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_logger": {
+            "path_match": "log.logger",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_origin_file_line": {
+            "path_match": "log.origin.file.line",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_origin_file_name": {
+            "path_match": "log.origin.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_origin_function": {
+            "path_match": "log.origin.function",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_appname": {
+            "path_match": "log.syslog.appname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_facility_code": {
+            "path_match": "log.syslog.facility.code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_facility_name": {
+            "path_match": "log.syslog.facility.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_hostname": {
+            "path_match": "log.syslog.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_msgid": {
+            "path_match": "log.syslog.msgid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_priority": {
+            "path_match": "log.syslog.priority",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_procid": {
+            "path_match": "log.syslog.procid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_severity_code": {
+            "path_match": "log.syslog.severity.code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_severity_name": {
+            "path_match": "log.syslog.severity.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_structured_data": {
+            "path_match": "log.syslog.structured_data",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_log_syslog_version": {
+            "path_match": "log.syslog.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_subtechnique_id": {
+            "path_match": "mitre.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_subtechnique_name": {
+            "path_match": "mitre.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_tactic_id": {
+            "path_match": "mitre.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_tactic_name": {
+            "path_match": "mitre.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_technique_id": {
+            "path_match": "mitre.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_mitre_technique_name": {
+            "path_match": "mitre.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_application": {
+            "path_match": "network.application",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_broadcast": {
+            "path_match": "network.broadcast",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_bytes": {
+            "path_match": "network.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_network_community_id": {
+            "path_match": "network.community_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_dhcp": {
+            "path_match": "network.dhcp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_direction": {
+            "path_match": "network.direction",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_forwarded_ip": {
+            "path_match": "network.forwarded_ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_gateway": {
+            "path_match": "network.gateway",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_iana_number": {
+            "path_match": "network.iana_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_inner_vlan_id": {
+            "path_match": "network.inner.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_inner_vlan_name": {
+            "path_match": "network.inner.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_metric": {
+            "path_match": "network.metric",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_network_name": {
+            "path_match": "network.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_netmask": {
+            "path_match": "network.netmask",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_network_packets": {
+            "path_match": "network.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_network_protocol": {
+            "path_match": "network.protocol",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_transport": {
+            "path_match": "network.transport",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_type": {
+            "path_match": "network.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_vlan_id": {
+            "path_match": "network.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_network_vlan_name": {
+            "path_match": "network.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_alias": {
+            "path_match": "observer.egress.interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_id": {
+            "path_match": "observer.egress.interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_mtu": {
+            "path_match": "observer.egress.interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_name": {
+            "path_match": "observer.egress.interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_alias": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_id": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_mtu": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_name": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_state": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_observer_ingress_interface_type": {
+            "path_match": "observer.egress.interface.observer.ingress.interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_state": {
+            "path_match": "observer.egress.interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_interface_type": {
+            "path_match": "observer.egress.interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_vlan_id": {
+            "path_match": "observer.egress.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_vlan_name": {
+            "path_match": "observer.egress.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_egress_zone": {
+            "path_match": "observer.egress.zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_city_name": {
+            "path_match": "observer.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_continent_code": {
+            "path_match": "observer.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_continent_name": {
+            "path_match": "observer.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_country_iso_code": {
+            "path_match": "observer.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_country_name": {
+            "path_match": "observer.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_location": {
+            "path_match": "observer.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_name": {
+            "path_match": "observer.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_postal_code": {
+            "path_match": "observer.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_region_iso_code": {
+            "path_match": "observer.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_region_name": {
+            "path_match": "observer.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_geo_timezone": {
+            "path_match": "observer.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_hostname": {
+            "path_match": "observer.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_alias": {
+            "path_match": "observer.ingress.interface.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_id": {
+            "path_match": "observer.ingress.interface.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_mtu": {
+            "path_match": "observer.ingress.interface.mtu",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_name": {
+            "path_match": "observer.ingress.interface.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_state": {
+            "path_match": "observer.ingress.interface.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_interface_type": {
+            "path_match": "observer.ingress.interface.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_vlan_id": {
+            "path_match": "observer.ingress.vlan.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_vlan_name": {
+            "path_match": "observer.ingress.vlan.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ingress_zone": {
+            "path_match": "observer.ingress.zone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_ip": {
+            "path_match": "observer.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_observer_mac": {
+            "path_match": "observer.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_name": {
+            "path_match": "observer.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_family": {
+            "path_match": "observer.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_full": {
+            "path_match": "observer.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_kernel": {
+            "path_match": "observer.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_name": {
+            "path_match": "observer.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_platform": {
+            "path_match": "observer.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_type": {
+            "path_match": "observer.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_os_version": {
+            "path_match": "observer.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_product": {
+            "path_match": "observer.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_serial_number": {
+            "path_match": "observer.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_type": {
+            "path_match": "observer.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_vendor": {
+            "path_match": "observer.vendor",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_observer_version": {
+            "path_match": "observer.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_api_version": {
+            "path_match": "orchestrator.api_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_id": {
+            "path_match": "orchestrator.cluster.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_name": {
+            "path_match": "orchestrator.cluster.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_url": {
+            "path_match": "orchestrator.cluster.url",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_cluster_version": {
+            "path_match": "orchestrator.cluster.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_namespace": {
+            "path_match": "orchestrator.namespace",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_organization": {
+            "path_match": "orchestrator.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_annotation": {
+            "path_match": "orchestrator.resource.annotation",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_id": {
+            "path_match": "orchestrator.resource.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_ip": {
+            "path_match": "orchestrator.resource.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_label": {
+            "path_match": "orchestrator.resource.label",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_name": {
+            "path_match": "orchestrator.resource.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_parent_type": {
+            "path_match": "orchestrator.resource.parent.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_resource_type": {
+            "path_match": "orchestrator.resource.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_orchestrator_type": {
+            "path_match": "orchestrator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_organization_id": {
+            "path_match": "organization.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_organization_name": {
+            "path_match": "organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_architecture": {
+            "path_match": "package.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_build_version": {
+            "path_match": "package.build_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_checksum": {
+            "path_match": "package.checksum",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_description": {
+            "path_match": "package.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_install_scope": {
+            "path_match": "package.install_scope",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_installed": {
+            "path_match": "package.installed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_package_license": {
+            "path_match": "package.license",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_name": {
+            "path_match": "package.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_path": {
+            "path_match": "package.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_previous_installed": {
+            "path_match": "package.previous.installed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_package_reference": {
+            "path_match": "package.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_size": {
+            "path_match": "package.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_package_type": {
+            "path_match": "package.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_package_version": {
+            "path_match": "package.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_description": {
+            "path_match": "policy.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_file": {
+            "path_match": "policy.file",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_id": {
+            "path_match": "policy.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_name": {
+            "path_match": "policy.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_policy_references": {
+            "path_match": "policy.references",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_args": {
+            "path_match": "process.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_args_count": {
+            "path_match": "process.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_digest_algorithm": {
+            "path_match": "process.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_exists": {
+            "path_match": "process.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_flags": {
+            "path_match": "process.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_signing_id": {
+            "path_match": "process.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_status": {
+            "path_match": "process.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_subject_name": {
+            "path_match": "process.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_team_id": {
+            "path_match": "process.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_thumbprint_sha256": {
+            "path_match": "process.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_timestamp": {
+            "path_match": "process.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_trusted": {
+            "path_match": "process.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_code_signature_valid": {
+            "path_match": "process.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_command_line": {
+            "path_match": "process.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_architecture": {
+            "path_match": "process.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_byte_order": {
+            "path_match": "process.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_cpu_type": {
+            "path_match": "process.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_creation_date": {
+            "path_match": "process.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_exports": {
+            "path_match": "process.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_import_hash": {
+            "path_match": "process.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_imports": {
+            "path_match": "process.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_imports_names_entropy": {
+            "path_match": "process.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_imports_names_var_entropy": {
+            "path_match": "process.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_go_stripped": {
+            "path_match": "process.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_abi_version": {
+            "path_match": "process.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_class": {
+            "path_match": "process.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_data": {
+            "path_match": "process.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_entrypoint": {
+            "path_match": "process.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_object_version": {
+            "path_match": "process.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_os_abi": {
+            "path_match": "process.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_type": {
+            "path_match": "process.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_header_version": {
+            "path_match": "process.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_import_hash": {
+            "path_match": "process.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_imports": {
+            "path_match": "process.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_imports_names_entropy": {
+            "path_match": "process.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_imports_names_var_entropy": {
+            "path_match": "process.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_chi2": {
+            "path_match": "process.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_entropy": {
+            "path_match": "process.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_flags": {
+            "path_match": "process.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_name": {
+            "path_match": "process.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_physical_offset": {
+            "path_match": "process.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_physical_size": {
+            "path_match": "process.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_type": {
+            "path_match": "process.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_var_entropy": {
+            "path_match": "process.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_virtual_address": {
+            "path_match": "process.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_sections_virtual_size": {
+            "path_match": "process.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_segments_sections": {
+            "path_match": "process.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_segments_type": {
+            "path_match": "process.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_shared_libraries": {
+            "path_match": "process.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_elf_telfhash": {
+            "path_match": "process.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_end": {
+            "path_match": "process.end",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entity_id": {
+            "path_match": "process.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_args": {
+            "path_match": "process.entry_leader.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_args_count": {
+            "path_match": "process.entry_leader.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_attested_groups_name": {
+            "path_match": "process.entry_leader.attested_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_attested_user_id": {
+            "path_match": "process.entry_leader.attested_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_attested_user_name": {
+            "path_match": "process.entry_leader.attested_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_command_line": {
+            "path_match": "process.entry_leader.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_entity_id": {
+            "path_match": "process.entry_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_entry_meta_source_ip": {
+            "path_match": "process.entry_leader.entry_meta.source.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_entry_meta_type": {
+            "path_match": "process.entry_leader.entry_meta.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_executable": {
+            "path_match": "process.entry_leader.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_group_id": {
+            "path_match": "process.entry_leader.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_group_name": {
+            "path_match": "process.entry_leader.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_interactive": {
+            "path_match": "process.entry_leader.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_name": {
+            "path_match": "process.entry_leader.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_entity_id": {
+            "path_match": "process.entry_leader.parent.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_pid": {
+            "path_match": "process.entry_leader.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_entity_id": {
+            "path_match": "process.entry_leader.parent.session_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_pid": {
+            "path_match": "process.entry_leader.parent.session_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_start": {
+            "path_match": "process.entry_leader.parent.session_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_session_leader_vpid": {
+            "path_match": "process.entry_leader.parent.session_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_start": {
+            "path_match": "process.entry_leader.parent.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_parent_vpid": {
+            "path_match": "process.entry_leader.parent.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_pid": {
+            "path_match": "process.entry_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_group_id": {
+            "path_match": "process.entry_leader.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_group_name": {
+            "path_match": "process.entry_leader.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_user_id": {
+            "path_match": "process.entry_leader.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_real_user_name": {
+            "path_match": "process.entry_leader.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_same_as_process": {
+            "path_match": "process.entry_leader.same_as_process",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_group_id": {
+            "path_match": "process.entry_leader.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_group_name": {
+            "path_match": "process.entry_leader.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_user_id": {
+            "path_match": "process.entry_leader.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_saved_user_name": {
+            "path_match": "process.entry_leader.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_start": {
+            "path_match": "process.entry_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_supplemental_groups_id": {
+            "path_match": "process.entry_leader.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_supplemental_groups_name": {
+            "path_match": "process.entry_leader.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_tty_char_device_major": {
+            "path_match": "process.entry_leader.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_tty_char_device_minor": {
+            "path_match": "process.entry_leader.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_user_id": {
+            "path_match": "process.entry_leader.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_user_name": {
+            "path_match": "process.entry_leader.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_vpid": {
+            "path_match": "process.entry_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_entry_leader_working_directory": {
+            "path_match": "process.entry_leader.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_env_vars": {
+            "path_match": "process.env_vars",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_executable": {
+            "path_match": "process.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_exit_code": {
+            "path_match": "process.exit_code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_id": {
+            "path_match": "process.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_args": {
+            "path_match": "process.group_leader.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_args_count": {
+            "path_match": "process.group_leader.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_command_line": {
+            "path_match": "process.group_leader.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_entity_id": {
+            "path_match": "process.group_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_executable": {
+            "path_match": "process.group_leader.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_group_id": {
+            "path_match": "process.group_leader.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_group_name": {
+            "path_match": "process.group_leader.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_interactive": {
+            "path_match": "process.group_leader.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_name": {
+            "path_match": "process.group_leader.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_pid": {
+            "path_match": "process.group_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_group_id": {
+            "path_match": "process.group_leader.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_group_name": {
+            "path_match": "process.group_leader.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_user_id": {
+            "path_match": "process.group_leader.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_real_user_name": {
+            "path_match": "process.group_leader.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_same_as_process": {
+            "path_match": "process.group_leader.same_as_process",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_group_id": {
+            "path_match": "process.group_leader.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_group_name": {
+            "path_match": "process.group_leader.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_user_id": {
+            "path_match": "process.group_leader.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_saved_user_name": {
+            "path_match": "process.group_leader.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_start": {
+            "path_match": "process.group_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_supplemental_groups_id": {
+            "path_match": "process.group_leader.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_supplemental_groups_name": {
+            "path_match": "process.group_leader.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_tty_char_device_major": {
+            "path_match": "process.group_leader.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_tty_char_device_minor": {
+            "path_match": "process.group_leader.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_user_id": {
+            "path_match": "process.group_leader.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_user_name": {
+            "path_match": "process.group_leader.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_vpid": {
+            "path_match": "process.group_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_group_leader_working_directory": {
+            "path_match": "process.group_leader.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_group_name": {
+            "path_match": "process.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_cdhash": {
+            "path_match": "process.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_md5": {
+            "path_match": "process.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha1": {
+            "path_match": "process.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha256": {
+            "path_match": "process.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha384": {
+            "path_match": "process.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_sha512": {
+            "path_match": "process.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_ssdeep": {
+            "path_match": "process.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_hash_tlsh": {
+            "path_match": "process.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_interactive": {
+            "path_match": "process.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_io_bytes_skipped_length": {
+            "path_match": "process.io.bytes_skipped.length",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_bytes_skipped_offset": {
+            "path_match": "process.io.bytes_skipped.offset",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_max_bytes_per_process_exceeded": {
+            "path_match": "process.io.max_bytes_per_process_exceeded",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_io_text": {
+            "path_match": "process.io.text",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_io_total_bytes_captured": {
+            "path_match": "process.io.total_bytes_captured",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_total_bytes_skipped": {
+            "path_match": "process.io.total_bytes_skipped",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_io_type": {
+            "path_match": "process.io.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_import_hash": {
+            "path_match": "process.macho.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_imports": {
+            "path_match": "process.macho.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_imports_names_entropy": {
+            "path_match": "process.macho.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_imports_names_var_entropy": {
+            "path_match": "process.macho.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_go_stripped": {
+            "path_match": "process.macho.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_import_hash": {
+            "path_match": "process.macho.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_imports": {
+            "path_match": "process.macho.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_imports_names_entropy": {
+            "path_match": "process.macho.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_imports_names_var_entropy": {
+            "path_match": "process.macho.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_entropy": {
+            "path_match": "process.macho.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_name": {
+            "path_match": "process.macho.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_physical_size": {
+            "path_match": "process.macho.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_var_entropy": {
+            "path_match": "process.macho.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_sections_virtual_size": {
+            "path_match": "process.macho.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_macho_symhash": {
+            "path_match": "process.macho.symhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_name": {
+            "path_match": "process.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_args": {
+            "path_match": "process.parent.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_args_count": {
+            "path_match": "process.parent.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_digest_algorithm": {
+            "path_match": "process.parent.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_exists": {
+            "path_match": "process.parent.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_flags": {
+            "path_match": "process.parent.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_signing_id": {
+            "path_match": "process.parent.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_status": {
+            "path_match": "process.parent.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_subject_name": {
+            "path_match": "process.parent.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_team_id": {
+            "path_match": "process.parent.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_thumbprint_sha256": {
+            "path_match": "process.parent.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_timestamp": {
+            "path_match": "process.parent.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_trusted": {
+            "path_match": "process.parent.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_code_signature_valid": {
+            "path_match": "process.parent.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_command_line": {
+            "path_match": "process.parent.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_architecture": {
+            "path_match": "process.parent.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_byte_order": {
+            "path_match": "process.parent.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_cpu_type": {
+            "path_match": "process.parent.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_creation_date": {
+            "path_match": "process.parent.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_exports": {
+            "path_match": "process.parent.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_import_hash": {
+            "path_match": "process.parent.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_imports": {
+            "path_match": "process.parent.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_imports_names_entropy": {
+            "path_match": "process.parent.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_imports_names_var_entropy": {
+            "path_match": "process.parent.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_go_stripped": {
+            "path_match": "process.parent.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_abi_version": {
+            "path_match": "process.parent.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_class": {
+            "path_match": "process.parent.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_data": {
+            "path_match": "process.parent.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_entrypoint": {
+            "path_match": "process.parent.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_object_version": {
+            "path_match": "process.parent.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_os_abi": {
+            "path_match": "process.parent.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_type": {
+            "path_match": "process.parent.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_header_version": {
+            "path_match": "process.parent.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_import_hash": {
+            "path_match": "process.parent.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_imports": {
+            "path_match": "process.parent.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_imports_names_entropy": {
+            "path_match": "process.parent.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_imports_names_var_entropy": {
+            "path_match": "process.parent.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_chi2": {
+            "path_match": "process.parent.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_entropy": {
+            "path_match": "process.parent.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_flags": {
+            "path_match": "process.parent.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_name": {
+            "path_match": "process.parent.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_physical_offset": {
+            "path_match": "process.parent.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_physical_size": {
+            "path_match": "process.parent.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_type": {
+            "path_match": "process.parent.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_var_entropy": {
+            "path_match": "process.parent.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_virtual_address": {
+            "path_match": "process.parent.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_sections_virtual_size": {
+            "path_match": "process.parent.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_segments_sections": {
+            "path_match": "process.parent.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_segments_type": {
+            "path_match": "process.parent.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_shared_libraries": {
+            "path_match": "process.parent.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_elf_telfhash": {
+            "path_match": "process.parent.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_end": {
+            "path_match": "process.parent.end",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_entity_id": {
+            "path_match": "process.parent.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_executable": {
+            "path_match": "process.parent.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_exit_code": {
+            "path_match": "process.parent.exit_code",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_id": {
+            "path_match": "process.parent.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_entity_id": {
+            "path_match": "process.parent.group_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_pid": {
+            "path_match": "process.parent.group_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_start": {
+            "path_match": "process.parent.group_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_leader_vpid": {
+            "path_match": "process.parent.group_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_group_name": {
+            "path_match": "process.parent.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_cdhash": {
+            "path_match": "process.parent.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_md5": {
+            "path_match": "process.parent.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha1": {
+            "path_match": "process.parent.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha256": {
+            "path_match": "process.parent.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha384": {
+            "path_match": "process.parent.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_sha512": {
+            "path_match": "process.parent.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_ssdeep": {
+            "path_match": "process.parent.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_hash_tlsh": {
+            "path_match": "process.parent.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_interactive": {
+            "path_match": "process.parent.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_import_hash": {
+            "path_match": "process.parent.macho.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_imports": {
+            "path_match": "process.parent.macho.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_imports_names_entropy": {
+            "path_match": "process.parent.macho.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_imports_names_var_entropy": {
+            "path_match": "process.parent.macho.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_go_stripped": {
+            "path_match": "process.parent.macho.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_import_hash": {
+            "path_match": "process.parent.macho.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_imports": {
+            "path_match": "process.parent.macho.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_imports_names_entropy": {
+            "path_match": "process.parent.macho.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_imports_names_var_entropy": {
+            "path_match": "process.parent.macho.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_entropy": {
+            "path_match": "process.parent.macho.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_name": {
+            "path_match": "process.parent.macho.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_physical_size": {
+            "path_match": "process.parent.macho.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_var_entropy": {
+            "path_match": "process.parent.macho.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_sections_virtual_size": {
+            "path_match": "process.parent.macho.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_macho_symhash": {
+            "path_match": "process.parent.macho.symhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_name": {
+            "path_match": "process.parent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_architecture": {
+            "path_match": "process.parent.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_company": {
+            "path_match": "process.parent.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_description": {
+            "path_match": "process.parent.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_file_version": {
+            "path_match": "process.parent.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_import_hash": {
+            "path_match": "process.parent.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_imports": {
+            "path_match": "process.parent.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_imports_names_entropy": {
+            "path_match": "process.parent.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_imports_names_var_entropy": {
+            "path_match": "process.parent.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_go_stripped": {
+            "path_match": "process.parent.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imphash": {
+            "path_match": "process.parent.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_import_hash": {
+            "path_match": "process.parent.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imports": {
+            "path_match": "process.parent.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imports_names_entropy": {
+            "path_match": "process.parent.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_imports_names_var_entropy": {
+            "path_match": "process.parent.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_original_file_name": {
+            "path_match": "process.parent.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_pehash": {
+            "path_match": "process.parent.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_product": {
+            "path_match": "process.parent.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_entropy": {
+            "path_match": "process.parent.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_name": {
+            "path_match": "process.parent.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_physical_size": {
+            "path_match": "process.parent.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_var_entropy": {
+            "path_match": "process.parent.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pe_sections_virtual_size": {
+            "path_match": "process.parent.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_pid": {
+            "path_match": "process.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_group_id": {
+            "path_match": "process.parent.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_group_name": {
+            "path_match": "process.parent.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_user_id": {
+            "path_match": "process.parent.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_real_user_name": {
+            "path_match": "process.parent.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_group_id": {
+            "path_match": "process.parent.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_group_name": {
+            "path_match": "process.parent.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_user_id": {
+            "path_match": "process.parent.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_saved_user_name": {
+            "path_match": "process.parent.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_start": {
+            "path_match": "process.parent.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_supplemental_groups_id": {
+            "path_match": "process.parent.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_supplemental_groups_name": {
+            "path_match": "process.parent.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_capabilities_effective": {
+            "path_match": "process.parent.thread.capabilities.effective",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_capabilities_permitted": {
+            "path_match": "process.parent.thread.capabilities.permitted",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_id": {
+            "path_match": "process.parent.thread.id",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_thread_name": {
+            "path_match": "process.parent.thread.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_title": {
+            "path_match": "process.parent.title",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_tty_char_device_major": {
+            "path_match": "process.parent.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_tty_char_device_minor": {
+            "path_match": "process.parent.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_uptime": {
+            "path_match": "process.parent.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_user_id": {
+            "path_match": "process.parent.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_user_name": {
+            "path_match": "process.parent.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_vpid": {
+            "path_match": "process.parent.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_parent_working_directory": {
+            "path_match": "process.parent.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_architecture": {
+            "path_match": "process.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_company": {
+            "path_match": "process.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_description": {
+            "path_match": "process.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_file_version": {
+            "path_match": "process.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_import_hash": {
+            "path_match": "process.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_imports": {
+            "path_match": "process.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_imports_names_entropy": {
+            "path_match": "process.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_imports_names_var_entropy": {
+            "path_match": "process.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_go_stripped": {
+            "path_match": "process.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imphash": {
+            "path_match": "process.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_import_hash": {
+            "path_match": "process.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imports": {
+            "path_match": "process.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imports_names_entropy": {
+            "path_match": "process.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_imports_names_var_entropy": {
+            "path_match": "process.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_original_file_name": {
+            "path_match": "process.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_pehash": {
+            "path_match": "process.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_product": {
+            "path_match": "process.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_entropy": {
+            "path_match": "process.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_name": {
+            "path_match": "process.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_physical_size": {
+            "path_match": "process.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_var_entropy": {
+            "path_match": "process.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pe_sections_virtual_size": {
+            "path_match": "process.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_pid": {
+            "path_match": "process.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_args": {
+            "path_match": "process.previous.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_args_count": {
+            "path_match": "process.previous.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_command_line": {
+            "path_match": "process.previous.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_executable": {
+            "path_match": "process.previous.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_name": {
+            "path_match": "process.previous.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_parent_pid": {
+            "path_match": "process.previous.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_pid": {
+            "path_match": "process.previous.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_previous_state": {
+            "path_match": "process.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_group_id": {
+            "path_match": "process.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_group_name": {
+            "path_match": "process.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_user_id": {
+            "path_match": "process.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_real_user_name": {
+            "path_match": "process.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_group_id": {
+            "path_match": "process.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_group_name": {
+            "path_match": "process.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_user_id": {
+            "path_match": "process.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_saved_user_name": {
+            "path_match": "process.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_args": {
+            "path_match": "process.session_leader.args",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_args_count": {
+            "path_match": "process.session_leader.args_count",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_command_line": {
+            "path_match": "process.session_leader.command_line",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_entity_id": {
+            "path_match": "process.session_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_executable": {
+            "path_match": "process.session_leader.executable",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_group_id": {
+            "path_match": "process.session_leader.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_group_name": {
+            "path_match": "process.session_leader.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_interactive": {
+            "path_match": "process.session_leader.interactive",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_name": {
+            "path_match": "process.session_leader.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_entity_id": {
+            "path_match": "process.session_leader.parent.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_pid": {
+            "path_match": "process.session_leader.parent.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_entity_id": {
+            "path_match": "process.session_leader.parent.session_leader.entity_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_pid": {
+            "path_match": "process.session_leader.parent.session_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_start": {
+            "path_match": "process.session_leader.parent.session_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_session_leader_vpid": {
+            "path_match": "process.session_leader.parent.session_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_start": {
+            "path_match": "process.session_leader.parent.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_parent_vpid": {
+            "path_match": "process.session_leader.parent.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_pid": {
+            "path_match": "process.session_leader.pid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_group_id": {
+            "path_match": "process.session_leader.real_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_group_name": {
+            "path_match": "process.session_leader.real_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_user_id": {
+            "path_match": "process.session_leader.real_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_real_user_name": {
+            "path_match": "process.session_leader.real_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_same_as_process": {
+            "path_match": "process.session_leader.same_as_process",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_group_id": {
+            "path_match": "process.session_leader.saved_group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_group_name": {
+            "path_match": "process.session_leader.saved_group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_user_id": {
+            "path_match": "process.session_leader.saved_user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_saved_user_name": {
+            "path_match": "process.session_leader.saved_user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_start": {
+            "path_match": "process.session_leader.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_supplemental_groups_id": {
+            "path_match": "process.session_leader.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_supplemental_groups_name": {
+            "path_match": "process.session_leader.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_tty_char_device_major": {
+            "path_match": "process.session_leader.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_tty_char_device_minor": {
+            "path_match": "process.session_leader.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_user_id": {
+            "path_match": "process.session_leader.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_user_name": {
+            "path_match": "process.session_leader.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_vpid": {
+            "path_match": "process.session_leader.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_session_leader_working_directory": {
+            "path_match": "process.session_leader.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_start": {
+            "path_match": "process.start",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_process_state": {
+            "path_match": "process.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_supplemental_groups_id": {
+            "path_match": "process.supplemental_groups.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_supplemental_groups_name": {
+            "path_match": "process.supplemental_groups.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_capabilities_effective": {
+            "path_match": "process.thread.capabilities.effective",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_capabilities_permitted": {
+            "path_match": "process.thread.capabilities.permitted",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_id": {
+            "path_match": "process.thread.id",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_thread_name": {
+            "path_match": "process.thread.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_title": {
+            "path_match": "process.title",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_char_device_major": {
+            "path_match": "process.tty.char_device.major",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_char_device_minor": {
+            "path_match": "process.tty.char_device.minor",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_columns": {
+            "path_match": "process.tty.columns",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_tty_rows": {
+            "path_match": "process.tty.rows",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_uptime": {
+            "path_match": "process.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_user_id": {
+            "path_match": "process.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_user_name": {
+            "path_match": "process.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_process_vpid": {
+            "path_match": "process.vpid",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_process_working_directory": {
+            "path_match": "process.working_directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_data_bytes": {
+            "path_match": "registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_data_strings": {
+            "path_match": "registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_data_type": {
+            "path_match": "registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_hive": {
+            "path_match": "registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_key": {
+            "path_match": "registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_path": {
+            "path_match": "registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_registry_value": {
+            "path_match": "registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_related_hash": {
+            "path_match": "related.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_related_hosts": {
+            "path_match": "related.hosts",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_related_ip": {
+            "path_match": "related.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_related_user": {
+            "path_match": "related.user",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_author": {
+            "path_match": "rule.author",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_category": {
+            "path_match": "rule.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_cmmc": {
+            "path_match": "rule.compliance.cmmc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_fedramp": {
+            "path_match": "rule.compliance.fedramp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_gdpr": {
+            "path_match": "rule.compliance.gdpr",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_hipaa": {
+            "path_match": "rule.compliance.hipaa",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_iso_27001": {
+            "path_match": "rule.compliance.iso_27001",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_nis2": {
+            "path_match": "rule.compliance.nis2",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_nist_800_171": {
+            "path_match": "rule.compliance.nist_800_171",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_nist_800_53": {
+            "path_match": "rule.compliance.nist_800_53",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_pci_dss": {
+            "path_match": "rule.compliance.pci_dss",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_compliance_tsc": {
+            "path_match": "rule.compliance.tsc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_description": {
+            "path_match": "rule.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_id": {
+            "path_match": "rule.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_level": {
+            "path_match": "rule.level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_license": {
+            "path_match": "rule.license",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_subtechnique_id": {
+            "path_match": "rule.mitre.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_subtechnique_name": {
+            "path_match": "rule.mitre.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_tactic_id": {
+            "path_match": "rule.mitre.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_tactic_name": {
+            "path_match": "rule.mitre.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_technique_id": {
+            "path_match": "rule.mitre.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_mitre_technique_name": {
+            "path_match": "rule.mitre.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_name": {
+            "path_match": "rule.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_reference": {
+            "path_match": "rule.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_ruleset": {
+            "path_match": "rule.ruleset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_sigma_id": {
+            "path_match": "rule.sigma_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_status": {
+            "path_match": "rule.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_tags": {
+            "path_match": "rule.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_title": {
+            "path_match": "rule.title",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_uuid": {
+            "path_match": "rule.uuid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_rule_version": {
+            "path_match": "rule.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_address": {
+            "path_match": "server.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_as_number": {
+            "path_match": "server.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_as_organization_name": {
+            "path_match": "server.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_bytes": {
+            "path_match": "server.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_domain": {
+            "path_match": "server.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_city_name": {
+            "path_match": "server.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_continent_code": {
+            "path_match": "server.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_continent_name": {
+            "path_match": "server.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_country_iso_code": {
+            "path_match": "server.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_country_name": {
+            "path_match": "server.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_location": {
+            "path_match": "server.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_name": {
+            "path_match": "server.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_postal_code": {
+            "path_match": "server.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_region_iso_code": {
+            "path_match": "server.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_region_name": {
+            "path_match": "server.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_geo_timezone": {
+            "path_match": "server.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_ip": {
+            "path_match": "server.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_server_mac": {
+            "path_match": "server.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_nat_ip": {
+            "path_match": "server.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_server_nat_port": {
+            "path_match": "server.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_packets": {
+            "path_match": "server.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_port": {
+            "path_match": "server.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_server_registered_domain": {
+            "path_match": "server.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_subdomain": {
+            "path_match": "server.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_top_level_domain": {
+            "path_match": "server.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_domain": {
+            "path_match": "server.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_email": {
+            "path_match": "server.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_full_name": {
+            "path_match": "server.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_group_domain": {
+            "path_match": "server.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_group_id": {
+            "path_match": "server.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_group_name": {
+            "path_match": "server.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_hash": {
+            "path_match": "server.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_id": {
+            "path_match": "server.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_name": {
+            "path_match": "server.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_server_user_roles": {
+            "path_match": "server.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_address": {
+            "path_match": "service.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_environment": {
+            "path_match": "service.environment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_ephemeral_id": {
+            "path_match": "service.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_id": {
+            "path_match": "service.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_name": {
+            "path_match": "service.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_node_name": {
+            "path_match": "service.node.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_node_role": {
+            "path_match": "service.node.role",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_node_roles": {
+            "path_match": "service.node.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_address": {
+            "path_match": "service.origin.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_environment": {
+            "path_match": "service.origin.environment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_ephemeral_id": {
+            "path_match": "service.origin.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_id": {
+            "path_match": "service.origin.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_name": {
+            "path_match": "service.origin.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_node_name": {
+            "path_match": "service.origin.node.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_node_role": {
+            "path_match": "service.origin.node.role",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_node_roles": {
+            "path_match": "service.origin.node.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_previous_state": {
+            "path_match": "service.origin.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_state": {
+            "path_match": "service.origin.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_type": {
+            "path_match": "service.origin.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_origin_version": {
+            "path_match": "service.origin.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_previous_state": {
+            "path_match": "service.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_state": {
+            "path_match": "service.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_address": {
+            "path_match": "service.target.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_environment": {
+            "path_match": "service.target.environment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_ephemeral_id": {
+            "path_match": "service.target.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_id": {
+            "path_match": "service.target.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_name": {
+            "path_match": "service.target.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_node_name": {
+            "path_match": "service.target.node.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_node_role": {
+            "path_match": "service.target.node.role",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_node_roles": {
+            "path_match": "service.target.node.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_previous_state": {
+            "path_match": "service.target.previous.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_state": {
+            "path_match": "service.target.state",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_type": {
+            "path_match": "service.target.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_target_version": {
+            "path_match": "service.target.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_type": {
+            "path_match": "service.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_service_version": {
+            "path_match": "service.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_address": {
+            "path_match": "source.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_as_number": {
+            "path_match": "source.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_as_organization_name": {
+            "path_match": "source.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_bytes": {
+            "path_match": "source.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_domain": {
+            "path_match": "source.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_city_name": {
+            "path_match": "source.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_continent_code": {
+            "path_match": "source.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_continent_name": {
+            "path_match": "source.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_country_iso_code": {
+            "path_match": "source.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_country_name": {
+            "path_match": "source.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_location": {
+            "path_match": "source.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_name": {
+            "path_match": "source.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_postal_code": {
+            "path_match": "source.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_region_iso_code": {
+            "path_match": "source.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_region_name": {
+            "path_match": "source.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_geo_timezone": {
+            "path_match": "source.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_ip": {
+            "path_match": "source.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_source_mac": {
+            "path_match": "source.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_nat_ip": {
+            "path_match": "source.nat.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_source_nat_port": {
+            "path_match": "source.nat.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_packets": {
+            "path_match": "source.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_port": {
+            "path_match": "source.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_source_registered_domain": {
+            "path_match": "source.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_subdomain": {
+            "path_match": "source.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_top_level_domain": {
+            "path_match": "source.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_domain": {
+            "path_match": "source.user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_email": {
+            "path_match": "source.user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_full_name": {
+            "path_match": "source.user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_group_domain": {
+            "path_match": "source.user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_group_id": {
+            "path_match": "source.user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_group_name": {
+            "path_match": "source.user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_hash": {
+            "path_match": "source.user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_id": {
+            "path_match": "source.user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_name": {
+            "path_match": "source.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_source_user_roles": {
+            "path_match": "source.user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_span_id": {
+            "path_match": "span.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_as_number": {
+            "path_match": "threat.enrichments.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_as_organization_name": {
+            "path_match": "threat.enrichments.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_confidence": {
+            "path_match": "threat.enrichments.indicator.confidence",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_description": {
+            "path_match": "threat.enrichments.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_email_address": {
+            "path_match": "threat.enrichments.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_feed_name": {
+            "path_match": "threat.enrichments.indicator.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_accessed": {
+            "path_match": "threat.enrichments.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_attributes": {
+            "path_match": "threat.enrichments.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_exists": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_flags": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_signing_id": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_status": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_subject_name": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_team_id": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_timestamp": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_trusted": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_code_signature_valid": {
+            "path_match": "threat.enrichments.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_created": {
+            "path_match": "threat.enrichments.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_ctime": {
+            "path_match": "threat.enrichments.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_device": {
+            "path_match": "threat.enrichments.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_directory": {
+            "path_match": "threat.enrichments.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_drive_letter": {
+            "path_match": "threat.enrichments.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_architecture": {
+            "path_match": "threat.enrichments.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_byte_order": {
+            "path_match": "threat.enrichments.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_cpu_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_creation_date": {
+            "path_match": "threat.enrichments.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_exports": {
+            "path_match": "threat.enrichments.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_imports": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_go_stripped": {
+            "path_match": "threat.enrichments.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_abi_version": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_class": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_data": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_entrypoint": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_object_version": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_os_abi": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_header_version": {
+            "path_match": "threat.enrichments.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_imports": {
+            "path_match": "threat.enrichments.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_chi2": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_flags": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_name": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_physical_offset": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_physical_size": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_virtual_address": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_sections_virtual_size": {
+            "path_match": "threat.enrichments.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_segments_sections": {
+            "path_match": "threat.enrichments.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_segments_type": {
+            "path_match": "threat.enrichments.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_shared_libraries": {
+            "path_match": "threat.enrichments.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_elf_telfhash": {
+            "path_match": "threat.enrichments.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_extension": {
+            "path_match": "threat.enrichments.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_fork_name": {
+            "path_match": "threat.enrichments.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_gid": {
+            "path_match": "threat.enrichments.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_group": {
+            "path_match": "threat.enrichments.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_cdhash": {
+            "path_match": "threat.enrichments.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_md5": {
+            "path_match": "threat.enrichments.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha1": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha256": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha384": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_sha512": {
+            "path_match": "threat.enrichments.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_ssdeep": {
+            "path_match": "threat.enrichments.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_hash_tlsh": {
+            "path_match": "threat.enrichments.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_inode": {
+            "path_match": "threat.enrichments.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_mime_type": {
+            "path_match": "threat.enrichments.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_mode": {
+            "path_match": "threat.enrichments.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_mtime": {
+            "path_match": "threat.enrichments.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_name": {
+            "path_match": "threat.enrichments.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_origin_referrer_url": {
+            "path_match": "threat.enrichments.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_origin_url": {
+            "path_match": "threat.enrichments.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_owner": {
+            "path_match": "threat.enrichments.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_path": {
+            "path_match": "threat.enrichments.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_architecture": {
+            "path_match": "threat.enrichments.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_company": {
+            "path_match": "threat.enrichments.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_description": {
+            "path_match": "threat.enrichments.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_file_version": {
+            "path_match": "threat.enrichments.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_imports": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_go_stripped": {
+            "path_match": "threat.enrichments.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imphash": {
+            "path_match": "threat.enrichments.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_import_hash": {
+            "path_match": "threat.enrichments.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imports": {
+            "path_match": "threat.enrichments.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imports_names_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_original_file_name": {
+            "path_match": "threat.enrichments.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_pehash": {
+            "path_match": "threat.enrichments.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_product": {
+            "path_match": "threat.enrichments.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_name": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_physical_size": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_var_entropy": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_pe_sections_virtual_size": {
+            "path_match": "threat.enrichments.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_size": {
+            "path_match": "threat.enrichments.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_target_path": {
+            "path_match": "threat.enrichments.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_type": {
+            "path_match": "threat.enrichments.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_uid": {
+            "path_match": "threat.enrichments.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_alternative_names": {
+            "path_match": "threat.enrichments.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_common_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_country": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_locality": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_organization": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "threat.enrichments.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_not_after": {
+            "path_match": "threat.enrichments.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_not_before": {
+            "path_match": "threat.enrichments.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_algorithm": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_curve": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_exponent": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_public_key_size": {
+            "path_match": "threat.enrichments.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_serial_number": {
+            "path_match": "threat.enrichments.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_signature_algorithm": {
+            "path_match": "threat.enrichments.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_common_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_country": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_locality": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_organization": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_subject_state_or_province": {
+            "path_match": "threat.enrichments.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_file_x509_version_number": {
+            "path_match": "threat.enrichments.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_first_seen": {
+            "path_match": "threat.enrichments.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_city_name": {
+            "path_match": "threat.enrichments.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_continent_code": {
+            "path_match": "threat.enrichments.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_continent_name": {
+            "path_match": "threat.enrichments.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_country_iso_code": {
+            "path_match": "threat.enrichments.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_country_name": {
+            "path_match": "threat.enrichments.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_location": {
+            "path_match": "threat.enrichments.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_name": {
+            "path_match": "threat.enrichments.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_postal_code": {
+            "path_match": "threat.enrichments.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_region_iso_code": {
+            "path_match": "threat.enrichments.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_region_name": {
+            "path_match": "threat.enrichments.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_geo_timezone": {
+            "path_match": "threat.enrichments.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_id": {
+            "path_match": "threat.enrichments.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_ip": {
+            "path_match": "threat.enrichments.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_last_seen": {
+            "path_match": "threat.enrichments.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_marking_tlp": {
+            "path_match": "threat.enrichments.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_marking_tlp_version": {
+            "path_match": "threat.enrichments.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_modified_at": {
+            "path_match": "threat.enrichments.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_name": {
+            "path_match": "threat.enrichments.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_port": {
+            "path_match": "threat.enrichments.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_provider": {
+            "path_match": "threat.enrichments.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_reference": {
+            "path_match": "threat.enrichments.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_data_bytes": {
+            "path_match": "threat.enrichments.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_data_strings": {
+            "path_match": "threat.enrichments.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_data_type": {
+            "path_match": "threat.enrichments.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_hive": {
+            "path_match": "threat.enrichments.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_key": {
+            "path_match": "threat.enrichments.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_path": {
+            "path_match": "threat.enrichments.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_registry_value": {
+            "path_match": "threat.enrichments.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_scanner_stats": {
+            "path_match": "threat.enrichments.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_sightings": {
+            "path_match": "threat.enrichments.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_software_alias": {
+            "path_match": "threat.enrichments.indicator.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_software_name": {
+            "path_match": "threat.enrichments.indicator.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_software_type": {
+            "path_match": "threat.enrichments.indicator.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_tags": {
+            "path_match": "threat.enrichments.indicator.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_type": {
+            "path_match": "threat.enrichments.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_domain": {
+            "path_match": "threat.enrichments.indicator.url.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_extension": {
+            "path_match": "threat.enrichments.indicator.url.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_fragment": {
+            "path_match": "threat.enrichments.indicator.url.fragment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_full": {
+            "path_match": "threat.enrichments.indicator.url.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_original": {
+            "path_match": "threat.enrichments.indicator.url.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_password": {
+            "path_match": "threat.enrichments.indicator.url.password",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_path": {
+            "path_match": "threat.enrichments.indicator.url.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_port": {
+            "path_match": "threat.enrichments.indicator.url.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_query": {
+            "path_match": "threat.enrichments.indicator.url.query",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_registered_domain": {
+            "path_match": "threat.enrichments.indicator.url.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_scheme": {
+            "path_match": "threat.enrichments.indicator.url.scheme",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_subdomain": {
+            "path_match": "threat.enrichments.indicator.url.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_top_level_domain": {
+            "path_match": "threat.enrichments.indicator.url.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_url_username": {
+            "path_match": "threat.enrichments.indicator.url.username",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_alternative_names": {
+            "path_match": "threat.enrichments.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_common_name": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_country": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_locality": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_organization": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_issuer_state_or_province": {
+            "path_match": "threat.enrichments.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_not_after": {
+            "path_match": "threat.enrichments.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_not_before": {
+            "path_match": "threat.enrichments.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_algorithm": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_curve": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_exponent": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_public_key_size": {
+            "path_match": "threat.enrichments.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_serial_number": {
+            "path_match": "threat.enrichments.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_signature_algorithm": {
+            "path_match": "threat.enrichments.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_common_name": {
+            "path_match": "threat.enrichments.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_country": {
+            "path_match": "threat.enrichments.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_distinguished_name": {
+            "path_match": "threat.enrichments.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_locality": {
+            "path_match": "threat.enrichments.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_organization": {
+            "path_match": "threat.enrichments.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_organizational_unit": {
+            "path_match": "threat.enrichments.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_subject_state_or_province": {
+            "path_match": "threat.enrichments.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_indicator_x509_version_number": {
+            "path_match": "threat.enrichments.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_atomic": {
+            "path_match": "threat.enrichments.matched.atomic",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_field": {
+            "path_match": "threat.enrichments.matched.field",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_id": {
+            "path_match": "threat.enrichments.matched.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_index": {
+            "path_match": "threat.enrichments.matched.index",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_occurred": {
+            "path_match": "threat.enrichments.matched.occurred",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_enrichments_matched_type": {
+            "path_match": "threat.enrichments.matched.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_dashboard_id": {
+            "path_match": "threat.feed.dashboard_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_description": {
+            "path_match": "threat.feed.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_name": {
+            "path_match": "threat.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_feed_reference": {
+            "path_match": "threat.feed.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_framework": {
+            "path_match": "threat.framework",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_alias": {
+            "path_match": "threat.group.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_id": {
+            "path_match": "threat.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_name": {
+            "path_match": "threat.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_group_reference": {
+            "path_match": "threat.group.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_as_number": {
+            "path_match": "threat.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_as_organization_name": {
+            "path_match": "threat.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_confidence": {
+            "path_match": "threat.indicator.confidence",
+            "mapping": {
+              "type": "short"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_description": {
+            "path_match": "threat.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_email_address": {
+            "path_match": "threat.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_accessed": {
+            "path_match": "threat.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_attributes": {
+            "path_match": "threat.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "threat.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_exists": {
+            "path_match": "threat.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_flags": {
+            "path_match": "threat.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_signing_id": {
+            "path_match": "threat.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_status": {
+            "path_match": "threat.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_subject_name": {
+            "path_match": "threat.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_team_id": {
+            "path_match": "threat.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "threat.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_timestamp": {
+            "path_match": "threat.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_trusted": {
+            "path_match": "threat.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_code_signature_valid": {
+            "path_match": "threat.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_created": {
+            "path_match": "threat.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_ctime": {
+            "path_match": "threat.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_device": {
+            "path_match": "threat.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_directory": {
+            "path_match": "threat.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_drive_letter": {
+            "path_match": "threat.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_architecture": {
+            "path_match": "threat.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_byte_order": {
+            "path_match": "threat.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_cpu_type": {
+            "path_match": "threat.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_creation_date": {
+            "path_match": "threat.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_exports": {
+            "path_match": "threat.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_import_hash": {
+            "path_match": "threat.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_imports": {
+            "path_match": "threat.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "threat.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_go_stripped": {
+            "path_match": "threat.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_abi_version": {
+            "path_match": "threat.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_class": {
+            "path_match": "threat.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_data": {
+            "path_match": "threat.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_entrypoint": {
+            "path_match": "threat.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_object_version": {
+            "path_match": "threat.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_os_abi": {
+            "path_match": "threat.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_type": {
+            "path_match": "threat.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_header_version": {
+            "path_match": "threat.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_import_hash": {
+            "path_match": "threat.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_imports": {
+            "path_match": "threat.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_imports_names_entropy": {
+            "path_match": "threat.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_chi2": {
+            "path_match": "threat.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_entropy": {
+            "path_match": "threat.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_flags": {
+            "path_match": "threat.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_name": {
+            "path_match": "threat.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_physical_offset": {
+            "path_match": "threat.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_physical_size": {
+            "path_match": "threat.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_type": {
+            "path_match": "threat.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_var_entropy": {
+            "path_match": "threat.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_virtual_address": {
+            "path_match": "threat.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_sections_virtual_size": {
+            "path_match": "threat.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_segments_sections": {
+            "path_match": "threat.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_segments_type": {
+            "path_match": "threat.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_shared_libraries": {
+            "path_match": "threat.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_elf_telfhash": {
+            "path_match": "threat.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_extension": {
+            "path_match": "threat.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_fork_name": {
+            "path_match": "threat.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_gid": {
+            "path_match": "threat.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_group": {
+            "path_match": "threat.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_cdhash": {
+            "path_match": "threat.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_md5": {
+            "path_match": "threat.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha1": {
+            "path_match": "threat.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha256": {
+            "path_match": "threat.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha384": {
+            "path_match": "threat.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_sha512": {
+            "path_match": "threat.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_ssdeep": {
+            "path_match": "threat.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_hash_tlsh": {
+            "path_match": "threat.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_inode": {
+            "path_match": "threat.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_mime_type": {
+            "path_match": "threat.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_mode": {
+            "path_match": "threat.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_mtime": {
+            "path_match": "threat.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_name": {
+            "path_match": "threat.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_origin_referrer_url": {
+            "path_match": "threat.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_origin_url": {
+            "path_match": "threat.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_owner": {
+            "path_match": "threat.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_path": {
+            "path_match": "threat.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_architecture": {
+            "path_match": "threat.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_company": {
+            "path_match": "threat.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_description": {
+            "path_match": "threat.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_file_version": {
+            "path_match": "threat.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_import_hash": {
+            "path_match": "threat.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_imports": {
+            "path_match": "threat.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "threat.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_go_stripped": {
+            "path_match": "threat.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imphash": {
+            "path_match": "threat.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_import_hash": {
+            "path_match": "threat.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imports": {
+            "path_match": "threat.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imports_names_entropy": {
+            "path_match": "threat.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "threat.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_original_file_name": {
+            "path_match": "threat.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_pehash": {
+            "path_match": "threat.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_product": {
+            "path_match": "threat.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_entropy": {
+            "path_match": "threat.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_name": {
+            "path_match": "threat.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_physical_size": {
+            "path_match": "threat.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_var_entropy": {
+            "path_match": "threat.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_pe_sections_virtual_size": {
+            "path_match": "threat.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_size": {
+            "path_match": "threat.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_target_path": {
+            "path_match": "threat.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_type": {
+            "path_match": "threat.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_uid": {
+            "path_match": "threat.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_alternative_names": {
+            "path_match": "threat.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_common_name": {
+            "path_match": "threat.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_country": {
+            "path_match": "threat.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "threat.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_locality": {
+            "path_match": "threat.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_organization": {
+            "path_match": "threat.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "threat.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "threat.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_not_after": {
+            "path_match": "threat.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_not_before": {
+            "path_match": "threat.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_algorithm": {
+            "path_match": "threat.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_curve": {
+            "path_match": "threat.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_exponent": {
+            "path_match": "threat.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_public_key_size": {
+            "path_match": "threat.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_serial_number": {
+            "path_match": "threat.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_signature_algorithm": {
+            "path_match": "threat.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_common_name": {
+            "path_match": "threat.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_country": {
+            "path_match": "threat.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "threat.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_locality": {
+            "path_match": "threat.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_organization": {
+            "path_match": "threat.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "threat.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_subject_state_or_province": {
+            "path_match": "threat.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_file_x509_version_number": {
+            "path_match": "threat.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_first_seen": {
+            "path_match": "threat.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_city_name": {
+            "path_match": "threat.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_continent_code": {
+            "path_match": "threat.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_continent_name": {
+            "path_match": "threat.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_country_iso_code": {
+            "path_match": "threat.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_country_name": {
+            "path_match": "threat.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_location": {
+            "path_match": "threat.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_name": {
+            "path_match": "threat.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_postal_code": {
+            "path_match": "threat.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_region_iso_code": {
+            "path_match": "threat.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_region_name": {
+            "path_match": "threat.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_geo_timezone": {
+            "path_match": "threat.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_id": {
+            "path_match": "threat.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_ip": {
+            "path_match": "threat.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_last_seen": {
+            "path_match": "threat.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_marking_tlp": {
+            "path_match": "threat.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_marking_tlp_version": {
+            "path_match": "threat.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_modified_at": {
+            "path_match": "threat.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_name": {
+            "path_match": "threat.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_port": {
+            "path_match": "threat.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_provider": {
+            "path_match": "threat.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_reference": {
+            "path_match": "threat.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_data_bytes": {
+            "path_match": "threat.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_data_strings": {
+            "path_match": "threat.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_data_type": {
+            "path_match": "threat.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_hive": {
+            "path_match": "threat.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_key": {
+            "path_match": "threat.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_path": {
+            "path_match": "threat.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_registry_value": {
+            "path_match": "threat.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_scanner_stats": {
+            "path_match": "threat.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_sightings": {
+            "path_match": "threat.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_type": {
+            "path_match": "threat.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_domain": {
+            "path_match": "threat.indicator.url.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_extension": {
+            "path_match": "threat.indicator.url.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_fragment": {
+            "path_match": "threat.indicator.url.fragment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_full": {
+            "path_match": "threat.indicator.url.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_original": {
+            "path_match": "threat.indicator.url.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_password": {
+            "path_match": "threat.indicator.url.password",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_path": {
+            "path_match": "threat.indicator.url.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_port": {
+            "path_match": "threat.indicator.url.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_query": {
+            "path_match": "threat.indicator.url.query",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_registered_domain": {
+            "path_match": "threat.indicator.url.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_scheme": {
+            "path_match": "threat.indicator.url.scheme",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_subdomain": {
+            "path_match": "threat.indicator.url.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_top_level_domain": {
+            "path_match": "threat.indicator.url.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_url_username": {
+            "path_match": "threat.indicator.url.username",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_alternative_names": {
+            "path_match": "threat.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_common_name": {
+            "path_match": "threat.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_country": {
+            "path_match": "threat.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_distinguished_name": {
+            "path_match": "threat.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_locality": {
+            "path_match": "threat.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_organization": {
+            "path_match": "threat.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_organizational_unit": {
+            "path_match": "threat.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_issuer_state_or_province": {
+            "path_match": "threat.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_not_after": {
+            "path_match": "threat.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_not_before": {
+            "path_match": "threat.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_algorithm": {
+            "path_match": "threat.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_curve": {
+            "path_match": "threat.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_exponent": {
+            "path_match": "threat.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_public_key_size": {
+            "path_match": "threat.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_serial_number": {
+            "path_match": "threat.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_signature_algorithm": {
+            "path_match": "threat.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_common_name": {
+            "path_match": "threat.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_country": {
+            "path_match": "threat.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_distinguished_name": {
+            "path_match": "threat.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_locality": {
+            "path_match": "threat.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_organization": {
+            "path_match": "threat.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_organizational_unit": {
+            "path_match": "threat.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_subject_state_or_province": {
+            "path_match": "threat.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_indicator_x509_version_number": {
+            "path_match": "threat.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_alias": {
+            "path_match": "threat.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_id": {
+            "path_match": "threat.software.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_name": {
+            "path_match": "threat.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_platforms": {
+            "path_match": "threat.software.platforms",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_reference": {
+            "path_match": "threat.software.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_software_type": {
+            "path_match": "threat.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_tactic_id": {
+            "path_match": "threat.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_tactic_name": {
+            "path_match": "threat.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_tactic_reference": {
+            "path_match": "threat.tactic.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_id": {
+            "path_match": "threat.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_name": {
+            "path_match": "threat.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_reference": {
+            "path_match": "threat.technique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_subtechnique_id": {
+            "path_match": "threat.technique.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_subtechnique_name": {
+            "path_match": "threat.technique.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_threat_technique_subtechnique_reference": {
+            "path_match": "threat.technique.subtechnique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_cipher": {
+            "path_match": "tls.cipher",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_certificate": {
+            "path_match": "tls.client.certificate",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_certificate_chain": {
+            "path_match": "tls.client.certificate_chain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_hash_md5": {
+            "path_match": "tls.client.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_hash_sha1": {
+            "path_match": "tls.client.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_hash_sha256": {
+            "path_match": "tls.client.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_issuer": {
+            "path_match": "tls.client.issuer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_ja3": {
+            "path_match": "tls.client.ja3",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_not_after": {
+            "path_match": "tls.client.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_not_before": {
+            "path_match": "tls.client.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_server_name": {
+            "path_match": "tls.client.server_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_subject": {
+            "path_match": "tls.client.subject",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_supported_ciphers": {
+            "path_match": "tls.client.supported_ciphers",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_alternative_names": {
+            "path_match": "tls.client.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_common_name": {
+            "path_match": "tls.client.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_country": {
+            "path_match": "tls.client.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_distinguished_name": {
+            "path_match": "tls.client.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_locality": {
+            "path_match": "tls.client.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_organization": {
+            "path_match": "tls.client.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_organizational_unit": {
+            "path_match": "tls.client.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_issuer_state_or_province": {
+            "path_match": "tls.client.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_not_after": {
+            "path_match": "tls.client.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_not_before": {
+            "path_match": "tls.client.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_algorithm": {
+            "path_match": "tls.client.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_curve": {
+            "path_match": "tls.client.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_exponent": {
+            "path_match": "tls.client.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_public_key_size": {
+            "path_match": "tls.client.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_serial_number": {
+            "path_match": "tls.client.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_signature_algorithm": {
+            "path_match": "tls.client.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_common_name": {
+            "path_match": "tls.client.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_country": {
+            "path_match": "tls.client.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_distinguished_name": {
+            "path_match": "tls.client.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_locality": {
+            "path_match": "tls.client.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_organization": {
+            "path_match": "tls.client.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_organizational_unit": {
+            "path_match": "tls.client.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_subject_state_or_province": {
+            "path_match": "tls.client.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_client_x509_version_number": {
+            "path_match": "tls.client.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_curve": {
+            "path_match": "tls.curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_established": {
+            "path_match": "tls.established",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_tls_next_protocol": {
+            "path_match": "tls.next_protocol",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_resumed": {
+            "path_match": "tls.resumed",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_certificate": {
+            "path_match": "tls.server.certificate",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_certificate_chain": {
+            "path_match": "tls.server.certificate_chain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_hash_md5": {
+            "path_match": "tls.server.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_hash_sha1": {
+            "path_match": "tls.server.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_hash_sha256": {
+            "path_match": "tls.server.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_issuer": {
+            "path_match": "tls.server.issuer",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_ja3s": {
+            "path_match": "tls.server.ja3s",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_not_after": {
+            "path_match": "tls.server.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_not_before": {
+            "path_match": "tls.server.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_subject": {
+            "path_match": "tls.server.subject",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_alternative_names": {
+            "path_match": "tls.server.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_common_name": {
+            "path_match": "tls.server.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_country": {
+            "path_match": "tls.server.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_distinguished_name": {
+            "path_match": "tls.server.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_locality": {
+            "path_match": "tls.server.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_organization": {
+            "path_match": "tls.server.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_organizational_unit": {
+            "path_match": "tls.server.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_issuer_state_or_province": {
+            "path_match": "tls.server.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_not_after": {
+            "path_match": "tls.server.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_not_before": {
+            "path_match": "tls.server.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_algorithm": {
+            "path_match": "tls.server.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_curve": {
+            "path_match": "tls.server.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_exponent": {
+            "path_match": "tls.server.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_public_key_size": {
+            "path_match": "tls.server.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_serial_number": {
+            "path_match": "tls.server.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_signature_algorithm": {
+            "path_match": "tls.server.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_common_name": {
+            "path_match": "tls.server.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_country": {
+            "path_match": "tls.server.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_distinguished_name": {
+            "path_match": "tls.server.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_locality": {
+            "path_match": "tls.server.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_organization": {
+            "path_match": "tls.server.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_organizational_unit": {
+            "path_match": "tls.server.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_subject_state_or_province": {
+            "path_match": "tls.server.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_server_x509_version_number": {
+            "path_match": "tls.server.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_version": {
+            "path_match": "tls.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_tls_version_protocol": {
+            "path_match": "tls.version_protocol",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_trace_id": {
+            "path_match": "trace.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_transaction_id": {
+            "path_match": "transaction.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_domain": {
+            "path_match": "url.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_extension": {
+            "path_match": "url.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_fragment": {
+            "path_match": "url.fragment",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_full": {
+            "path_match": "url.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_original": {
+            "path_match": "url.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_password": {
+            "path_match": "url.password",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_path": {
+            "path_match": "url.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_port": {
+            "path_match": "url.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_url_query": {
+            "path_match": "url.query",
+            "mapping": {
+              "ignore_above": 2083,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_registered_domain": {
+            "path_match": "url.registered_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_scheme": {
+            "path_match": "url.scheme",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_subdomain": {
+            "path_match": "url.subdomain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_top_level_domain": {
+            "path_match": "url.top_level_domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_url_username": {
+            "path_match": "url.username",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_device_name": {
+            "path_match": "user_agent.device.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_name": {
+            "path_match": "user_agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_original": {
+            "path_match": "user_agent.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_family": {
+            "path_match": "user_agent.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_full": {
+            "path_match": "user_agent.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_kernel": {
+            "path_match": "user_agent.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_name": {
+            "path_match": "user_agent.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_platform": {
+            "path_match": "user_agent.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_type": {
+            "path_match": "user_agent.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_os_version": {
+            "path_match": "user_agent.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_agent_version": {
+            "path_match": "user_agent.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_domain": {
+            "path_match": "user.changes.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_email": {
+            "path_match": "user.changes.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_full_name": {
+            "path_match": "user.changes.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_group_domain": {
+            "path_match": "user.changes.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_group_id": {
+            "path_match": "user.changes.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_group_name": {
+            "path_match": "user.changes.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_hash": {
+            "path_match": "user.changes.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_id": {
+            "path_match": "user.changes.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_name": {
+            "path_match": "user.changes.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_changes_roles": {
+            "path_match": "user.changes.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_domain": {
+            "path_match": "user.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_domain": {
+            "path_match": "user.effective.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_email": {
+            "path_match": "user.effective.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_full_name": {
+            "path_match": "user.effective.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_group_domain": {
+            "path_match": "user.effective.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_group_id": {
+            "path_match": "user.effective.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_group_name": {
+            "path_match": "user.effective.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_hash": {
+            "path_match": "user.effective.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_id": {
+            "path_match": "user.effective.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_name": {
+            "path_match": "user.effective.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_effective_roles": {
+            "path_match": "user.effective.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_email": {
+            "path_match": "user.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_full_name": {
+            "path_match": "user.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_group_domain": {
+            "path_match": "user.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_group_id": {
+            "path_match": "user.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_group_name": {
+            "path_match": "user.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_hash": {
+            "path_match": "user.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_id": {
+            "path_match": "user.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_name": {
+            "path_match": "user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_calculated_level": {
+            "path_match": "user.risk.calculated_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_calculated_score": {
+            "path_match": "user.risk.calculated_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_calculated_score_norm": {
+            "path_match": "user.risk.calculated_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_static_level": {
+            "path_match": "user.risk.static_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_static_score": {
+            "path_match": "user.risk.static_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_risk_static_score_norm": {
+            "path_match": "user.risk.static_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_user_roles": {
+            "path_match": "user.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_domain": {
+            "path_match": "user.target.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_email": {
+            "path_match": "user.target.email",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_full_name": {
+            "path_match": "user.target.full_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_group_domain": {
+            "path_match": "user.target.group.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_group_id": {
+            "path_match": "user.target.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_group_name": {
+            "path_match": "user.target.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_hash": {
+            "path_match": "user.target.hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_id": {
+            "path_match": "user.target.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_name": {
+            "path_match": "user.target.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_user_target_roles": {
+            "path_match": "user.target.roles",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_bus_type": {
+            "path_match": "volume.bus_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_default_access": {
+            "path_match": "volume.default_access",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_device_name": {
+            "path_match": "volume.device_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_device_type": {
+            "path_match": "volume.device_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_dos_name": {
+            "path_match": "volume.dos_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_file_system_type": {
+            "path_match": "volume.file_system_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_mount_name": {
+            "path_match": "volume.mount_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_nt_name": {
+            "path_match": "volume.nt_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_product_id": {
+            "path_match": "volume.product_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_product_name": {
+            "path_match": "volume.product_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_removable": {
+            "path_match": "volume.removable",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_volume_serial_number": {
+            "path_match": "volume.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_size": {
+            "path_match": "volume.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_volume_vendor_id": {
+            "path_match": "volume.vendor_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_vendor_name": {
+            "path_match": "volume.vendor_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_volume_writable": {
+            "path_match": "volume.writable",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_category": {
+            "path_match": "vulnerability.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_classification": {
+            "path_match": "vulnerability.classification",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_description": {
+            "path_match": "vulnerability.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_detected_at": {
+            "path_match": "vulnerability.detected_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_enumeration": {
+            "path_match": "vulnerability.enumeration",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_id": {
+            "path_match": "vulnerability.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_published_at": {
+            "path_match": "vulnerability.published_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_report_id": {
+            "path_match": "vulnerability.report_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_condition": {
+            "path_match": "vulnerability.scanner.condition",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_reference": {
+            "path_match": "vulnerability.scanner.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_source": {
+            "path_match": "vulnerability.scanner.source",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_scanner_vendor": {
+            "path_match": "vulnerability.scanner.vendor",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_base": {
+            "path_match": "vulnerability.score.base",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_environmental": {
+            "path_match": "vulnerability.score.environmental",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_temporal": {
+            "path_match": "vulnerability.score.temporal",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_score_version": {
+            "path_match": "vulnerability.score.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_severity": {
+            "path_match": "vulnerability.severity",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_vulnerability_under_evaluation": {
+            "path_match": "vulnerability.under_evaluation",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_build_original": {
+            "path_match": "wazuh.agent.build.original",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_ephemeral_id": {
+            "path_match": "wazuh.agent.ephemeral_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_groups": {
+            "path_match": "wazuh.agent.groups",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_architecture": {
+            "path_match": "wazuh.agent.host.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_boot_id": {
+            "path_match": "wazuh.agent.host.boot.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_cores": {
+            "path_match": "wazuh.agent.host.cpu.cores",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_name": {
+            "path_match": "wazuh.agent.host.cpu.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_speed": {
+            "path_match": "wazuh.agent.host.cpu.speed",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_cpu_usage": {
+            "path_match": "wazuh.agent.host.cpu.usage",
+            "mapping": {
+              "scaling_factor": 1000,
+              "type": "scaled_float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_disk_read_bytes": {
+            "path_match": "wazuh.agent.host.disk.read.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_disk_write_bytes": {
+            "path_match": "wazuh.agent.host.disk.write.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_domain": {
+            "path_match": "wazuh.agent.host.domain",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_city_name": {
+            "path_match": "wazuh.agent.host.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_continent_code": {
+            "path_match": "wazuh.agent.host.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_continent_name": {
+            "path_match": "wazuh.agent.host.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_country_iso_code": {
+            "path_match": "wazuh.agent.host.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_country_name": {
+            "path_match": "wazuh.agent.host.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_location": {
+            "path_match": "wazuh.agent.host.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_name": {
+            "path_match": "wazuh.agent.host.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_postal_code": {
+            "path_match": "wazuh.agent.host.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_region_iso_code": {
+            "path_match": "wazuh.agent.host.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_region_name": {
+            "path_match": "wazuh.agent.host.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_geo_timezone": {
+            "path_match": "wazuh.agent.host.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_hostname": {
+            "path_match": "wazuh.agent.host.hostname",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_id": {
+            "path_match": "wazuh.agent.host.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_ip": {
+            "path_match": "wazuh.agent.host.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_mac": {
+            "path_match": "wazuh.agent.host.mac",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_memory_free": {
+            "path_match": "wazuh.agent.host.memory.free",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_memory_total": {
+            "path_match": "wazuh.agent.host.memory.total",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_memory_used_percentage": {
+            "path_match": "wazuh.agent.host.memory.used.percentage",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_name": {
+            "path_match": "wazuh.agent.host.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_bytes": {
+            "path_match": "wazuh.agent.host.network.egress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_drops": {
+            "path_match": "wazuh.agent.host.network.egress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_errors": {
+            "path_match": "wazuh.agent.host.network.egress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_packets": {
+            "path_match": "wazuh.agent.host.network.egress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_egress_queue": {
+            "path_match": "wazuh.agent.host.network.egress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_bytes": {
+            "path_match": "wazuh.agent.host.network.ingress.bytes",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_drops": {
+            "path_match": "wazuh.agent.host.network.ingress.drops",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_errors": {
+            "path_match": "wazuh.agent.host.network.ingress.errors",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_packets": {
+            "path_match": "wazuh.agent.host.network.ingress.packets",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_network_ingress_queue": {
+            "path_match": "wazuh.agent.host.network.ingress.queue",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_family": {
+            "path_match": "wazuh.agent.host.os.family",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_full": {
+            "path_match": "wazuh.agent.host.os.full",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_kernel": {
+            "path_match": "wazuh.agent.host.os.kernel",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_name": {
+            "path_match": "wazuh.agent.host.os.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_platform": {
+            "path_match": "wazuh.agent.host.os.platform",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_type": {
+            "path_match": "wazuh.agent.host.os.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_os_version": {
+            "path_match": "wazuh.agent.host.os.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_pid_ns_ino": {
+            "path_match": "wazuh.agent.host.pid_ns_ino",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_calculated_level": {
+            "path_match": "wazuh.agent.host.risk.calculated_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_calculated_score": {
+            "path_match": "wazuh.agent.host.risk.calculated_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_calculated_score_norm": {
+            "path_match": "wazuh.agent.host.risk.calculated_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_static_level": {
+            "path_match": "wazuh.agent.host.risk.static_level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_static_score": {
+            "path_match": "wazuh.agent.host.risk.static_score",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_risk_static_score_norm": {
+            "path_match": "wazuh.agent.host.risk.static_score_norm",
+            "mapping": {
+              "type": "float"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_type": {
+            "path_match": "wazuh.agent.host.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_host_uptime": {
+            "path_match": "wazuh.agent.host.uptime",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_id": {
+            "path_match": "wazuh.agent.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_name": {
+            "path_match": "wazuh.agent.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_type": {
+            "path_match": "wazuh.agent.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_agent_version": {
+            "path_match": "wazuh.agent.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_comments_author": {
+            "path_match": "wazuh.case.comments.author",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_comments_comment": {
+            "path_match": "wazuh.case.comments.comment",
+            "mapping": {
+              "type": "match_only_text"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_comments_created_at": {
+            "path_match": "wazuh.case.comments.created_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_comments_updated_at": {
+            "path_match": "wazuh.case.comments.updated_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_created_at": {
+            "path_match": "wazuh.case.created_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_description": {
+            "path_match": "wazuh.case.description",
+            "mapping": {
+              "type": "match_only_text"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_priority": {
+            "path_match": "wazuh.case.priority",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_severity": {
+            "path_match": "wazuh.case.severity",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_status": {
+            "path_match": "wazuh.case.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_tags": {
+            "path_match": "wazuh.case.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_title": {
+            "path_match": "wazuh.case.title",
+            "mapping": {
+              "type": "match_only_text"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_tlp": {
+            "path_match": "wazuh.case.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_updated_at": {
+            "path_match": "wazuh.case.updated_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_case_user_name": {
+            "path_match": "wazuh.case.user.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_cluster_name": {
+            "path_match": "wazuh.cluster.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_cluster_node": {
+            "path_match": "wazuh.cluster.node",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_event_id": {
+            "path_match": "wazuh.event.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_category": {
+            "path_match": "wazuh.integration.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_decoders": {
+            "path_match": "wazuh.integration.decoders",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_name": {
+            "path_match": "wazuh.integration.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_integration_rules": {
+            "path_match": "wazuh.integration.rules",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_protocol_location": {
+            "path_match": "wazuh.protocol.location",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_protocol_queue": {
+            "path_match": "wazuh.protocol.queue",
+            "mapping": {
+              "type": "byte"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_author": {
+            "path_match": "wazuh.rule.author",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_category": {
+            "path_match": "wazuh.rule.category",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_cmmc": {
+            "path_match": "wazuh.rule.compliance.cmmc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_fedramp": {
+            "path_match": "wazuh.rule.compliance.fedramp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_gdpr": {
+            "path_match": "wazuh.rule.compliance.gdpr",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_hipaa": {
+            "path_match": "wazuh.rule.compliance.hipaa",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_iso_27001": {
+            "path_match": "wazuh.rule.compliance.iso_27001",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_nis2": {
+            "path_match": "wazuh.rule.compliance.nis2",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_nist_800_171": {
+            "path_match": "wazuh.rule.compliance.nist_800_171",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_nist_800_53": {
+            "path_match": "wazuh.rule.compliance.nist_800_53",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_pci_dss": {
+            "path_match": "wazuh.rule.compliance.pci_dss",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_compliance_tsc": {
+            "path_match": "wazuh.rule.compliance.tsc",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_description": {
+            "path_match": "wazuh.rule.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_id": {
+            "path_match": "wazuh.rule.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_level": {
+            "path_match": "wazuh.rule.level",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_license": {
+            "path_match": "wazuh.rule.license",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_mitre_subtechnique_id": {
+            "path_match": "wazuh.rule.mitre.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_mitre_subtechnique_name": {
+            "path_match": "wazuh.rule.mitre.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_mitre_tactic_id": {
+            "path_match": "wazuh.rule.mitre.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_mitre_tactic_name": {
+            "path_match": "wazuh.rule.mitre.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_mitre_technique_id": {
+            "path_match": "wazuh.rule.mitre.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_mitre_technique_name": {
+            "path_match": "wazuh.rule.mitre.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_name": {
+            "path_match": "wazuh.rule.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_reference": {
+            "path_match": "wazuh.rule.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_ruleset": {
+            "path_match": "wazuh.rule.ruleset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_sigma_id": {
+            "path_match": "wazuh.rule.sigma_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_status": {
+            "path_match": "wazuh.rule.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_tags": {
+            "path_match": "wazuh.rule.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_title": {
+            "path_match": "wazuh.rule.title",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_uuid": {
+            "path_match": "wazuh.rule.uuid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_rule_version": {
+            "path_match": "wazuh.rule.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_schema_version": {
+            "path_match": "wazuh.schema.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_space_event_discarded": {
+            "path_match": "wazuh.space.event_discarded",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_space_name": {
+            "path_match": "wazuh.space.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_as_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_as_organization_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_confidence": {
+            "path_match": "wazuh.threat.enrichments.indicator.confidence",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_description": {
+            "path_match": "wazuh.threat.enrichments.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_email_address": {
+            "path_match": "wazuh.threat.enrichments.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_feed_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_accessed": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_attributes": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_exists": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_flags": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_signing_id": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_status": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_subject_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_team_id": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_timestamp": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_trusted": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_code_signature_valid": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_created": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_ctime": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_device": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_directory": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_drive_letter": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_architecture": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_byte_order": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_cpu_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_creation_date": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_exports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_go_stripped": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_abi_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_class": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_data": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_entrypoint": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_object_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_os_abi": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_header_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_chi2": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_flags": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_physical_offset": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_physical_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_virtual_address": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_sections_virtual_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_segments_sections": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_segments_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_shared_libraries": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_elf_telfhash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_extension": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_fork_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_gid": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_group": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_cdhash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_md5": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha1": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha256": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha384": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_sha512": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_ssdeep": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_hash_tlsh": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_inode": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_mime_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_mode": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_mtime": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_origin_referrer_url": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_origin_url": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_owner": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_path": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_architecture": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_company": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_description": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_file_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_go_stripped": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imphash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_import_hash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports_names_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_original_file_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_pehash": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_product": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_physical_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_var_entropy": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_pe_sections_virtual_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_target_path": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_uid": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_alternative_names": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_not_after": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_not_before": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_curve": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_public_key_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_serial_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_file_x509_version_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_first_seen": {
+            "path_match": "wazuh.threat.enrichments.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_city_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_continent_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_continent_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_country_iso_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_country_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_location": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_postal_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_region_iso_code": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_region_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_geo_timezone": {
+            "path_match": "wazuh.threat.enrichments.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_id": {
+            "path_match": "wazuh.threat.enrichments.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_ip": {
+            "path_match": "wazuh.threat.enrichments.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_last_seen": {
+            "path_match": "wazuh.threat.enrichments.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_marking_tlp": {
+            "path_match": "wazuh.threat.enrichments.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_marking_tlp_version": {
+            "path_match": "wazuh.threat.enrichments.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_modified_at": {
+            "path_match": "wazuh.threat.enrichments.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_port": {
+            "path_match": "wazuh.threat.enrichments.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_provider": {
+            "path_match": "wazuh.threat.enrichments.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_reference": {
+            "path_match": "wazuh.threat.enrichments.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_data_bytes": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_data_strings": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_data_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_hive": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_key": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_path": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_registry_value": {
+            "path_match": "wazuh.threat.enrichments.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_scanner_stats": {
+            "path_match": "wazuh.threat.enrichments.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_sightings": {
+            "path_match": "wazuh.threat.enrichments.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_software_alias": {
+            "path_match": "wazuh.threat.enrichments.indicator.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_software_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_software_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_tags": {
+            "path_match": "wazuh.threat.enrichments.indicator.tags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_type": {
+            "path_match": "wazuh.threat.enrichments.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_alternative_names": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_not_after": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_not_before": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_curve": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_public_key_size": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_serial_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_common_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_country": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_locality": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_organization": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_indicator_x509_version_number": {
+            "path_match": "wazuh.threat.enrichments.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_atomic": {
+            "path_match": "wazuh.threat.enrichments.matched.atomic",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_field": {
+            "path_match": "wazuh.threat.enrichments.matched.field",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_id": {
+            "path_match": "wazuh.threat.enrichments.matched.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_index": {
+            "path_match": "wazuh.threat.enrichments.matched.index",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_occurred": {
+            "path_match": "wazuh.threat.enrichments.matched.occurred",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_enrichments_matched_type": {
+            "path_match": "wazuh.threat.enrichments.matched.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_dashboard_id": {
+            "path_match": "wazuh.threat.feed.dashboard_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_description": {
+            "path_match": "wazuh.threat.feed.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_name": {
+            "path_match": "wazuh.threat.feed.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_feed_reference": {
+            "path_match": "wazuh.threat.feed.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_framework": {
+            "path_match": "wazuh.threat.framework",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_alias": {
+            "path_match": "wazuh.threat.group.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_id": {
+            "path_match": "wazuh.threat.group.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_name": {
+            "path_match": "wazuh.threat.group.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_group_reference": {
+            "path_match": "wazuh.threat.group.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_as_number": {
+            "path_match": "wazuh.threat.indicator.as.number",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_as_organization_name": {
+            "path_match": "wazuh.threat.indicator.as.organization.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_confidence": {
+            "path_match": "wazuh.threat.indicator.confidence",
+            "mapping": {
+              "type": "short"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_description": {
+            "path_match": "wazuh.threat.indicator.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_email_address": {
+            "path_match": "wazuh.threat.indicator.email.address",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_accessed": {
+            "path_match": "wazuh.threat.indicator.file.accessed",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_attributes": {
+            "path_match": "wazuh.threat.indicator.file.attributes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_digest_algorithm": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.digest_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_exists": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.exists",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_flags": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_signing_id": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.signing_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_status": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.status",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_subject_name": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.subject_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_team_id": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.team_id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_thumbprint_sha256": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.thumbprint_sha256",
+            "mapping": {
+              "ignore_above": 64,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_timestamp": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.timestamp",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_trusted": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.trusted",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_code_signature_valid": {
+            "path_match": "wazuh.threat.indicator.file.code_signature.valid",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_created": {
+            "path_match": "wazuh.threat.indicator.file.created",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_ctime": {
+            "path_match": "wazuh.threat.indicator.file.ctime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_device": {
+            "path_match": "wazuh.threat.indicator.file.device",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_directory": {
+            "path_match": "wazuh.threat.indicator.file.directory",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_drive_letter": {
+            "path_match": "wazuh.threat.indicator.file.drive_letter",
+            "mapping": {
+              "ignore_above": 1,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_architecture": {
+            "path_match": "wazuh.threat.indicator.file.elf.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_byte_order": {
+            "path_match": "wazuh.threat.indicator.file.elf.byte_order",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_cpu_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.cpu_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_creation_date": {
+            "path_match": "wazuh.threat.indicator.file.elf.creation_date",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_exports": {
+            "path_match": "wazuh.threat.indicator.file.elf.exports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_imports": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_go_stripped": {
+            "path_match": "wazuh.threat.indicator.file.elf.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_abi_version": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.abi_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_class": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.class",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_data": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.data",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_entrypoint": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.entrypoint",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_object_version": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.object_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_os_abi": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.os_abi",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_header_version": {
+            "path_match": "wazuh.threat.indicator.file.elf.header.version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.elf.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_imports": {
+            "path_match": "wazuh.threat.indicator.file.elf.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_chi2": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.chi2",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_flags": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.flags",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_name": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_physical_offset": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.physical_offset",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_physical_size": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_virtual_address": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.virtual_address",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_sections_virtual_size": {
+            "path_match": "wazuh.threat.indicator.file.elf.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_segments_sections": {
+            "path_match": "wazuh.threat.indicator.file.elf.segments.sections",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_segments_type": {
+            "path_match": "wazuh.threat.indicator.file.elf.segments.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_shared_libraries": {
+            "path_match": "wazuh.threat.indicator.file.elf.shared_libraries",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_elf_telfhash": {
+            "path_match": "wazuh.threat.indicator.file.elf.telfhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_extension": {
+            "path_match": "wazuh.threat.indicator.file.extension",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_fork_name": {
+            "path_match": "wazuh.threat.indicator.file.fork_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_gid": {
+            "path_match": "wazuh.threat.indicator.file.gid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_group": {
+            "path_match": "wazuh.threat.indicator.file.group",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_cdhash": {
+            "path_match": "wazuh.threat.indicator.file.hash.cdhash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_md5": {
+            "path_match": "wazuh.threat.indicator.file.hash.md5",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha1": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha1",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha256": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha256",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha384": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha384",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_sha512": {
+            "path_match": "wazuh.threat.indicator.file.hash.sha512",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_ssdeep": {
+            "path_match": "wazuh.threat.indicator.file.hash.ssdeep",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_hash_tlsh": {
+            "path_match": "wazuh.threat.indicator.file.hash.tlsh",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_inode": {
+            "path_match": "wazuh.threat.indicator.file.inode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_mime_type": {
+            "path_match": "wazuh.threat.indicator.file.mime_type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_mode": {
+            "path_match": "wazuh.threat.indicator.file.mode",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_mtime": {
+            "path_match": "wazuh.threat.indicator.file.mtime",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_name": {
+            "path_match": "wazuh.threat.indicator.file.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_origin_referrer_url": {
+            "path_match": "wazuh.threat.indicator.file.origin_referrer_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_origin_url": {
+            "path_match": "wazuh.threat.indicator.file.origin_url",
+            "mapping": {
+              "ignore_above": 8192,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_owner": {
+            "path_match": "wazuh.threat.indicator.file.owner",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_path": {
+            "path_match": "wazuh.threat.indicator.file.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_architecture": {
+            "path_match": "wazuh.threat.indicator.file.pe.architecture",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_company": {
+            "path_match": "wazuh.threat.indicator.file.pe.company",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_description": {
+            "path_match": "wazuh.threat.indicator.file.pe.description",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_file_version": {
+            "path_match": "wazuh.threat.indicator.file.pe.file_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_imports": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_go_stripped": {
+            "path_match": "wazuh.threat.indicator.file.pe.go_stripped",
+            "mapping": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imphash": {
+            "path_match": "wazuh.threat.indicator.file.pe.imphash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_import_hash": {
+            "path_match": "wazuh.threat.indicator.file.pe.import_hash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imports": {
+            "path_match": "wazuh.threat.indicator.file.pe.imports",
+            "mapping": {
+              "type": "flat_object"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imports_names_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.imports_names_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_imports_names_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.imports_names_var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_original_file_name": {
+            "path_match": "wazuh.threat.indicator.file.pe.original_file_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_pehash": {
+            "path_match": "wazuh.threat.indicator.file.pe.pehash",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_product": {
+            "path_match": "wazuh.threat.indicator.file.pe.product",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_name": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_physical_size": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.physical_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_var_entropy": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.var_entropy",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_pe_sections_virtual_size": {
+            "path_match": "wazuh.threat.indicator.file.pe.sections.virtual_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_size": {
+            "path_match": "wazuh.threat.indicator.file.size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_target_path": {
+            "path_match": "wazuh.threat.indicator.file.target_path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_type": {
+            "path_match": "wazuh.threat.indicator.file.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_uid": {
+            "path_match": "wazuh.threat.indicator.file.uid",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_alternative_names": {
+            "path_match": "wazuh.threat.indicator.file.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_country": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_locality": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_organization": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.indicator.file.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_not_after": {
+            "path_match": "wazuh.threat.indicator.file.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_not_before": {
+            "path_match": "wazuh.threat.indicator.file.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_curve": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_public_key_size": {
+            "path_match": "wazuh.threat.indicator.file.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_serial_number": {
+            "path_match": "wazuh.threat.indicator.file.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.indicator.file.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_common_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_country": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_locality": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_organization": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.indicator.file.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_file_x509_version_number": {
+            "path_match": "wazuh.threat.indicator.file.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_first_seen": {
+            "path_match": "wazuh.threat.indicator.first_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_city_name": {
+            "path_match": "wazuh.threat.indicator.geo.city_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_continent_code": {
+            "path_match": "wazuh.threat.indicator.geo.continent_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_continent_name": {
+            "path_match": "wazuh.threat.indicator.geo.continent_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_country_iso_code": {
+            "path_match": "wazuh.threat.indicator.geo.country_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_country_name": {
+            "path_match": "wazuh.threat.indicator.geo.country_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_location": {
+            "path_match": "wazuh.threat.indicator.geo.location",
+            "mapping": {
+              "type": "geo_point"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_name": {
+            "path_match": "wazuh.threat.indicator.geo.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_postal_code": {
+            "path_match": "wazuh.threat.indicator.geo.postal_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_region_iso_code": {
+            "path_match": "wazuh.threat.indicator.geo.region_iso_code",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_region_name": {
+            "path_match": "wazuh.threat.indicator.geo.region_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_geo_timezone": {
+            "path_match": "wazuh.threat.indicator.geo.timezone",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_id": {
+            "path_match": "wazuh.threat.indicator.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_ip": {
+            "path_match": "wazuh.threat.indicator.ip",
+            "mapping": {
+              "type": "ip"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_last_seen": {
+            "path_match": "wazuh.threat.indicator.last_seen",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_marking_tlp": {
+            "path_match": "wazuh.threat.indicator.marking.tlp",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_marking_tlp_version": {
+            "path_match": "wazuh.threat.indicator.marking.tlp_version",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_modified_at": {
+            "path_match": "wazuh.threat.indicator.modified_at",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_name": {
+            "path_match": "wazuh.threat.indicator.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_port": {
+            "path_match": "wazuh.threat.indicator.port",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_provider": {
+            "path_match": "wazuh.threat.indicator.provider",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_reference": {
+            "path_match": "wazuh.threat.indicator.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_data_bytes": {
+            "path_match": "wazuh.threat.indicator.registry.data.bytes",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_data_strings": {
+            "path_match": "wazuh.threat.indicator.registry.data.strings",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_data_type": {
+            "path_match": "wazuh.threat.indicator.registry.data.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_hive": {
+            "path_match": "wazuh.threat.indicator.registry.hive",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_key": {
+            "path_match": "wazuh.threat.indicator.registry.key",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_path": {
+            "path_match": "wazuh.threat.indicator.registry.path",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_registry_value": {
+            "path_match": "wazuh.threat.indicator.registry.value",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_scanner_stats": {
+            "path_match": "wazuh.threat.indicator.scanner_stats",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_sightings": {
+            "path_match": "wazuh.threat.indicator.sightings",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_type": {
+            "path_match": "wazuh.threat.indicator.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_alternative_names": {
+            "path_match": "wazuh.threat.indicator.x509.alternative_names",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_common_name": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_country": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_locality": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_organization": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_issuer_state_or_province": {
+            "path_match": "wazuh.threat.indicator.x509.issuer.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_not_after": {
+            "path_match": "wazuh.threat.indicator.x509.not_after",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_not_before": {
+            "path_match": "wazuh.threat.indicator.x509.not_before",
+            "mapping": {
+              "type": "date"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_algorithm": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_curve": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_curve",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_exponent": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_exponent",
+            "mapping": {
+              "doc_values": false,
+              "index": false,
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_public_key_size": {
+            "path_match": "wazuh.threat.indicator.x509.public_key_size",
+            "mapping": {
+              "type": "long"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_serial_number": {
+            "path_match": "wazuh.threat.indicator.x509.serial_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_signature_algorithm": {
+            "path_match": "wazuh.threat.indicator.x509.signature_algorithm",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_common_name": {
+            "path_match": "wazuh.threat.indicator.x509.subject.common_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_country": {
+            "path_match": "wazuh.threat.indicator.x509.subject.country",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_distinguished_name": {
+            "path_match": "wazuh.threat.indicator.x509.subject.distinguished_name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_locality": {
+            "path_match": "wazuh.threat.indicator.x509.subject.locality",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_organization": {
+            "path_match": "wazuh.threat.indicator.x509.subject.organization",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_organizational_unit": {
+            "path_match": "wazuh.threat.indicator.x509.subject.organizational_unit",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_subject_state_or_province": {
+            "path_match": "wazuh.threat.indicator.x509.subject.state_or_province",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_indicator_x509_version_number": {
+            "path_match": "wazuh.threat.indicator.x509.version_number",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_alias": {
+            "path_match": "wazuh.threat.software.alias",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_id": {
+            "path_match": "wazuh.threat.software.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_name": {
+            "path_match": "wazuh.threat.software.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_platforms": {
+            "path_match": "wazuh.threat.software.platforms",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_reference": {
+            "path_match": "wazuh.threat.software.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_software_type": {
+            "path_match": "wazuh.threat.software.type",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_tactic_id": {
+            "path_match": "wazuh.threat.tactic.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_tactic_name": {
+            "path_match": "wazuh.threat.tactic.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_tactic_reference": {
+            "path_match": "wazuh.threat.tactic.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_id": {
+            "path_match": "wazuh.threat.technique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_name": {
+            "path_match": "wazuh.threat.technique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_reference": {
+            "path_match": "wazuh.threat.technique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_subtechnique_id": {
+            "path_match": "wazuh.threat.technique.subtechnique.id",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_subtechnique_name": {
+            "path_match": "wazuh.threat.technique.subtechnique.name",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        {
+          "wcs_wazuh_threat_technique_subtechnique_reference": {
+            "path_match": "wazuh.threat.technique.subtechnique.reference",
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      ],
+      "properties": {
         "agent": {
           "properties": {
             "build": {
-              "properties": {
-                "original": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ephemeral_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "groups": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "check": {
           "properties": {
             "compliance": {
-              "properties": {
-                "cmmc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "fedramp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "gdpr": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "hipaa": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "iso_27001": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nis2": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_171": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_53": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pci_dss": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tsc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "condition": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "mitre": {
               "properties": {
                 "subtechnique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "tactic": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "technique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 }
               }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "rationale": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reason": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "references": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "remediation": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "result": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "rules": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "client": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -366,520 +20602,125 @@
         "cloud": {
           "properties": {
             "account": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "availability_zone": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "instance": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "machine": {
-              "properties": {
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "origin": {
               "properties": {
                 "account": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "availability_zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "instance": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "machine": {
-                  "properties": {
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "project": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "provider": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "service": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             },
             "project": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "provider": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "region": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "service": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "target": {
               "properties": {
                 "account": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "availability_zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "instance": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "machine": {
-                  "properties": {
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "project": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "provider": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "service": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             }
           }
         },
         "compliance": {
-          "properties": {
-            "cmmc": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "fedramp": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "gdpr": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "hipaa": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "iso_27001": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nis2": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nist_800_171": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nist_800_53": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "pci_dss": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "tsc": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "container": {
           "properties": {
             "cpu": {
-              "properties": {
-                "usage": {
-                  "scaling_factor": 1000,
-                  "type": "scaled_float"
-                }
-              }
+              "properties": {}
             },
             "disk": {
               "properties": {
                 "read": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "write": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "image": {
               "properties": {
                 "hash": {
-                  "properties": {
-                    "all": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tag": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "labels": {
-              "type": "object"
             },
             "memory": {
-              "properties": {
-                "usage": {
-                  "scaling_factor": 1000,
-                  "type": "scaled_float"
-                }
-              }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "network": {
               "properties": {
                 "egress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "ingress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "runtime": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "security_context": {
-              "properties": {
-                "privileged": {
-                  "type": "boolean"
-                }
-              }
+              "properties": {}
             }
           }
         },
         "data_stream": {
-          "properties": {
-            "dataset": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "namespace": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "destination": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -887,213 +20728,23 @@
         },
         "device": {
           "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "manufacturer": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "model": {
-              "properties": {
-                "identifier": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "dll": {
           "properties": {
             "code_signature": {
-              "properties": {
-                "digest_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exists": {
-                  "type": "boolean"
-                },
-                "flags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signing_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "team_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "thumbprint_sha256": {
-                  "ignore_above": 64,
-                  "type": "keyword"
-                },
-                "timestamp": {
-                  "type": "date"
-                },
-                "trusted": {
-                  "type": "boolean"
-                },
-                "valid": {
-                  "type": "boolean"
-                }
-              }
+              "properties": {}
             },
             "hash": {
-              "properties": {
-                "cdhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "md5": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha1": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha256": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha384": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha512": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ssdeep": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tlsh": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "origin_referrer_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "origin_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "pe": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "company": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "file_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "imphash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pehash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "product": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 }
               }
             }
@@ -1102,79 +20753,10 @@
         "dns": {
           "properties": {
             "answers": {
-              "properties": {
-                "class": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "data": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ttl": {
-                  "type": "long"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "header_flags": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "op_code": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "question": {
-              "properties": {
-                "class": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "registered_domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subdomain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "top_level_domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "resolved_ip": {
-              "type": "ip"
-            },
-            "response_code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
@@ -1184,883 +20766,88 @@
               "properties": {
                 "file": {
                   "properties": {
-                    "extension": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "hash": {
-                      "properties": {
-                        "cdhash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "md5": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha1": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha256": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha384": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha512": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "ssdeep": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlsh": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "mime_type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "size": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
                 }
-              },
-              "type": "nested"
+              }
             },
             "bcc": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "cc": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "content_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "delivery_timestamp": {
-              "type": "date"
-            },
-            "direction": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "from": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "local_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "message_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "origination_timestamp": {
-              "type": "date"
+              "properties": {}
             },
             "reply_to": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "sender": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "subject": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "to": {
-              "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "x_mailer": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "error": {
-          "properties": {
-            "code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "message": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "stack_trace": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "event": {
-          "properties": {
-            "action": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "agent_id_status": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "changed_fields": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "collector": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "created": {
-              "type": "date"
-            },
-            "dataset": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "doc_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "duration": {
-              "type": "long"
-            },
-            "end": {
-              "type": "date"
-            },
-            "hash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "index": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "kind": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "module": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            },
-            "outcome": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "provider": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reason": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reference": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "risk_score": {
-              "type": "float"
-            },
-            "risk_score_norm": {
-              "type": "float"
-            },
-            "sequence": {
-              "type": "long"
-            },
-            "severity": {
-              "type": "long"
-            },
-            "start": {
-              "type": "date"
-            },
-            "timezone": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "url": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "faas": {
           "properties": {
-            "coldstart": {
-              "type": "boolean"
-            },
-            "execution": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "trigger": {
-              "properties": {
-                "request_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "file": {
           "properties": {
-            "accessed": {
-              "type": "date"
-            },
-            "attributes": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "code_signature": {
-              "properties": {
-                "digest_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exists": {
-                  "type": "boolean"
-                },
-                "flags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signing_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "team_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "thumbprint_sha256": {
-                  "ignore_above": 64,
-                  "type": "keyword"
-                },
-                "timestamp": {
-                  "type": "date"
-                },
-                "trusted": {
-                  "type": "boolean"
-                },
-                "valid": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "created": {
-              "type": "date"
-            },
-            "ctime": {
-              "type": "date"
-            },
-            "device": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "diff": {
-              "type": "match_only_text"
-            },
-            "directory": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "drive_letter": {
-              "ignore_above": 1,
-              "type": "keyword"
+              "properties": {}
             },
             "elf": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "byte_order": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "cpu_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "creation_date": {
-                  "type": "date"
-                },
-                "exports": {
-                  "type": "flat_object"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
                 "header": {
-                  "properties": {
-                    "abi_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "class": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "data": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "entrypoint": {
-                      "type": "long"
-                    },
-                    "object_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os_abi": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
+                  "properties": {}
                 },
                 "sections": {
-                  "properties": {
-                    "chi2": {
-                      "type": "long"
-                    },
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "flags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_offset": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_address": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 },
                 "segments": {
-                  "properties": {
-                    "sections": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "shared_libraries": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "telfhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "extension": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "fork_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "gid": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "group": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "hash": {
-              "properties": {
-                "cdhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "md5": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha1": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha256": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha384": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha512": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ssdeep": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tlsh": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "inode": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "macho": {
               "properties": {
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "symhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "mime_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mode": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mtime": {
-              "type": "date"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "origin_referrer_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "origin_url": {
-              "ignore_above": 8192,
-              "type": "keyword"
-            },
-            "owner": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "pe": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "company": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "file_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "imphash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pehash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "product": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 }
               }
             },
-            "size": {
-              "type": "long"
-            },
-            "target_path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "uid": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "x509": {
               "properties": {
-                "alternative_names": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "issuer": {
-                  "properties": {
-                    "common_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "distinguished_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "locality": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organization": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organizational_unit": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "state_or_province": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "not_after": {
-                  "type": "date"
-                },
-                "not_before": {
-                  "type": "date"
-                },
-                "public_key_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "public_key_curve": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "public_key_exponent": {
-                  "doc_values": false,
-                  "index": false,
-                  "type": "long"
-                },
-                "public_key_size": {
-                  "type": "long"
-                },
-                "serial_number": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signature_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "subject": {
-                  "properties": {
-                    "common_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "distinguished_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "locality": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organization": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "organizational_unit": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "state_or_province": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "version_number": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -2069,406 +20856,85 @@
         "gen_ai": {
           "properties": {
             "agent": {
-              "properties": {
-                "description": {
-                  "doc_values": false,
-                  "index": false,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "operation": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "output": {
-              "properties": {
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "request": {
               "properties": {
                 "choice": {
-                  "properties": {
-                    "count": {
-                      "type": "integer"
-                    }
-                  }
-                },
-                "encoding_formats": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "frequency_penalty": {
-                  "type": "double"
-                },
-                "max_tokens": {
-                  "type": "integer"
-                },
-                "model": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "presence_penalty": {
-                  "type": "double"
-                },
-                "seed": {
-                  "type": "integer"
-                },
-                "stop_sequences": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "temperature": {
-                  "type": "double"
-                },
-                "top_k": {
-                  "type": "double"
-                },
-                "top_p": {
-                  "type": "double"
+                  "properties": {}
                 }
               }
             },
             "response": {
-              "properties": {
-                "finish_reasons": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "model": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "system": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "token": {
-              "properties": {
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "tool": {
               "properties": {
                 "call": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "usage": {
-              "properties": {
-                "input_tokens": {
-                  "type": "integer"
-                },
-                "output_tokens": {
-                  "type": "integer"
-                }
-              }
+              "properties": {}
             }
           }
         },
         "group": {
-          "properties": {
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "host": {
           "properties": {
-            "architecture": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "boot": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "cpu": {
-              "properties": {
-                "cores": {
-                  "type": "long"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "speed": {
-                  "type": "long"
-                },
-                "usage": {
-                  "scaling_factor": 1000,
-                  "type": "scaled_float"
-                }
-              },
-              "type": "object"
+              "properties": {}
             },
             "disk": {
               "properties": {
                 "read": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "write": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "memory": {
               "properties": {
-                "free": {
-                  "type": "long"
-                },
-                "total": {
-                  "type": "long"
-                },
                 "used": {
-                  "properties": {
-                    "percentage": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 }
-              },
-              "type": "object"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              }
             },
             "network": {
               "properties": {
                 "egress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "drops": {
-                      "type": "long"
-                    },
-                    "errors": {
-                      "type": "long"
-                    },
-                    "packets": {
-                      "type": "long"
-                    },
-                    "queue": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "ingress": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "drops": {
-                      "type": "long"
-                    },
-                    "errors": {
-                      "type": "long"
-                    },
-                    "packets": {
-                      "type": "long"
-                    },
-                    "queue": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             },
             "os": {
-              "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "kernel": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platform": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "pid_ns_ino": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "risk": {
-              "properties": {
-                "calculated_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "calculated_score": {
-                  "type": "float"
-                },
-                "calculated_score_norm": {
-                  "type": "float"
-                },
-                "static_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "static_score": {
-                  "type": "float"
-                },
-                "static_score_norm": {
-                  "type": "float"
-                }
-              }
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "uptime": {
-              "type": "long"
+              "properties": {}
             }
           }
         },
@@ -2477,324 +20943,70 @@
             "request": {
               "properties": {
                 "body": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "content": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "bytes": {
-                  "type": "long"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "method": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "mime_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "referrer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "response": {
               "properties": {
                 "body": {
-                  "properties": {
-                    "bytes": {
-                      "type": "long"
-                    },
-                    "content": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "bytes": {
-                  "type": "long"
-                },
-                "mime_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status_code": {
-                  "type": "long"
+                  "properties": {}
                 }
               }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "interface": {
-          "properties": {
-            "alias": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mtu": {
-              "type": "long"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "labels": {
-          "type": "object"
+          "properties": {}
         },
         "log": {
           "properties": {
             "file": {
-              "properties": {
-                "path": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "level": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "logger": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "origin": {
               "properties": {
                 "file": {
-                  "properties": {
-                    "line": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "function": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "syslog": {
               "properties": {
-                "appname": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "facility": {
-                  "properties": {
-                    "code": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hostname": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "msgid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "priority": {
-                  "type": "long"
-                },
-                "procid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "severity": {
-                  "properties": {
-                    "code": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "structured_data": {
-                  "type": "flat_object"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
-              },
-              "type": "object"
+              }
             }
           }
-        },
-        "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
         },
         "mitre": {
           "properties": {
             "subtechnique": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
+              "properties": {}
             },
             "tactic": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
+              "properties": {}
             },
             "technique": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
+              "properties": {}
             }
           }
         },
         "network": {
           "properties": {
-            "application": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "broadcast": {
-              "type": "ip"
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "community_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "dhcp": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "direction": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "forwarded_ip": {
-              "type": "ip"
-            },
-            "gateway": {
-              "type": "ip"
-            },
-            "iana_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "inner": {
               "properties": {
                 "vlan": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                }
-              },
-              "type": "object"
-            },
-            "metric": {
-              "type": "long"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "netmask": {
-              "type": "ip"
-            },
-            "packets": {
-              "type": "long"
-            },
-            "protocol": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "transport": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "vlan": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
+            },
+            "vlan": {
+              "properties": {}
             }
           }
         },
@@ -2804,2517 +21016,402 @@
               "properties": {
                 "interface": {
                   "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mtu": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "observer": {
                       "properties": {
                         "ingress": {
                           "properties": {
                             "interface": {
-                              "properties": {
-                                "alias": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "id": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "mtu": {
-                                  "type": "long"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
+                              "properties": {}
                             }
                           }
                         }
                       }
-                    },
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     }
                   }
                 },
                 "vlan": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "geo": {
+              "properties": {}
             },
             "ingress": {
               "properties": {
                 "interface": {
-                  "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mtu": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "vlan": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "zone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "os": {
-              "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "kernel": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platform": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "product": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "vendor": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "os": {
+              "properties": {}
             }
           }
         },
         "orchestrator": {
           "properties": {
-            "api_version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "cluster": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "url": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "namespace": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "organization": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "resource": {
               "properties": {
-                "annotation": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ip": {
-                  "type": "ip"
-                },
-                "label": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "parent": {
-                  "properties": {
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "organization": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "package": {
           "properties": {
-            "architecture": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "build_version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "checksum": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "install_scope": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "installed": {
-              "type": "date"
-            },
-            "license": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "previous": {
-              "properties": {
-                "installed": {
-                  "type": "date"
-                }
-              }
-            },
-            "reference": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "size": {
-              "type": "long"
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "policy": {
-          "properties": {
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "file": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "references": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "process": {
           "properties": {
-            "args": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "args_count": {
-              "type": "long"
-            },
             "code_signature": {
-              "properties": {
-                "digest_algorithm": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exists": {
-                  "type": "boolean"
-                },
-                "flags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "signing_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "team_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "thumbprint_sha256": {
-                  "ignore_above": 64,
-                  "type": "keyword"
-                },
-                "timestamp": {
-                  "type": "date"
-                },
-                "trusted": {
-                  "type": "boolean"
-                },
-                "valid": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "command_line": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "elf": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "byte_order": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "cpu_type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "creation_date": {
-                  "type": "date"
-                },
-                "exports": {
-                  "type": "flat_object"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
                 "header": {
-                  "properties": {
-                    "abi_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "class": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "data": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "entrypoint": {
-                      "type": "long"
-                    },
-                    "object_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "os_abi": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
+                  "properties": {}
                 },
                 "sections": {
-                  "properties": {
-                    "chi2": {
-                      "type": "long"
-                    },
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "flags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_offset": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_address": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 },
                 "segments": {
-                  "properties": {
-                    "sections": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "shared_libraries": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "telfhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "end": {
-              "type": "date"
-            },
-            "entity_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "entry_leader": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
                 "attested_groups": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "attested_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "entry_meta": {
                   "properties": {
                     "source": {
-                      "properties": {
-                        "ip": {
-                          "type": "ip"
-                        }
-                      }
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "parent": {
                   "properties": {
-                    "entity_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pid": {
-                      "type": "long"
-                    },
                     "session_leader": {
-                      "properties": {
-                        "entity_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "pid": {
-                          "type": "long"
-                        },
-                        "start": {
-                          "type": "date"
-                        },
-                        "vpid": {
-                          "type": "long"
-                        }
-                      }
-                    },
-                    "start": {
-                      "type": "date"
-                    },
-                    "vpid": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
-                },
-                "pid": {
-                  "type": "long"
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "same_as_process": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
-            },
-            "env_vars": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "executable": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "exit_code": {
-              "type": "long"
             },
             "group": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "group_leader": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pid": {
-                  "type": "long"
+                  "properties": {}
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "same_as_process": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
             },
             "hash": {
-              "properties": {
-                "cdhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "md5": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha1": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha256": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha384": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sha512": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ssdeep": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tlsh": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "interactive": {
-              "type": "boolean"
+              "properties": {}
             },
             "io": {
               "properties": {
                 "bytes_skipped": {
-                  "properties": {
-                    "length": {
-                      "type": "long"
-                    },
-                    "offset": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "object"
-                },
-                "max_bytes_per_process_exceeded": {
-                  "type": "boolean"
-                },
-                "text": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "total_bytes_captured": {
-                  "type": "long"
-                },
-                "total_bytes_skipped": {
-                  "type": "long"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "type": "object"
-            },
-            "macho": {
-              "properties": {
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "symhash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "macho": {
+              "properties": {
+                "sections": {
+                  "properties": {}
+                }
+              }
             },
             "parent": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
                 "code_signature": {
-                  "properties": {
-                    "digest_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "exists": {
-                      "type": "boolean"
-                    },
-                    "flags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signing_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "status": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "subject_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "team_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "thumbprint_sha256": {
-                      "ignore_above": 64,
-                      "type": "keyword"
-                    },
-                    "timestamp": {
-                      "type": "date"
-                    },
-                    "trusted": {
-                      "type": "boolean"
-                    },
-                    "valid": {
-                      "type": "boolean"
-                    }
-                  }
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "elf": {
                   "properties": {
-                    "architecture": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "byte_order": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "cpu_type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "creation_date": {
-                      "type": "date"
-                    },
-                    "exports": {
-                      "type": "flat_object"
-                    },
-                    "go_import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_imports": {
-                      "type": "flat_object"
-                    },
-                    "go_imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "go_imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "go_stripped": {
-                      "type": "boolean"
-                    },
                     "header": {
-                      "properties": {
-                        "abi_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "class": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "data": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "entrypoint": {
-                          "type": "long"
-                        },
-                        "object_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "os_abi": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "imports": {
-                      "type": "flat_object"
-                    },
-                    "imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "imports_names_var_entropy": {
-                      "type": "long"
+                      "properties": {}
                     },
                     "sections": {
-                      "properties": {
-                        "chi2": {
-                          "type": "long"
-                        },
-                        "entropy": {
-                          "type": "long"
-                        },
-                        "flags": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_offset": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_size": {
-                          "type": "long"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "var_entropy": {
-                          "type": "long"
-                        },
-                        "virtual_address": {
-                          "type": "long"
-                        },
-                        "virtual_size": {
-                          "type": "long"
-                        }
-                      },
-                      "type": "nested"
+                      "properties": {}
                     },
                     "segments": {
-                      "properties": {
-                        "sections": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "nested"
-                    },
-                    "shared_libraries": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "telfhash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "end": {
-                  "type": "date"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "exit_code": {
-                  "type": "long"
                 },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "group_leader": {
-                  "properties": {
-                    "entity_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pid": {
-                      "type": "long"
-                    },
-                    "start": {
-                      "type": "date"
-                    },
-                    "vpid": {
-                      "type": "long"
-                    }
-                  }
+                  "properties": {}
                 },
                 "hash": {
-                  "properties": {
-                    "cdhash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "md5": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha1": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha256": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha384": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha512": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ssdeep": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "tlsh": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "macho": {
                   "properties": {
-                    "go_import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_imports": {
-                      "type": "flat_object"
-                    },
-                    "go_imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "go_imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "go_stripped": {
-                      "type": "boolean"
-                    },
-                    "import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "imports": {
-                      "type": "flat_object"
-                    },
-                    "imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "imports_names_var_entropy": {
-                      "type": "long"
-                    },
                     "sections": {
-                      "properties": {
-                        "entropy": {
-                          "type": "long"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_size": {
-                          "type": "long"
-                        },
-                        "var_entropy": {
-                          "type": "long"
-                        },
-                        "virtual_size": {
-                          "type": "long"
-                        }
-                      },
-                      "type": "nested"
-                    },
-                    "symhash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "pe": {
                   "properties": {
-                    "architecture": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "company": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "file_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "go_imports": {
-                      "type": "flat_object"
-                    },
-                    "go_imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "go_imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "go_stripped": {
-                      "type": "boolean"
-                    },
-                    "imphash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "import_hash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "imports": {
-                      "type": "flat_object"
-                    },
-                    "imports_names_entropy": {
-                      "type": "long"
-                    },
-                    "imports_names_var_entropy": {
-                      "type": "long"
-                    },
-                    "original_file_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pehash": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "product": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "sections": {
-                      "properties": {
-                        "entropy": {
-                          "type": "long"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "physical_size": {
-                          "type": "long"
-                        },
-                        "var_entropy": {
-                          "type": "long"
-                        },
-                        "virtual_size": {
-                          "type": "long"
-                        }
-                      },
-                      "type": "nested"
+                      "properties": {}
                     }
                   }
-                },
-                "pid": {
-                  "type": "long"
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "thread": {
                   "properties": {
                     "capabilities": {
-                      "properties": {
-                        "effective": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "permitted": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "id": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "title": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "uptime": {
-                  "type": "long"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
             },
             "pe": {
               "properties": {
-                "architecture": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "company": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "file_version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "go_imports": {
-                  "type": "flat_object"
-                },
-                "go_imports_names_entropy": {
-                  "type": "long"
-                },
-                "go_imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "go_stripped": {
-                  "type": "boolean"
-                },
-                "imphash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "import_hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "imports": {
-                  "type": "flat_object"
-                },
-                "imports_names_entropy": {
-                  "type": "long"
-                },
-                "imports_names_var_entropy": {
-                  "type": "long"
-                },
-                "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pehash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "product": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "sections": {
-                  "properties": {
-                    "entropy": {
-                      "type": "long"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "physical_size": {
-                      "type": "long"
-                    },
-                    "var_entropy": {
-                      "type": "long"
-                    },
-                    "virtual_size": {
-                      "type": "long"
-                    }
-                  },
-                  "type": "nested"
+                  "properties": {}
                 }
               }
             },
-            "pid": {
-              "type": "long"
-            },
             "previous": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "parent": {
-                  "properties": {
-                    "pid": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "pid": {
-                  "type": "long"
-                },
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "real_group": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "real_user": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "saved_group": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "saved_user": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "session_leader": {
               "properties": {
-                "args": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "args_count": {
-                  "type": "long"
-                },
-                "command_line": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "entity_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "executable": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "interactive": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "parent": {
                   "properties": {
-                    "entity_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pid": {
-                      "type": "long"
-                    },
                     "session_leader": {
-                      "properties": {
-                        "entity_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "pid": {
-                          "type": "long"
-                        },
-                        "start": {
-                          "type": "date"
-                        },
-                        "vpid": {
-                          "type": "long"
-                        }
-                      }
-                    },
-                    "start": {
-                      "type": "date"
-                    },
-                    "vpid": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
-                },
-                "pid": {
-                  "type": "long"
                 },
                 "real_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "real_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "same_as_process": {
-                  "type": "boolean"
+                  "properties": {}
                 },
                 "saved_group": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "saved_user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "start": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "supplemental_groups": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tty": {
                   "properties": {
                     "char_device": {
-                      "properties": {
-                        "major": {
-                          "type": "long"
-                        },
-                        "minor": {
-                          "type": "long"
-                        }
-                      }
-                    }
-                  },
-                  "type": "object"
-                },
-                "user": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 },
-                "vpid": {
-                  "type": "long"
-                },
-                "working_directory": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "user": {
+                  "properties": {}
                 }
               }
-            },
-            "start": {
-              "type": "date"
-            },
-            "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "supplemental_groups": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "thread": {
               "properties": {
                 "capabilities": {
-                  "properties": {
-                    "effective": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "permitted": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "id": {
-                  "type": "long"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "title": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "tty": {
               "properties": {
                 "char_device": {
-                  "properties": {
-                    "major": {
-                      "type": "long"
-                    },
-                    "minor": {
-                      "type": "long"
-                    }
-                  }
-                },
-                "columns": {
-                  "type": "long"
-                },
-                "rows": {
-                  "type": "long"
-                }
-              },
-              "type": "object"
-            },
-            "uptime": {
-              "type": "long"
-            },
-            "user": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
-            "vpid": {
-              "type": "long"
-            },
-            "working_directory": {
-              "ignore_above": 1024,
-              "type": "keyword"
+            "user": {
+              "properties": {}
             }
           }
         },
         "registry": {
           "properties": {
             "data": {
-              "properties": {
-                "bytes": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "strings": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "hive": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "key": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "value": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "related": {
-          "properties": {
-            "hash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "hosts": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "user": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "rule": {
           "properties": {
-            "author": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "compliance": {
-              "properties": {
-                "cmmc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "fedramp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "gdpr": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "hipaa": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "iso_27001": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nis2": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_171": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "nist_800_53": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "pci_dss": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tsc": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "level": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "license": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "mitre": {
               "properties": {
                 "subtechnique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "tactic": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 },
                 "technique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  },
-                  "type": "object"
+                  "properties": {}
                 }
               }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "reference": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ruleset": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "sigma_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "status": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "tags": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "title": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "uuid": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "server": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -5322,355 +21419,60 @@
         },
         "service": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "environment": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "ephemeral_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "node": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "role": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "origin": {
               "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "environment": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ephemeral_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "node": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "role": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "roles": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "previous": {
-                  "properties": {
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             },
             "previous": {
-              "properties": {
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "state": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "target": {
               "properties": {
-                "address": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "environment": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ephemeral_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "node": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "role": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "roles": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "previous": {
-                  "properties": {
-                    "state": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "state": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "source": {
           "properties": {
-            "address": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "as": {
               "properties": {
-                "number": {
-                  "type": "long"
-                },
                 "organization": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
-            },
-            "bytes": {
-              "type": "long"
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "geo": {
-              "properties": {
-                "city_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "continent_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "country_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "location": {
-                  "type": "geo_point"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "postal_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_iso_code": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "region_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "timezone": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "ip": {
-              "type": "ip"
-            },
-            "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "nat": {
-              "properties": {
-                "ip": {
-                  "type": "ip"
-                },
-                "port": {
-                  "type": "long"
-                }
-              }
-            },
-            "packets": {
-              "type": "long"
-            },
-            "port": {
-              "type": "long"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "user": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
           }
         },
         "span": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "tags": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "properties": {}
         },
         "threat": {
           "properties": {
@@ -5680,1876 +21482,189 @@
                   "properties": {
                     "as": {
                       "properties": {
-                        "number": {
-                          "type": "long"
-                        },
                         "organization": {
-                          "properties": {
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
-                    },
-                    "confidence": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "email": {
-                      "properties": {
-                        "address": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "feed": {
-                      "properties": {
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "file": {
                       "properties": {
-                        "accessed": {
-                          "type": "date"
-                        },
-                        "attributes": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "code_signature": {
-                          "properties": {
-                            "digest_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "exists": {
-                              "type": "boolean"
-                            },
-                            "flags": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signing_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "status": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "subject_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "team_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "thumbprint_sha256": {
-                              "ignore_above": 64,
-                              "type": "keyword"
-                            },
-                            "timestamp": {
-                              "type": "date"
-                            },
-                            "trusted": {
-                              "type": "boolean"
-                            },
-                            "valid": {
-                              "type": "boolean"
-                            }
-                          }
-                        },
-                        "created": {
-                          "type": "date"
-                        },
-                        "ctime": {
-                          "type": "date"
-                        },
-                        "device": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "directory": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "drive_letter": {
-                          "ignore_above": 1,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "elf": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "byte_order": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "cpu_type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "creation_date": {
-                              "type": "date"
-                            },
-                            "exports": {
-                              "type": "flat_object"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
                             "header": {
-                              "properties": {
-                                "abi_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "class": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "data": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "entrypoint": {
-                                  "type": "long"
-                                },
-                                "object_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "os_abi": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
+                              "properties": {}
                             },
                             "sections": {
-                              "properties": {
-                                "chi2": {
-                                  "type": "long"
-                                },
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "flags": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_offset": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_address": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             },
                             "segments": {
-                              "properties": {
-                                "sections": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "nested"
-                            },
-                            "shared_libraries": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "telfhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
-                        },
-                        "extension": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "fork_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "gid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "group": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "hash": {
-                          "properties": {
-                            "cdhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "md5": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha1": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha256": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha384": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha512": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "ssdeep": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "tlsh": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "inode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mime_type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mtime": {
-                          "type": "date"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "origin_referrer_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "origin_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "owner": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "pe": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "company": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "description": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "file_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
-                            "imphash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "original_file_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "pehash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "product": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "sections": {
-                              "properties": {
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             }
                           }
-                        },
-                        "size": {
-                          "type": "long"
-                        },
-                        "target_path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "uid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "x509": {
                           "properties": {
-                            "alternative_names": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "issuer": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "not_after": {
-                              "type": "date"
-                            },
-                            "not_before": {
-                              "type": "date"
-                            },
-                            "public_key_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_curve": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_exponent": {
-                              "doc_values": false,
-                              "index": false,
-                              "type": "long"
-                            },
-                            "public_key_size": {
-                              "type": "long"
-                            },
-                            "serial_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signature_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "subject": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "version_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         }
                       }
                     },
-                    "first_seen": {
-                      "type": "date"
-                    },
                     "geo": {
-                      "properties": {
-                        "city_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "location": {
-                          "type": "geo_point"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "postal_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "timezone": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ip": {
-                      "type": "ip"
-                    },
-                    "last_seen": {
-                      "type": "date"
+                      "properties": {}
                     },
                     "marking": {
-                      "properties": {
-                        "tlp": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlp_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "modified_at": {
-                      "type": "date"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "port": {
-                      "type": "long"
-                    },
-                    "provider": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "registry": {
                       "properties": {
                         "data": {
-                          "properties": {
-                            "bytes": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "strings": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "hive": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "key": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "value": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
-                    },
-                    "scanner_stats": {
-                      "type": "long"
-                    },
-                    "sightings": {
-                      "type": "long"
                     },
                     "software": {
-                      "properties": {
-                        "alias": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "tags": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "url": {
-                      "properties": {
-                        "domain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "extension": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "fragment": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "full": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "original": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "password": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "port": {
-                          "type": "long"
-                        },
-                        "query": {
-                          "ignore_above": 2083,
-                          "type": "keyword"
-                        },
-                        "registered_domain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "scheme": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "subdomain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "top_level_domain": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "username": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "x509": {
                       "properties": {
-                        "alternative_names": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "issuer": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "not_after": {
-                          "type": "date"
-                        },
-                        "not_before": {
-                          "type": "date"
-                        },
-                        "public_key_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_curve": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_exponent": {
-                          "doc_values": false,
-                          "index": false,
-                          "type": "long"
-                        },
-                        "public_key_size": {
-                          "type": "long"
-                        },
-                        "serial_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signature_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "subject": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "version_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     }
-                  },
-                  "type": "object"
+                  }
                 },
                 "matched": {
-                  "properties": {
-                    "atomic": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "field": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "index": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "occurred": {
-                      "type": "date"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
-              },
-              "type": "object"
+              }
             },
             "feed": {
-              "properties": {
-                "dashboard_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "framework": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "group": {
-              "properties": {
-                "alias": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "indicator": {
               "properties": {
                 "as": {
                   "properties": {
-                    "number": {
-                      "type": "long"
-                    },
                     "organization": {
-                      "properties": {
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     }
                   }
-                },
-                "confidence": {
-                  "type": "short"
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "email": {
-                  "properties": {
-                    "address": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "file": {
                   "properties": {
-                    "accessed": {
-                      "type": "date"
-                    },
-                    "attributes": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "code_signature": {
-                      "properties": {
-                        "digest_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "exists": {
-                          "type": "boolean"
-                        },
-                        "flags": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signing_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "status": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "subject_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "team_id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "thumbprint_sha256": {
-                          "ignore_above": 64,
-                          "type": "keyword"
-                        },
-                        "timestamp": {
-                          "type": "date"
-                        },
-                        "trusted": {
-                          "type": "boolean"
-                        },
-                        "valid": {
-                          "type": "boolean"
-                        }
-                      }
-                    },
-                    "created": {
-                      "type": "date"
-                    },
-                    "ctime": {
-                      "type": "date"
-                    },
-                    "device": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "directory": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "drive_letter": {
-                      "ignore_above": 1,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "elf": {
                       "properties": {
-                        "architecture": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "byte_order": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "cpu_type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "creation_date": {
-                          "type": "date"
-                        },
-                        "exports": {
-                          "type": "flat_object"
-                        },
-                        "go_import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "go_imports": {
-                          "type": "flat_object"
-                        },
-                        "go_imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "go_imports_names_var_entropy": {
-                          "type": "long"
-                        },
-                        "go_stripped": {
-                          "type": "boolean"
-                        },
                         "header": {
-                          "properties": {
-                            "abi_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "class": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "data": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "entrypoint": {
-                              "type": "long"
-                            },
-                            "object_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "os_abi": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "imports": {
-                          "type": "flat_object"
-                        },
-                        "imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "imports_names_var_entropy": {
-                          "type": "long"
+                          "properties": {}
                         },
                         "sections": {
-                          "properties": {
-                            "chi2": {
-                              "type": "long"
-                            },
-                            "entropy": {
-                              "type": "long"
-                            },
-                            "flags": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "physical_offset": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "physical_size": {
-                              "type": "long"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "var_entropy": {
-                              "type": "long"
-                            },
-                            "virtual_address": {
-                              "type": "long"
-                            },
-                            "virtual_size": {
-                              "type": "long"
-                            }
-                          },
-                          "type": "nested"
+                          "properties": {}
                         },
                         "segments": {
-                          "properties": {
-                            "sections": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "nested"
-                        },
-                        "shared_libraries": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "telfhash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
-                    },
-                    "extension": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "fork_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "gid": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "group": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "hash": {
-                      "properties": {
-                        "cdhash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "md5": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha1": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha256": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha384": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "sha512": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "ssdeep": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlsh": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "inode": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mime_type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mode": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "mtime": {
-                      "type": "date"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "origin_referrer_url": {
-                      "ignore_above": 8192,
-                      "type": "keyword"
-                    },
-                    "origin_url": {
-                      "ignore_above": 8192,
-                      "type": "keyword"
-                    },
-                    "owner": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "pe": {
                       "properties": {
-                        "architecture": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "company": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "description": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "file_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "go_import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "go_imports": {
-                          "type": "flat_object"
-                        },
-                        "go_imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "go_imports_names_var_entropy": {
-                          "type": "long"
-                        },
-                        "go_stripped": {
-                          "type": "boolean"
-                        },
-                        "imphash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "import_hash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "imports": {
-                          "type": "flat_object"
-                        },
-                        "imports_names_entropy": {
-                          "type": "long"
-                        },
-                        "imports_names_var_entropy": {
-                          "type": "long"
-                        },
-                        "original_file_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "pehash": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "product": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "sections": {
-                          "properties": {
-                            "entropy": {
-                              "type": "long"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "physical_size": {
-                              "type": "long"
-                            },
-                            "var_entropy": {
-                              "type": "long"
-                            },
-                            "virtual_size": {
-                              "type": "long"
-                            }
-                          },
-                          "type": "nested"
+                          "properties": {}
                         }
                       }
-                    },
-                    "size": {
-                      "type": "long"
-                    },
-                    "target_path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "uid": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "x509": {
                       "properties": {
-                        "alternative_names": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "issuer": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "not_after": {
-                          "type": "date"
-                        },
-                        "not_before": {
-                          "type": "date"
-                        },
-                        "public_key_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_curve": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_exponent": {
-                          "doc_values": false,
-                          "index": false,
-                          "type": "long"
-                        },
-                        "public_key_size": {
-                          "type": "long"
-                        },
-                        "serial_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signature_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "subject": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "version_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     }
                   }
                 },
-                "first_seen": {
-                  "type": "date"
-                },
                 "geo": {
-                  "properties": {
-                    "city_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "continent_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "continent_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country_iso_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "country_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "location": {
-                      "type": "geo_point"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "postal_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "region_iso_code": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "region_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "timezone": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ip": {
-                  "type": "ip"
-                },
-                "last_seen": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "marking": {
-                  "properties": {
-                    "tlp": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "tlp_version": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "modified_at": {
-                  "type": "date"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "port": {
-                  "type": "long"
-                },
-                "provider": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "registry": {
                   "properties": {
                     "data": {
-                      "properties": {
-                        "bytes": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "strings": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "hive": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "key": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "value": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
-                },
-                "scanner_stats": {
-                  "type": "long"
-                },
-                "sightings": {
-                  "type": "long"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 },
                 "url": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "extension": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "fragment": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "full": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "original": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "password": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "path": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "port": {
-                      "type": "long"
-                    },
-                    "query": {
-                      "ignore_above": 2083,
-                      "type": "keyword"
-                    },
-                    "registered_domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "scheme": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "subdomain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "top_level_domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "username": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "x509": {
                   "properties": {
-                    "alternative_names": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "issuer": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "not_after": {
-                      "type": "date"
-                    },
-                    "not_before": {
-                      "type": "date"
-                    },
-                    "public_key_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_curve": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_exponent": {
-                      "doc_values": false,
-                      "index": false,
-                      "type": "long"
-                    },
-                    "public_key_size": {
-                      "type": "long"
-                    },
-                    "serial_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signature_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "subject": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "version_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 }
               }
             },
             "software": {
-              "properties": {
-                "alias": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platforms": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "tactic": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "technique": {
               "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "subtechnique": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             }
@@ -7557,632 +21672,77 @@
         },
         "tls": {
           "properties": {
-            "cipher": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "client": {
               "properties": {
-                "certificate": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "certificate_chain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "hash": {
-                  "properties": {
-                    "md5": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha1": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha256": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "issuer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ja3": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "not_after": {
-                  "type": "date"
-                },
-                "not_before": {
-                  "type": "date"
-                },
-                "server_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "subject": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "supported_ciphers": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "x509": {
                   "properties": {
-                    "alternative_names": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "issuer": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "not_after": {
-                      "type": "date"
-                    },
-                    "not_before": {
-                      "type": "date"
-                    },
-                    "public_key_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_curve": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_exponent": {
-                      "doc_values": false,
-                      "index": false,
-                      "type": "long"
-                    },
-                    "public_key_size": {
-                      "type": "long"
-                    },
-                    "serial_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signature_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "subject": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "version_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 }
               }
-            },
-            "curve": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "established": {
-              "type": "boolean"
-            },
-            "next_protocol": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "resumed": {
-              "type": "boolean"
             },
             "server": {
               "properties": {
-                "certificate": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "certificate_chain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "hash": {
-                  "properties": {
-                    "md5": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha1": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "sha256": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "issuer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ja3s": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "not_after": {
-                  "type": "date"
-                },
-                "not_before": {
-                  "type": "date"
-                },
-                "subject": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "x509": {
                   "properties": {
-                    "alternative_names": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "issuer": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "not_after": {
-                      "type": "date"
-                    },
-                    "not_before": {
-                      "type": "date"
-                    },
-                    "public_key_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_curve": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "public_key_exponent": {
-                      "doc_values": false,
-                      "index": false,
-                      "type": "long"
-                    },
-                    "public_key_size": {
-                      "type": "long"
-                    },
-                    "serial_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "signature_algorithm": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "subject": {
-                      "properties": {
-                        "common_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "locality": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organization": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "organizational_unit": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "state_or_province": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "version_number": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     }
                   }
                 }
               }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version_protocol": {
-              "ignore_above": 1024,
-              "type": "keyword"
             }
           }
         },
         "trace": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "transaction": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "url": {
-          "properties": {
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "extension": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "fragment": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "full": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "password": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "port": {
-              "type": "long"
-            },
-            "query": {
-              "ignore_above": 2083,
-              "type": "keyword"
-            },
-            "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "scheme": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subdomain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "top_level_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "username": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
+          "properties": {}
         },
         "user": {
           "properties": {
             "changes": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "effective": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
-            },
-            "email": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "full_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
             },
             "group": {
-              "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "hash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "risk": {
-              "properties": {
-                "calculated_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "calculated_score": {
-                  "type": "float"
-                },
-                "calculated_score_norm": {
-                  "type": "float"
-                },
-                "static_level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "static_score": {
-                  "type": "float"
-                },
-                "static_score_norm": {
-                  "type": "float"
-                }
-              }
-            },
-            "roles": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "target": {
               "properties": {
-                "domain": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "group": {
-                  "properties": {
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "hash": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "roles": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 }
               }
             }
@@ -8191,199 +21751,23 @@
         "user_agent": {
           "properties": {
             "device": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             },
             "os": {
-              "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "full": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "kernel": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platform": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {}
             }
           }
         },
         "volume": {
-          "properties": {
-            "bus_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "default_access": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "device_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "device_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "dos_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "file_system_type": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "mount_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "nt_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "product_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "product_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "removable": {
-              "type": "boolean"
-            },
-            "serial_number": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "size": {
-              "type": "long"
-            },
-            "vendor_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "vendor_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "writable": {
-              "type": "boolean"
-            }
-          }
+          "properties": {}
         },
         "vulnerability": {
           "properties": {
-            "category": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "classification": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "detected_at": {
-              "type": "date"
-            },
-            "enumeration": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "published_at": {
-              "type": "date"
-            },
-            "report_id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "scanner": {
-              "properties": {
-                "condition": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "source": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "vendor": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "score": {
-              "properties": {
-                "base": {
-                  "type": "float"
-                },
-                "environmental": {
-                  "type": "float"
-                },
-                "temporal": {
-                  "type": "float"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
-            "severity": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "under_evaluation": {
-              "type": "boolean"
+              "properties": {}
             }
           }
         },
@@ -8392,572 +21776,103 @@
             "agent": {
               "properties": {
                 "build": {
-                  "properties": {
-                    "original": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "ephemeral_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "groups": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "host": {
                   "properties": {
-                    "architecture": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "boot": {
-                      "properties": {
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "cpu": {
-                      "properties": {
-                        "cores": {
-                          "type": "long"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "speed": {
-                          "type": "long"
-                        },
-                        "usage": {
-                          "scaling_factor": 1000,
-                          "type": "scaled_float"
-                        }
-                      },
-                      "type": "object"
+                      "properties": {}
                     },
                     "disk": {
                       "properties": {
                         "read": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         },
                         "write": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
-                    },
-                    "domain": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "geo": {
-                      "properties": {
-                        "city_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "location": {
-                          "type": "geo_point"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "postal_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "timezone": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "hostname": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ip": {
-                      "type": "ip"
-                    },
-                    "mac": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "memory": {
                       "properties": {
-                        "free": {
-                          "type": "long"
-                        },
-                        "total": {
-                          "type": "long"
-                        },
                         "used": {
-                          "properties": {
-                            "percentage": {
-                              "type": "long"
-                            }
-                          },
-                          "type": "object"
+                          "properties": {}
                         }
-                      },
-                      "type": "object"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      }
                     },
                     "network": {
                       "properties": {
                         "egress": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            },
-                            "drops": {
-                              "type": "long"
-                            },
-                            "errors": {
-                              "type": "long"
-                            },
-                            "packets": {
-                              "type": "long"
-                            },
-                            "queue": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         },
                         "ingress": {
-                          "properties": {
-                            "bytes": {
-                              "type": "long"
-                            },
-                            "drops": {
-                              "type": "long"
-                            },
-                            "errors": {
-                              "type": "long"
-                            },
-                            "packets": {
-                              "type": "long"
-                            },
-                            "queue": {
-                              "type": "long"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
                     },
                     "os": {
-                      "properties": {
-                        "family": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "full": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "kernel": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "platform": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "pid_ns_ino": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "risk": {
-                      "properties": {
-                        "calculated_level": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "calculated_score": {
-                          "type": "float"
-                        },
-                        "calculated_score_norm": {
-                          "type": "float"
-                        },
-                        "static_level": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "static_score": {
-                          "type": "float"
-                        },
-                        "static_score_norm": {
-                          "type": "float"
-                        }
-                      }
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "uptime": {
-                      "type": "long"
+                      "properties": {}
                     }
                   }
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "type": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 }
               }
             },
             "case": {
               "properties": {
                 "comments": {
-                  "properties": {
-                    "author": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "comment": {
-                      "type": "match_only_text"
-                    },
-                    "created_at": {
-                      "type": "date"
-                    },
-                    "updated_at": {
-                      "type": "date"
-                    }
-                  },
-                  "type": "nested"
-                },
-                "created_at": {
-                  "type": "date"
-                },
-                "description": {
-                  "type": "match_only_text"
-                },
-                "priority": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "severity": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "title": {
-                  "type": "match_only_text"
-                },
-                "tlp": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "updated_at": {
-                  "type": "date"
+                  "properties": {}
                 },
                 "user": {
-                  "properties": {
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 }
               }
             },
             "cluster": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "node": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "event": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "integration": {
-              "properties": {
-                "category": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "decoders": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "rules": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "protocol": {
-              "properties": {
-                "location": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "queue": {
-                  "type": "byte"
-                }
-              }
+              "properties": {}
             },
             "rule": {
               "properties": {
-                "author": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "category": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
                 "compliance": {
-                  "properties": {
-                    "cmmc": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "fedramp": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "gdpr": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "hipaa": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "iso_27001": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "nis2": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "nist_800_171": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "nist_800_53": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "pci_dss": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "tsc": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "description": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "level": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "license": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "mitre": {
                   "properties": {
                     "subtechnique": {
-                      "properties": {
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "object"
+                      "properties": {}
                     },
                     "tactic": {
-                      "properties": {
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "object"
+                      "properties": {}
                     },
                     "technique": {
-                      "properties": {
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      },
-                      "type": "object"
+                      "properties": {}
                     }
                   }
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "reference": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "ruleset": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "sigma_id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "status": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "tags": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "title": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "uuid": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
                 }
               }
             },
             "schema": {
-              "properties": {
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "space": {
-              "properties": {
-                "event_discarded": {
-                  "type": "boolean"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+              "properties": {}
             },
             "threat": {
               "properties": {
@@ -8967,1764 +21882,203 @@
                       "properties": {
                         "as": {
                           "properties": {
-                            "number": {
-                              "type": "long"
-                            },
                             "organization": {
-                              "properties": {
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
+                              "properties": {}
                             }
                           }
-                        },
-                        "confidence": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "description": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "email": {
-                          "properties": {
-                            "address": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         },
                         "feed": {
-                          "properties": {
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         },
                         "file": {
                           "properties": {
-                            "accessed": {
-                              "type": "date"
-                            },
-                            "attributes": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "code_signature": {
-                              "properties": {
-                                "digest_algorithm": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "exists": {
-                                  "type": "boolean"
-                                },
-                                "flags": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "signing_id": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "status": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "subject_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "team_id": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "thumbprint_sha256": {
-                                  "ignore_above": 64,
-                                  "type": "keyword"
-                                },
-                                "timestamp": {
-                                  "type": "date"
-                                },
-                                "trusted": {
-                                  "type": "boolean"
-                                },
-                                "valid": {
-                                  "type": "boolean"
-                                }
-                              }
-                            },
-                            "created": {
-                              "type": "date"
-                            },
-                            "ctime": {
-                              "type": "date"
-                            },
-                            "device": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "directory": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "drive_letter": {
-                              "ignore_above": 1,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "elf": {
                               "properties": {
-                                "architecture": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "byte_order": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "cpu_type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "creation_date": {
-                                  "type": "date"
-                                },
-                                "exports": {
-                                  "type": "flat_object"
-                                },
-                                "go_import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "go_imports": {
-                                  "type": "flat_object"
-                                },
-                                "go_imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "go_imports_names_var_entropy": {
-                                  "type": "long"
-                                },
-                                "go_stripped": {
-                                  "type": "boolean"
-                                },
                                 "header": {
-                                  "properties": {
-                                    "abi_version": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "class": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "data": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "entrypoint": {
-                                      "type": "long"
-                                    },
-                                    "object_version": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "os_abi": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "type": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "version": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  }
-                                },
-                                "import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "imports": {
-                                  "type": "flat_object"
-                                },
-                                "imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "imports_names_var_entropy": {
-                                  "type": "long"
+                                  "properties": {}
                                 },
                                 "sections": {
-                                  "properties": {
-                                    "chi2": {
-                                      "type": "long"
-                                    },
-                                    "entropy": {
-                                      "type": "long"
-                                    },
-                                    "flags": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "physical_offset": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "physical_size": {
-                                      "type": "long"
-                                    },
-                                    "type": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "var_entropy": {
-                                      "type": "long"
-                                    },
-                                    "virtual_address": {
-                                      "type": "long"
-                                    },
-                                    "virtual_size": {
-                                      "type": "long"
-                                    }
-                                  },
-                                  "type": "nested"
+                                  "properties": {}
                                 },
                                 "segments": {
-                                  "properties": {
-                                    "sections": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "type": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  },
-                                  "type": "nested"
-                                },
-                                "shared_libraries": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "telfhash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
+                                  "properties": {}
                                 }
                               }
-                            },
-                            "extension": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "fork_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "gid": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "group": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
                             },
                             "hash": {
-                              "properties": {
-                                "cdhash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "md5": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha1": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha256": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha384": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "sha512": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "ssdeep": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "tlsh": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "inode": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "mime_type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "mode": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "mtime": {
-                              "type": "date"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "origin_referrer_url": {
-                              "ignore_above": 8192,
-                              "type": "keyword"
-                            },
-                            "origin_url": {
-                              "ignore_above": 8192,
-                              "type": "keyword"
-                            },
-                            "owner": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "path": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "pe": {
                               "properties": {
-                                "architecture": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "company": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "description": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "file_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "go_import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "go_imports": {
-                                  "type": "flat_object"
-                                },
-                                "go_imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "go_imports_names_var_entropy": {
-                                  "type": "long"
-                                },
-                                "go_stripped": {
-                                  "type": "boolean"
-                                },
-                                "imphash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "import_hash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "imports": {
-                                  "type": "flat_object"
-                                },
-                                "imports_names_entropy": {
-                                  "type": "long"
-                                },
-                                "imports_names_var_entropy": {
-                                  "type": "long"
-                                },
-                                "original_file_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "pehash": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "product": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
                                 "sections": {
-                                  "properties": {
-                                    "entropy": {
-                                      "type": "long"
-                                    },
-                                    "name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "physical_size": {
-                                      "type": "long"
-                                    },
-                                    "var_entropy": {
-                                      "type": "long"
-                                    },
-                                    "virtual_size": {
-                                      "type": "long"
-                                    }
-                                  },
-                                  "type": "nested"
+                                  "properties": {}
                                 }
                               }
-                            },
-                            "size": {
-                              "type": "long"
-                            },
-                            "target_path": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "uid": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
                             },
                             "x509": {
                               "properties": {
-                                "alternative_names": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
                                 "issuer": {
-                                  "properties": {
-                                    "common_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "country": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "distinguished_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "locality": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organization": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organizational_unit": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "state_or_province": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  }
-                                },
-                                "not_after": {
-                                  "type": "date"
-                                },
-                                "not_before": {
-                                  "type": "date"
-                                },
-                                "public_key_algorithm": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "public_key_curve": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "public_key_exponent": {
-                                  "doc_values": false,
-                                  "index": false,
-                                  "type": "long"
-                                },
-                                "public_key_size": {
-                                  "type": "long"
-                                },
-                                "serial_number": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "signature_algorithm": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
+                                  "properties": {}
                                 },
                                 "subject": {
-                                  "properties": {
-                                    "common_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "country": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "distinguished_name": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "locality": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organization": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "organizational_unit": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    },
-                                    "state_or_province": {
-                                      "ignore_above": 1024,
-                                      "type": "keyword"
-                                    }
-                                  }
-                                },
-                                "version_number": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
+                                  "properties": {}
                                 }
                               }
                             }
                           }
                         },
-                        "first_seen": {
-                          "type": "date"
-                        },
                         "geo": {
-                          "properties": {
-                            "city_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "continent_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "continent_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country_iso_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "location": {
-                              "type": "geo_point"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "postal_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "region_iso_code": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "region_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "timezone": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "ip": {
-                          "type": "ip"
-                        },
-                        "last_seen": {
-                          "type": "date"
+                          "properties": {}
                         },
                         "marking": {
-                          "properties": {
-                            "tlp": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "tlp_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "modified_at": {
-                          "type": "date"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "port": {
-                          "type": "long"
-                        },
-                        "provider": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "reference": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "registry": {
                           "properties": {
                             "data": {
-                              "properties": {
-                                "bytes": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "strings": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "hive": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "key": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "path": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "value": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         },
-                        "scanner_stats": {
-                          "type": "long"
-                        },
-                        "sightings": {
-                          "type": "long"
-                        },
                         "software": {
-                          "properties": {
-                            "alias": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "tags": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "x509": {
                           "properties": {
-                            "alternative_names": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "issuer": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "not_after": {
-                              "type": "date"
-                            },
-                            "not_before": {
-                              "type": "date"
-                            },
-                            "public_key_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_curve": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_exponent": {
-                              "doc_values": false,
-                              "index": false,
-                              "type": "long"
-                            },
-                            "public_key_size": {
-                              "type": "long"
-                            },
-                            "serial_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signature_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "subject": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "version_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         }
-                      },
-                      "type": "object"
+                      }
                     },
                     "matched": {
-                      "properties": {
-                        "atomic": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "field": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "index": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "occurred": {
-                          "type": "date"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     }
-                  },
-                  "type": "object"
+                  }
                 },
                 "feed": {
-                  "properties": {
-                    "dashboard_id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "framework": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "properties": {}
                 },
                 "group": {
-                  "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "indicator": {
                   "properties": {
                     "as": {
                       "properties": {
-                        "number": {
-                          "type": "long"
-                        },
                         "organization": {
-                          "properties": {
-                            "name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "properties": {}
                         }
                       }
-                    },
-                    "confidence": {
-                      "type": "short"
-                    },
-                    "description": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
                     },
                     "email": {
-                      "properties": {
-                        "address": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     },
                     "file": {
                       "properties": {
-                        "accessed": {
-                          "type": "date"
-                        },
-                        "attributes": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "code_signature": {
-                          "properties": {
-                            "digest_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "exists": {
-                              "type": "boolean"
-                            },
-                            "flags": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signing_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "status": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "subject_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "team_id": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "thumbprint_sha256": {
-                              "ignore_above": 64,
-                              "type": "keyword"
-                            },
-                            "timestamp": {
-                              "type": "date"
-                            },
-                            "trusted": {
-                              "type": "boolean"
-                            },
-                            "valid": {
-                              "type": "boolean"
-                            }
-                          }
-                        },
-                        "created": {
-                          "type": "date"
-                        },
-                        "ctime": {
-                          "type": "date"
-                        },
-                        "device": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "directory": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "drive_letter": {
-                          "ignore_above": 1,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "elf": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "byte_order": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "cpu_type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "creation_date": {
-                              "type": "date"
-                            },
-                            "exports": {
-                              "type": "flat_object"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
                             "header": {
-                              "properties": {
-                                "abi_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "class": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "data": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "entrypoint": {
-                                  "type": "long"
-                                },
-                                "object_version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "os_abi": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "version": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
+                              "properties": {}
                             },
                             "sections": {
-                              "properties": {
-                                "chi2": {
-                                  "type": "long"
-                                },
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "flags": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_offset": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_address": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             },
                             "segments": {
-                              "properties": {
-                                "sections": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "type": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              },
-                              "type": "nested"
-                            },
-                            "shared_libraries": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "telfhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
-                        },
-                        "extension": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "fork_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "gid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "group": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "hash": {
-                          "properties": {
-                            "cdhash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "md5": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha1": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha256": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha384": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "sha512": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "ssdeep": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "tlsh": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "inode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mime_type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mode": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "mtime": {
-                          "type": "date"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "origin_referrer_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "origin_url": {
-                          "ignore_above": 8192,
-                          "type": "keyword"
-                        },
-                        "owner": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "pe": {
                           "properties": {
-                            "architecture": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "company": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "description": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "file_version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "go_imports": {
-                              "type": "flat_object"
-                            },
-                            "go_imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "go_imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "go_stripped": {
-                              "type": "boolean"
-                            },
-                            "imphash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "import_hash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "imports": {
-                              "type": "flat_object"
-                            },
-                            "imports_names_entropy": {
-                              "type": "long"
-                            },
-                            "imports_names_var_entropy": {
-                              "type": "long"
-                            },
-                            "original_file_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "pehash": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "product": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "sections": {
-                              "properties": {
-                                "entropy": {
-                                  "type": "long"
-                                },
-                                "name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "physical_size": {
-                                  "type": "long"
-                                },
-                                "var_entropy": {
-                                  "type": "long"
-                                },
-                                "virtual_size": {
-                                  "type": "long"
-                                }
-                              },
-                              "type": "nested"
+                              "properties": {}
                             }
                           }
-                        },
-                        "size": {
-                          "type": "long"
-                        },
-                        "target_path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "uid": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
                         },
                         "x509": {
                           "properties": {
-                            "alternative_names": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
                             "issuer": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "not_after": {
-                              "type": "date"
-                            },
-                            "not_before": {
-                              "type": "date"
-                            },
-                            "public_key_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_curve": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "public_key_exponent": {
-                              "doc_values": false,
-                              "index": false,
-                              "type": "long"
-                            },
-                            "public_key_size": {
-                              "type": "long"
-                            },
-                            "serial_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "signature_algorithm": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             },
                             "subject": {
-                              "properties": {
-                                "common_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "country": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "distinguished_name": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "locality": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organization": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "organizational_unit": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                },
-                                "state_or_province": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
-                                }
-                              }
-                            },
-                            "version_number": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "properties": {}
                             }
                           }
                         }
                       }
                     },
-                    "first_seen": {
-                      "type": "date"
-                    },
                     "geo": {
-                      "properties": {
-                        "city_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "continent_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "country_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "location": {
-                          "type": "geo_point"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "postal_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_iso_code": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "region_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "timezone": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "ip": {
-                      "type": "ip"
-                    },
-                    "last_seen": {
-                      "type": "date"
+                      "properties": {}
                     },
                     "marking": {
-                      "properties": {
-                        "tlp": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "tlp_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    },
-                    "modified_at": {
-                      "type": "date"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "port": {
-                      "type": "long"
-                    },
-                    "provider": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "properties": {}
                     },
                     "registry": {
                       "properties": {
                         "data": {
-                          "properties": {
-                            "bytes": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "strings": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "type": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "hive": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "key": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "path": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "value": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     },
-                    "scanner_stats": {
-                      "type": "long"
-                    },
-                    "sightings": {
-                      "type": "long"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "x509": {
                       "properties": {
-                        "alternative_names": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "issuer": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "not_after": {
-                          "type": "date"
-                        },
-                        "not_before": {
-                          "type": "date"
-                        },
-                        "public_key_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_curve": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "public_key_exponent": {
-                          "doc_values": false,
-                          "index": false,
-                          "type": "long"
-                        },
-                        "public_key_size": {
-                          "type": "long"
-                        },
-                        "serial_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "signature_algorithm": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         },
                         "subject": {
-                          "properties": {
-                            "common_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "country": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "distinguished_name": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "locality": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organization": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "organizational_unit": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            },
-                            "state_or_province": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "version_number": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "properties": {}
                         }
                       }
                     }
                   }
                 },
                 "software": {
-                  "properties": {
-                    "alias": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "platforms": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "type": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "tactic": {
-                  "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    }
-                  }
+                  "properties": {}
                 },
                 "technique": {
                   "properties": {
-                    "id": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
-                    "reference": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
-                    },
                     "subtechnique": {
-                      "properties": {
-                        "id": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
-                        "reference": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
+                      "properties": {}
                     }
                   }
                 }
               }
             }
           }
+        },
+        "@timestamp": {
+          "type": "date"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "message": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
         }
       }
     }

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 200,
         "number_of_replicas": "0",

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -31,7 +31,7 @@
     },
     "mappings": {
       "date_detection": false,
-      "dynamic": "strict_allow_templates",
+      "dynamic": "strict",
       "dynamic_templates": [
         {
           "wcs_agent_build_original": {

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -31,7 +31,7 @@
     },
     "mappings": {
       "date_detection": false,
-      "dynamic": "strict",
+      "dynamic": "strict_allow_templates",
       "dynamic_templates": [
         {
           "wcs_agent_build_original": {

--- a/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
@@ -9,6 +9,7 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
@@ -23,8 +24,7 @@
           "wazuh.cluster.node",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "5s",
-        "max_docvalue_fields_search": 100
+        "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-metrics-policy",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
@@ -23,7 +23,8 @@
           "wazuh.cluster.node",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "5s"
+        "refresh_interval": "5s",
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-metrics-policy",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
@@ -17,7 +17,8 @@
           "wazuh.cluster.node",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "5s"
+        "refresh_interval": "5s",
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-metrics-policy",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
@@ -9,6 +9,7 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
@@ -17,8 +18,7 @@
           "wazuh.cluster.node",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "5s",
-        "max_docvalue_fields_search": 100
+        "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-metrics-policy",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
         "number_of_shards": "1",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
@@ -21,7 +21,8 @@
           "wazuh.space.name",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "5s"
+        "refresh_interval": "5s",
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-metrics-policy",

--- a/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
@@ -9,6 +9,7 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
@@ -21,8 +22,7 @@
           "wazuh.space.name",
           "wazuh.schema.version"
         ],
-        "refresh_interval": "5s",
-        "max_docvalue_fields_search": 100
+        "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-metrics-policy",

--- a/plugins/setup/src/main/resources/templates/streams/raw.json
+++ b/plugins/setup/src/main/resources/templates/streams/raw.json
@@ -7,6 +7,7 @@
   "template": {
     "settings": {
       "index": {
+        "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",

--- a/wcs/ai-assistant/sessions/fields/template-settings-legacy.json
+++ b/wcs/ai-assistant/sessions/fields/template-settings-legacy.json
@@ -10,6 +10,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "1s",
       "query.default_field": [
         "title",

--- a/wcs/ai-assistant/sessions/fields/template-settings-legacy.json
+++ b/wcs/ai-assistant/sessions/fields/template-settings-legacy.json
@@ -15,7 +15,8 @@
       "query.default_field": [
         "title",
         "user"
-      ]
+      ],
+      "max_docvalue_fields_search": 100
     },
     "mapping.total_fields.limit": 1000
   }

--- a/wcs/ai-assistant/sessions/fields/template-settings.json
+++ b/wcs/ai-assistant/sessions/fields/template-settings.json
@@ -17,7 +17,8 @@
         "query.default_field": [
           "title",
           "user"
-        ]
+        ],
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000
     }

--- a/wcs/ai-assistant/sessions/fields/template-settings.json
+++ b/wcs/ai-assistant/sessions/fields/template-settings.json
@@ -12,6 +12,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "1s",
         "query.default_field": [
           "title",

--- a/wcs/content/filters/fields/template-settings-legacy.json
+++ b/wcs/content/filters/fields/template-settings-legacy.json
@@ -10,6 +10,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "document.name",

--- a/wcs/content/filters/fields/template-settings.json
+++ b/wcs/content/filters/fields/template-settings.json
@@ -12,6 +12,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "document.name",

--- a/wcs/content/ioc/fields/template-settings-legacy.json
+++ b/wcs/content/ioc/fields/template-settings-legacy.json
@@ -11,6 +11,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "document.confidence",

--- a/wcs/content/ioc/fields/template-settings.json
+++ b/wcs/content/ioc/fields/template-settings.json
@@ -12,6 +12,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "document.confidence",

--- a/wcs/cve/fields/template-settings-legacy.json
+++ b/wcs/cve/fields/template-settings-legacy.json
@@ -8,6 +8,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "name"

--- a/wcs/cve/fields/template-settings-legacy.json
+++ b/wcs/cve/fields/template-settings-legacy.json
@@ -12,7 +12,8 @@
       "refresh_interval": "5s",
       "query.default_field": [
         "name"
-      ]
+      ],
+      "max_docvalue_fields_search": 100
     },
     "mapping.total_fields.limit": 1000
   }

--- a/wcs/cve/fields/template-settings.json
+++ b/wcs/cve/fields/template-settings.json
@@ -9,6 +9,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "name"

--- a/wcs/cve/fields/template-settings.json
+++ b/wcs/cve/fields/template-settings.json
@@ -13,7 +13,8 @@
         "refresh_interval": "5s",
         "query.default_field": [
           "name"
-        ]
+        ],
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000
     }

--- a/wcs/generator/README.md
+++ b/wcs/generator/README.md
@@ -3,7 +3,7 @@
 The generation of the Wazuh Common Schema is automated using a set of scripts and Docker projects.
 
 - [compose.yml](./compose.yml): Docker Compose file to define the services for the schema generator.
-- [generate_schema.sh](./generate_schema.sh): generates the complete schema. The list of modules to generate is read from the [module_list.txt](../module_list.txt) file. Copies the generated files to the appropriate folders. The index templates are copied to Setup plugin's [resources/](../../plugins/setup/src/main/resources/) folder, while the CSV files are copied to each module's `docs/` folder.
+- [generate_schema.sh](./generate_schema.sh): generates the complete schema. The list of modules to generate is read from the [module_list.txt](../module_list.txt) file. Copies the generated files to the appropriate folders. The index templates are copied to Setup plugin's [resources/](../../plugins/setup/src/main/resources/) folder, while the CSV files are copied to each module's `docs/` folder. For the `stateless/events/main` and `stateless/events/findings` modules, it also converts the copied template to `dynamic_templates` via `convert_to_dynamic_templates.py`.
 - [push_schema.sh](./push_schema.sh): commits and pushes the changes in the schema to the repository. This script is meant to be used by our GH Workflow. Do not use it locally.
 - [run_generator.sh](./run_generator.sh): Script to start the Docker Compose project. This is the main entry point for the schema generation.
 - [update_module_list.sh](./update_module_list.sh): generates the [module_list.txt](../module_list.txt) file, by scanning the [wcs/](..) folder. Run this script whenever a new module is added.
@@ -11,10 +11,12 @@ The generation of the Wazuh Common Schema is automated using a set of scripts an
 - [images/generator.sh](./images/generator.sh): our actual schema generation script. It is executed inside the container. Contains post-processing steps to make the templates compatible with OpenSearch and to adapt them to our needs. Its `EXCLUDED_FIELDS` list holds the fields to remove from every module, used to drop the unwanted copies of a custom field.
 - [images/schema_sanitizer.py](./images/schema_sanitizer.py): Python script that modifies the ECS source mapping files to meet WCS requirements before generating the final templates. It is executedi in the image build process.
 - [count_and_update_total_fields.sh](./count_and_update_total_fields.sh): counts fields in a generated index template and proposes (or applies with --apply) an updated mapping.total_fields.limit rounded up to the next 500.
+- [convert_to_dynamic_templates.py](./convert_to_dynamic_templates.py): converts a generated index template's monolithic static `properties` block into a `dynamic_templates` array, so fields are mapped lazily on first ingest instead of all at once. Used to keep the field mapping count of the `wazuh-events` and `wazuh-findings` data streams (`stateless/events/main` and `stateless/events/findings` modules) under the `mapping.total_fields.limit`, since those streams define far more fields than any single document actually uses. `generate_schema.sh` runs it automatically for those two modules; see "Dynamic templates" below.
 
 ### Requirements
 
 - [Docker Compose](https://docs.docker.com/compose/install/)
+- [Python 3](https://www.python.org/) (for `convert_to_dynamic_templates.py` and `count_and_update_total_fields.sh`)
 
 ### Usage
 
@@ -32,6 +34,8 @@ However, it can also be run locally. To do so, follow these steps.
     ```bash
     ./generate_schema.sh
     ```
+
+    This also converts the `stateless/events/main` and `stateless/events/findings` templates to `dynamic_templates` (see "Dynamic templates" below) when either module is regenerated.
 
 3. Update the number of total field of each module:
     ``` bash
@@ -56,6 +60,26 @@ In order to make this template compatible with OpenSearch, the following changes
 The tooling takes care of these changes automatically, generating the `opensearch-template.json` file as a result.
 
 If a module has been removed from the repository, the `generate_schema.sh` script will skip it gracefully, issuing a warning message instead of failing.
+
+### Dynamic templates
+
+The `wazuh-events` and `wazuh-findings` data streams (`stateless/events/main` and `stateless/events/findings` modules) cover a very large surface of possible fields, but any single document only ever populates a small subset of them. Mapping every field statically at index-template level counts all of them towards `mapping.total_fields.limit` right away, which can exhaust the limit before any real data is ingested.
+
+To avoid this, [convert_to_dynamic_templates.py](./convert_to_dynamic_templates.py) rewrites the generated template's static `properties` block into a `dynamic_templates` array (one `path_match` rule per field, keyed off the original mapping) plus a minimal `properties` scaffolding for the object structure. Field mappings are then created lazily, only when a document actually uses them, while still constraining each field to its intended type. A handful of fields (`@timestamp`, `labels`, `message`, `tags`) are kept as static `properties` rather than converted.
+
+`generate_schema.sh` runs this conversion automatically, in place, on the copied `templates/streams/events.json` and `templates/streams/findings.json` files whenever `stateless/events/main` or `stateless/events/findings` is regenerated — no manual step is required. The conversion is idempotent: if a template already has `dynamic_templates` populated, the script leaves it unchanged.
+
+To run it manually against an already-generated template:
+
+```bash
+python3 wcs/generator/convert_to_dynamic_templates.py input_template.json [output_template.json]
+```
+
+Omitting the output path prints the result to stdout instead of writing a file. To convert a template in place (as the pipeline does):
+
+```bash
+find plugins/setup/src/main/resources/templates/streams/ -name "events.json" -type f -exec python3 wcs/generator/convert_to_dynamic_templates.py {} {} \;
+```
 
 ### Uploading templates to the Indexer
 

--- a/wcs/generator/generate_schema.sh
+++ b/wcs/generator/generate_schema.sh
@@ -16,6 +16,11 @@ declare -a modules_to_update
 declare -A module_to_file
 declare force_update=false
 
+# Modules whose generated template must be converted from static properties to
+# dynamic_templates, to keep the field mapping count of the wazuh-events and
+# wazuh-findings data streams low. See convert_to_dynamic_templates.py.
+declare -a dynamic_template_modules=("stateless/events/main" "stateless/events/findings")
+
 # ====
 # Checks that the script is run from the intended location
 # ====
@@ -183,6 +188,17 @@ function copy_files() {
     fi
     cp "$repo_path/wcs/$ecs_module/$mappings_path" "$destination_path"
     echo "  - '$destination_path' updated"
+  done
+
+  echo "---> Dynamic templates"
+  for ecs_module in "${modules_to_update[@]}"; do
+    for dynamic_module in "${dynamic_template_modules[@]}"; do
+      if [[ "$ecs_module" == "$dynamic_module" ]]; then
+        destination_path="$resources_path/${module_to_file[$ecs_module]}"
+        python3 "$repo_path/wcs/generator/convert_to_dynamic_templates.py" "$destination_path" "$destination_path"
+        echo "  - '$destination_path' converted to dynamic_templates"
+      fi
+    done
   done
 
   echo "---> CSV documentation"

--- a/wcs/internal-state/fields/template-settings-legacy.json
+++ b/wcs/internal-state/fields/template-settings-legacy.json
@@ -6,6 +6,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "-1",
       "hidden": true
     }

--- a/wcs/internal-state/fields/template-settings.json
+++ b/wcs/internal-state/fields/template-settings.json
@@ -9,6 +9,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "-1",
         "hidden": true
       }

--- a/wcs/settings/fields/template-settings-legacy.json
+++ b/wcs/settings/fields/template-settings-legacy.json
@@ -6,6 +6,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "hidden": true
     }

--- a/wcs/settings/fields/template-settings.json
+++ b/wcs/settings/fields/template-settings.json
@@ -9,6 +9,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "hidden": true
       }

--- a/wcs/stateful/agent-config/fields/template-settings-legacy.json
+++ b/wcs/stateful/agent-config/fields/template-settings-legacy.json
@@ -5,6 +5,7 @@
     "index": {
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "wazuh.agent.id"

--- a/wcs/stateful/agent-config/fields/template-settings.json
+++ b/wcs/stateful/agent-config/fields/template-settings.json
@@ -8,6 +8,7 @@
       "index": {
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "wazuh.agent.id"

--- a/wcs/stateful/agent-stats/fields/template-settings-legacy.json
+++ b/wcs/stateful/agent-stats/fields/template-settings-legacy.json
@@ -5,6 +5,7 @@
     "index": {
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "wazuh.agent.id"

--- a/wcs/stateful/agent-stats/fields/template-settings.json
+++ b/wcs/stateful/agent-stats/fields/template-settings.json
@@ -8,6 +8,7 @@
       "index": {
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "wazuh.agent.id"

--- a/wcs/stateful/fim/files/fields/template-settings-legacy.json
+++ b/wcs/stateful/fim/files/fields/template-settings-legacy.json
@@ -9,6 +9,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.groups ",

--- a/wcs/stateful/fim/files/fields/template-settings.json
+++ b/wcs/stateful/fim/files/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.groups ",

--- a/wcs/stateful/fim/windows-registry-keys/fields/template-settings-legacy.json
+++ b/wcs/stateful/fim/windows-registry-keys/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/fim/windows-registry-keys/fields/template-settings.json
+++ b/wcs/stateful/fim/windows-registry-keys/fields/template-settings.json
@@ -8,6 +8,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/fim/windows-registry-values/fields/template-settings-legacy.json
+++ b/wcs/stateful/fim/windows-registry-values/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/fim/windows-registry-values/fields/template-settings.json
+++ b/wcs/stateful/fim/windows-registry-values/fields/template-settings.json
@@ -8,6 +8,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/browser-extensions/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/browser-extensions/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/browser-extensions/fields/template-settings.json
+++ b/wcs/stateful/inventory/browser-extensions/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/groups/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/groups/fields/template-settings-legacy.json
@@ -9,6 +9,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "group.name",

--- a/wcs/stateful/inventory/groups/fields/template-settings.json
+++ b/wcs/stateful/inventory/groups/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "group.name",

--- a/wcs/stateful/inventory/hardware/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/hardware/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/hardware/fields/template-settings.json
+++ b/wcs/stateful/inventory/hardware/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/hotfixes/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/hotfixes/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/hotfixes/fields/template-settings.json
+++ b/wcs/stateful/inventory/hotfixes/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/interfaces/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/interfaces/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.id",

--- a/wcs/stateful/inventory/interfaces/fields/template-settings.json
+++ b/wcs/stateful/inventory/interfaces/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.id",

--- a/wcs/stateful/inventory/networks/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/networks/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.id",

--- a/wcs/stateful/inventory/networks/fields/template-settings.json
+++ b/wcs/stateful/inventory/networks/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.id",

--- a/wcs/stateful/inventory/packages/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/packages/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/packages/fields/template-settings.json
+++ b/wcs/stateful/inventory/packages/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/ports/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/ports/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/ports/fields/template-settings.json
+++ b/wcs/stateful/inventory/ports/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/processes/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/processes/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/processes/fields/template-settings.json
+++ b/wcs/stateful/inventory/processes/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/protocols/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/protocols/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/protocols/fields/template-settings.json
+++ b/wcs/stateful/inventory/protocols/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/services/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/services/fields/template-settings-legacy.json
@@ -9,6 +9,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/services/fields/template-settings.json
+++ b/wcs/stateful/inventory/services/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/system/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/system/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateful/inventory/system/fields/template-settings.json
+++ b/wcs/stateful/inventory/system/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateful/inventory/users/fields/template-settings-legacy.json
+++ b/wcs/stateful/inventory/users/fields/template-settings-legacy.json
@@ -9,6 +9,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "user.id",

--- a/wcs/stateful/inventory/users/fields/template-settings.json
+++ b/wcs/stateful/inventory/users/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "user.id",

--- a/wcs/stateful/sca/fields/template-settings-legacy.json
+++ b/wcs/stateful/sca/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "agent.id",

--- a/wcs/stateful/sca/fields/template-settings.json
+++ b/wcs/stateful/sca/fields/template-settings.json
@@ -10,6 +10,7 @@
         "gc_deletes": "15s",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "agent.id",

--- a/wcs/stateful/vulnerabilities/fields/template-settings-legacy.json
+++ b/wcs/stateful/vulnerabilities/fields/template-settings-legacy.json
@@ -7,6 +7,7 @@
       "gc_deletes": "15s",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateless/active-responses/fields/template-settings-legacy.json
+++ b/wcs/stateless/active-responses/fields/template-settings-legacy.json
@@ -12,6 +12,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "wazuh.agent.id",

--- a/wcs/stateless/active-responses/fields/template-settings-legacy.json
+++ b/wcs/stateless/active-responses/fields/template-settings-legacy.json
@@ -22,7 +22,7 @@
         "event.index",
         "event.doc_id"
       ],
-      "max_docvalue_fields_search": 50
+      "max_docvalue_fields_search": 100
     },
     "mapping.total_fields.limit": 1000
   }

--- a/wcs/stateless/active-responses/fields/template-settings.json
+++ b/wcs/stateless/active-responses/fields/template-settings.json
@@ -13,6 +13,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "wazuh.agent.id",

--- a/wcs/stateless/active-responses/fields/template-settings.json
+++ b/wcs/stateless/active-responses/fields/template-settings.json
@@ -23,7 +23,7 @@
           "event.index",
           "event.doc_id"
         ],
-        "max_docvalue_fields_search": 50
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000
     }

--- a/wcs/stateless/events/findings/fields/mapping-settings.json
+++ b/wcs/stateless/events/findings/fields/mapping-settings.json
@@ -1,4 +1,4 @@
 {
-  "dynamic": "strict",
+  "dynamic": "strict_allow_templates",
   "date_detection": false
 }

--- a/wcs/stateless/events/findings/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/findings/fields/template-settings-legacy.json
@@ -6,7 +6,7 @@
   "settings": {
     "plugins.index_state_management.rollover_alias": "wazuh-findings-v5",
     "plugins.index_state_management.policy_id": "stream-findings-policy",
-    "mapping.total_fields.limit": 3000,
+    "mapping.total_fields.limit": 1000,
     "index": {
       "codec": "zstd",
       "number_of_shards": "1",

--- a/wcs/stateless/events/findings/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/findings/fields/template-settings-legacy.json
@@ -11,6 +11,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateless/events/findings/fields/template-settings.json
+++ b/wcs/stateless/events/findings/fields/template-settings.json
@@ -8,7 +8,7 @@
     "settings": {
       "plugins.index_state_management.rollover_alias": "wazuh-findings-v5",
       "plugins.index_state_management.policy_id": "stream-findings-policy",
-      "mapping.total_fields.limit": 3000,
+      "mapping.total_fields.limit": 1000,
       "index": {
         "codec": "zstd",
         "number_of_shards": "1",

--- a/wcs/stateless/events/findings/fields/template-settings.json
+++ b/wcs/stateless/events/findings/fields/template-settings.json
@@ -13,6 +13,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateless/events/main/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/main/fields/template-settings-legacy.json
@@ -21,7 +21,8 @@
         "wazuh.cluster.name",
         "wazuh.cluster.node",
         "wazuh.schema.version"
-      ]
+      ],
+      "max_docvalue_fields_search": 100
     },
     "mapping.nested_fields.limit": 50,
     "mapping.total_fields.limit": 1000

--- a/wcs/stateless/events/main/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/main/fields/template-settings-legacy.json
@@ -10,6 +10,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "2s",
       "query.default_field": [
         "agent.host.architecture",

--- a/wcs/stateless/events/main/fields/template-settings.json
+++ b/wcs/stateless/events/main/fields/template-settings.json
@@ -12,6 +12,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "2s",
         "query.default_field": [
           "agent.host.architecture",

--- a/wcs/stateless/events/main/fields/template-settings.json
+++ b/wcs/stateless/events/main/fields/template-settings.json
@@ -23,7 +23,8 @@
           "wazuh.cluster.name",
           "wazuh.cluster.node",
           "wazuh.schema.version"
-        ]
+        ],
+        "max_docvalue_fields_search": 100
       },
       "mapping.nested_fields.limit": 50,
       "mapping.total_fields.limit": 1000

--- a/wcs/stateless/events/raw/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/raw/fields/template-settings-legacy.json
@@ -11,6 +11,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "wazuh.agent.id",

--- a/wcs/stateless/events/raw/fields/template-settings.json
+++ b/wcs/stateless/events/raw/fields/template-settings.json
@@ -13,6 +13,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "wazuh.agent.id",

--- a/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
@@ -24,7 +24,8 @@
         "wazuh.cluster.name",
         "wazuh.cluster.node",
         "wazuh.schema.version"
-      ]
+      ],
+      "max_docvalue_fields_search": 100
     },
     "mapping.total_fields.limit": 1000
   }

--- a/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
@@ -11,6 +11,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "wazuh.agent.id",

--- a/wcs/stateless/metrics/agents/fields/template-settings.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings.json
@@ -12,6 +12,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "wazuh.agent.id",

--- a/wcs/stateless/metrics/agents/fields/template-settings.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings.json
@@ -25,7 +25,8 @@
           "wazuh.cluster.name",
           "wazuh.cluster.node",
           "wazuh.schema.version"
-        ]
+        ],
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000
     }

--- a/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
@@ -11,6 +11,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "events.module",

--- a/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
@@ -18,7 +18,8 @@
         "wazuh.cluster.name",
         "wazuh.cluster.node",
         "wazuh.schema.version"
-      ]
+      ],
+      "max_docvalue_fields_search": 100
     },
     "mapping.total_fields.limit": 1000
   }

--- a/wcs/stateless/metrics/comms/fields/template-settings.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings.json
@@ -19,7 +19,8 @@
           "wazuh.cluster.name",
           "wazuh.cluster.node",
           "wazuh.schema.version"
-        ]
+        ],
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000
     }

--- a/wcs/stateless/metrics/comms/fields/template-settings.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings.json
@@ -12,6 +12,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "events.module",

--- a/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
@@ -11,6 +11,7 @@
       "codec": "zstd",
       "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
       "refresh_interval": "5s",
       "query.default_field": [
         "event.module",

--- a/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
@@ -22,7 +22,8 @@
         "wazuh.cluster.node",
         "wazuh.space.name",
         "wazuh.schema.version"
-      ]
+      ],
+      "max_docvalue_fields_search": 100
     },
     "mapping.total_fields.limit": 1000
   }

--- a/wcs/stateless/metrics/engine/fields/template-settings.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings.json
@@ -23,7 +23,8 @@
           "wazuh.cluster.node",
           "wazuh.space.name",
           "wazuh.schema.version"
-        ]
+        ],
+        "max_docvalue_fields_search": 100
       },
       "mapping.total_fields.limit": 1000
     }

--- a/wcs/stateless/metrics/engine/fields/template-settings.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings.json
@@ -12,6 +12,7 @@
         "codec": "zstd",
         "number_of_shards": "1",
         "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
         "refresh_interval": "5s",
         "query.default_field": [
           "event.module",


### PR DESCRIPTION
## Description

Every Wazuh-owned index is currently hardcoded to `number_of_replicas: 0` with no way to gain a replica automatically, regardless of cluster size. On a single node that's correct (no second node to host a copy), but on a multi-node cluster it means no shard ever has a live copy anywhere else — so a single node closing (planned restart, OOM, etc.) drops that shard's data and search coverage until the cluster reallocates it. This is a likely contributing factor to the node-closure/shard-failure symptoms QA reported on a 10-node cluster.

Related to wazuh/wazuh-indexer#1793, wazuh/wazuh-indexer#1817, wazuh/wazuh-indexer#1818 (the QA reports that prompted this investigation — note #1817/#1818 trace mainly to shutdown/restart ordering during test teardown and are tracked separately; this PR removes the zero-replica contributing factor behind them, it doesn't claim to fully resolve either).

`wazuh-indexer-security-analytics` already solves this correctly for its own system indices via `index.auto_expand_replicas` (see `DetectorIndices`, `CorrelationIndices`, `RuleIndices`). This PR brings the rest of the Wazuh-owned indices in `wazuh-indexer-plugins` up to the same idiom.

Closes https://github.com/wazuh/wazuh-indexer/issues/1818
Closes https://github.com/wazuh/wazuh-indexer/issues/1793
Closes https://github.com/wazuh/wazuh-indexer/issues/1817

## Proposed Changes

- Added `index.auto_expand_replicas: "0-1"` alongside the existing `number_of_replicas: 0` on every Wazuh-owned index: 0 replicas alone on a single node (avoids permanent yellow health with no partner node to host a copy), 1 replica automatically the instant there's a second node (enough to survive one node closing), with no operator configuration required either way.
- Applied uniformly across:
  - All WCS-generated index templates (`wcs/*/fields/template-settings.json` + `-legacy.json`, and their regenerated deployed counterparts under `plugins/setup/src/main/resources/templates/`) — states, streams, content, settings, cve, ai-assistant, internal-state.
  - The two standalone setup templates with no WCS source (`ism-config.json`, `setup-status.json`).
  - content-manager's programmatic index creation: `ContentIndex` (both the normal and blue/green shadow-swap paths), `ConsumersIndex`, `ResourceLockService`, and `ContentManagerPlugin`'s jobs index, plus `internal-state-mapping.json`.
- No shard counts were changed — replicas are the correct lever for spreading search load and surviving a node closing at this data volume; shard count only matters if a single index's throughput saturates one shard, which isn't the case here.
- Left `cluster.default_number_of_replicas` (in `SetupPlugin.java`) untouched — it's a legitimate, correctly-wired upstream OpenSearch mechanism, but it only supplies a default for indices that *omit* `number_of_replicas`, so it never reached any Wazuh-owned index (every one of them sets it explicitly). It still matters for third-party-plugin system indices (Alerting/ISM/job-scheduler) that don't declare a replica count.

### Results and Evidence

- `./gradlew :wazuh-indexer-content-manager:compileJava` → `BUILD SUCCESSFUL`, no new warnings introduced.
- Verified via `jq` that every one of the 34 deployed templates (33 WCS-generated + the 2 standalone) and the content-manager JSON mapping now contain `"auto_expand_replicas": "0-1"` alongside `"number_of_replicas": "0"`, and that all touched JSON remains valid.
- **Not yet done, recommend before merge:** live cluster verification — (1) single-node install reaches `green` health (not stuck `yellow`); (2) on a 2+ node cluster, `GET <index>/_settings` shows `number_of_replicas` dynamically become `"1"` and `GET _cat/shards` shows a second copy assigned to a different node.

```
GET /_cluster/health

{
  "cluster_name": "integTest",
  "status": "green",
  "timed_out": false,
  "number_of_nodes": 2,
  "number_of_data_nodes": 2,
  "discovered_master": true,
  "discovered_cluster_manager": true,
  "active_primary_shards": 14,
  "active_shards": 28,
  "relocating_shards": 0,
  "initializing_shards": 0,
  "unassigned_shards": 0,
  "delayed_unassigned_shards": 0,
  "number_of_pending_tasks": 0,
  "number_of_in_flight_fetch": 0,
  "task_max_waiting_in_queue_millis": 0,
  "active_shards_percent_as_number": 100
}
```

```
GET /_cat/shards?v

index                                              shard prirep state     docs   store ip        node
.ds-wazuh-events-v5-system-activity-000001         0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-system-activity-000001         0     r      STARTED      0    208b 127.0.0.1 integTest-0
.wazuh-cti-consumers                               0     r      STARTED                127.0.0.1 integTest-1
.wazuh-cti-consumers                               0     p      STARTED                127.0.0.1 integTest-0
.opendistro_security                               0     p      STARTED      9  85.3kb 127.0.0.1 integTest-1
.opendistro_security                               0     r      STARTED      9  85.3kb 127.0.0.1 integTest-0
.ds-wazuh-active-responses-000001                  0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-active-responses-000001                  0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-hardware                    0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-hardware                    0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-browser-extensions          0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-browser-extensions          0     r      STARTED      0    208b 127.0.0.1 integTest-0
.opensearch-sap-log-types-config                   0     p      STARTED                127.0.0.1 integTest-1
.opensearch-sap-log-types-config                   0     r      STARTED                127.0.0.1 integTest-0
wazuh-states-inventory-protocols                   0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-protocols                   0     r      STARTED      0    208b 127.0.0.1 integTest-0
.wazuh-internal-state                              0     p      STARTED                127.0.0.1 integTest-1
.wazuh-internal-state                              0     r      STARTED                127.0.0.1 integTest-0
wazuh-agent-config                                 0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-agent-config                                 0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-fim-registry-keys                     0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-fim-registry-keys                     0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-security-000001              0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-security-000001              0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-sca                                   0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-sca                                   0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-processes                   0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-processes                   0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-access-management-000001     0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-access-management-000001     0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-events-raw-v5-000001                     0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-raw-v5-000001                     0     r      STARTED      0    208b 127.0.0.1 integTest-0
security-auditlog-2026.08.19                       0     r      STARTED      3    70kb 127.0.0.1 integTest-1
security-auditlog-2026.08.19                       0     p      STARTED      4  66.4kb 127.0.0.1 integTest-0
wazuh-threatintel-policies-a                       0     r      STARTED      4  73.2kb 127.0.0.1 integTest-1
wazuh-threatintel-policies-a                       0     p      STARTED      4  73.2kb 127.0.0.1 integTest-0
wazuh-threatintel-decoders-a                       0     p      STARTED    345     1mb 127.0.0.1 integTest-1
wazuh-threatintel-decoders-a                       0     r      STARTED    345     1mb 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-other-000001                 0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-other-000001                 0     r      STARTED      0    208b 127.0.0.1 integTest-0
.opendistro-ism-config                             0     r      STARTED                127.0.0.1 integTest-1
.opendistro-ism-config                             0     p      STARTED                127.0.0.1 integTest-0
.ds-wazuh-events-v5-network-activity-000001        0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-network-activity-000001        0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-hotfixes                    0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-hotfixes                    0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-ports                       0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-ports                       0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-system                      0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-system                      0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-events-v5-applications-000001            0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-applications-000001            0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-threatintel-kvdbs-a                          0     p      STARTED     32 172.2kb 127.0.0.1 integTest-1
wazuh-threatintel-kvdbs-a                          0     r      STARTED     32 172.2kb 127.0.0.1 integTest-0
wazuh-agent-stats                                  0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-agent-stats                                  0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-events-v5-other-000001                   0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-other-000001                   0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-network-activity-000001      0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-network-activity-000001      0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-ai-assistant-sessions-000001             0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-ai-assistant-sessions-000001             0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-users                       0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-users                       0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-unclassified-000001          0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-unclassified-000001          0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-threatintel-integrations-a                   0     p      STARTED     86 127.2kb 127.0.0.1 integTest-1
wazuh-threatintel-integrations-a                   0     r      STARTED     86 113.7kb 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-system-activity-000001       0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-system-activity-000001       0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-packages                    0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-packages                    0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-threatintel-filters-a                        0     r      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-threatintel-filters-a                        0     p      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-metrics-comms-v4-000001                  0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-metrics-comms-v4-000001                  0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-threatintel-enrichments-a                    0     p      STARTED 209790 104.2mb 127.0.0.1 integTest-1
wazuh-threatintel-enrichments-a                    0     r      STARTED 209790  82.3mb 127.0.0.1 integTest-0
wazuh-states-inventory-services                    0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-services                    0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-events-v5-security-000001                0     r      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-security-000001                0     p      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-metrics-normalization-000001             0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-metrics-normalization-000001             0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-fim-files                             0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-fim-files                             0     r      STARTED      0    208b 127.0.0.1 integTest-0
.wazuh-settings                                    0     p      STARTED                127.0.0.1 integTest-1
.wazuh-settings                                    0     r      STARTED                127.0.0.1 integTest-0
.opendistro-ism-managed-index-history-2026.08.19-1 0     p      STARTED                127.0.0.1 integTest-1
.opendistro-ism-managed-index-history-2026.08.19-1 0     r      STARTED                127.0.0.1 integTest-0
.ds-wazuh-events-v5-unclassified-000001            0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-unclassified-000001            0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-interfaces                  0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-interfaces                  0     r      STARTED      0    208b 127.0.0.1 integTest-0
.wazuh-content-manager-jobs                        0     p      STARTED                127.0.0.1 integTest-1
.wazuh-content-manager-jobs                        0     r      STARTED                127.0.0.1 integTest-0
.ds-wazuh-events-v5-cloud-services-000001          0     r      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-cloud-services-000001          0     p      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-groups                      0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-groups                      0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-inventory-networks                    0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-inventory-networks                    0     r      STARTED      0    208b 127.0.0.1 integTest-0
.wazuh-setup-status                                0     r      STARTED                127.0.0.1 integTest-1
.wazuh-setup-status                                0     p      STARTED                127.0.0.1 integTest-0
wazuh-threatintel-rules-a                          0     r      STARTED    127   183kb 127.0.0.1 integTest-1
wazuh-threatintel-rules-a                          0     p      STARTED    127   183kb 127.0.0.1 integTest-0
wazuh-states-fim-registry-values                   0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-fim-registry-values                   0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-applications-000001          0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-applications-000001          0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-events-v5-access-management-000001       0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-events-v5-access-management-000001       0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-metrics-agents-000001                    0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-metrics-agents-000001                    0     r      STARTED      0    208b 127.0.0.1 integTest-0
wazuh-states-vulnerabilities                       0     p      STARTED      0    208b 127.0.0.1 integTest-1
wazuh-states-vulnerabilities                       0     r      STARTED      0    208b 127.0.0.1 integTest-0
.ds-wazuh-findings-v5-cloud-services-000001        0     p      STARTED      0    208b 127.0.0.1 integTest-1
.ds-wazuh-findings-v5-cloud-services-000001        0     r      STARTED      0    208b 127.0.0.1 integTest-0
.opendistro-job-scheduler-lock                     0     p      STARTED     22  38.6kb 127.0.0.1 integTest-1
.opendistro-job-scheduler-lock                     0     r      STARTED     22  43.9kb 127.0.0.1 integTest-0
```

### Artifacts Affected

- Default index/composable-template configuration files under `wcs/**/fields/` and `plugins/setup/src/main/resources/templates/**`.
- `plugins/content-manager/src/main/resources/mappings/internal-state-mapping.json`.
- The `wazuh-indexer-setup` and `wazuh-indexer-content-manager` plugin JARs (embed the above as resources / construct these settings at index-creation time).

### Configuration Changes

- No new Wazuh-specific configuration parameter. The *default* index settings change: every Wazuh-owned index additionally gets `index.auto_expand_replicas: "0-1"`. Operators can still override replica behavior per-index at any time via OpenSearch's standard `_settings`/`_index_template` API — nothing here is Wazuh-specific or requires a new API.
- Backward compatibility: N/A — major version, no upgrade path. This only affects index-creation time (new templates / index-creation code), so it applies to fresh installs; it does not retroactively touch indices already created by an earlier 5.0 build.

### Documentation Updates

- None yet. `docs/ref/modules/setup/architecture.md`'s "Replica configuration" section only documents the `cluster.default_number_of_replicas` passthrough — worth a follow-up note there describing this new default, since that section could otherwise read as the only replica-related behavior in the plugin.

### Tests Introduced

- None. Existing unit tests for `ContentIndex`, `ConsumersIndex`, `ResourceLockService`, and `ContentManagerPlugin` were not modified and don't assert exact `Settings` equality, so they continue to pass unmodified against the new settings. No new automated test was added to assert the presence of `auto_expand_replicas` itself — flagging as a gap; consider a small assertion in the existing index-creation tests, or rely on the manual cluster verification above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality — *no new automated test added, see above*
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes — *architecture.md not yet updated, see above*
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`) — *this changes operator-visible index behavior, likely not a `no-changelog` candidate*
- [ ] ...
