### PR TITLE
Fix ManagedIndexMetaData errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@
 - [BUG] Vulnerability Detection empty for all agents after a transient snapshot bootstrap failure [(#1383)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1383)
 - [BUG] Log test does not use manually enabled integrations [(#1410)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1410)
 - [BUG] Undefined state if a node is restarted while the standard space hash is being calculated [(#1773)](https://github.com/wazuh/wazuh-indexer/issues/1773)
+- Failed to save/update ManagedIndexMetaData [(#1828)](https://github.com/wazuh/wazuh-indexer/issues/1828)
 
 ## Prior versions
 - []()

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/StreamIndex.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/StreamIndex.java
@@ -90,13 +90,6 @@ public class StreamIndex extends WazuhIndex {
             // Dynamically set the index patterns to match this specific index
             indexTemplate.setIndexPatterns(List.of(this.index + "*"));
 
-            // Dynamically update the rollover alias if it exists in the base template
-            Map<String, Object> settingsMap = indexTemplate.getSettings();
-            if (settingsMap != null
-                    && settingsMap.containsKey("plugins.index_state_management.rollover_alias")) {
-                settingsMap.put("plugins.index_state_management.rollover_alias", this.index);
-            }
-
             String indexMappings = mapper.writeValueAsString(indexTemplate.getMappings());
             CompressedXContent compressedMapping = new CompressedXContent(indexMappings);
             Settings settings = Settings.builder().loadFromMap(indexTemplate.getSettings()).build();

--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -23,8 +23,7 @@
       },
       "mapping.nested_fields.limit": 10,
       "mapping.total_fields.limit": 1000,
-      "plugins.index_state_management.policy_id": "stream-active-responses-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-active-responses"
+      "plugins.index_state_management.policy_id": "stream-active-responses-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
+++ b/plugins/setup/src/main/resources/templates/streams/ai-assistant-sessions.json
@@ -17,8 +17,7 @@
         "refresh_interval": "1s"
       },
       "mapping.total_fields.limit": 1000,
-      "plugins.index_state_management.policy_id": "ai-assistant-sessions-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-ai-assistant-sessions"
+      "plugins.index_state_management.policy_id": "ai-assistant-sessions-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -25,7 +25,7 @@
         "refresh_interval": "2s"
       },
       "mapping.nested_fields.limit": 50,
-      "mapping.total_fields.limit": 1000,
+      "mapping.total_fields.limit": 3000,
       "plugins.index_state_management.policy_id": "stream-events-policy"
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -24,8 +24,7 @@
       },
       "mapping.nested_fields.limit": 50,
       "mapping.total_fields.limit": 1000,
-      "plugins.index_state_management.policy_id": "stream-events-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-events-v5"
+      "plugins.index_state_management.policy_id": "stream-events-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -25,7 +25,7 @@
         "refresh_interval": "2s"
       },
       "mapping.nested_fields.limit": 50,
-      "mapping.total_fields.limit": 3000,
+      "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-events-policy"
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -25,8 +25,7 @@
       },
       "mapping.nested_fields.limit": 50,
       "mapping.total_fields.limit": 3000,
-      "plugins.index_state_management.policy_id": "stream-findings-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-findings-v5"
+      "plugins.index_state_management.policy_id": "stream-findings-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -25,7 +25,7 @@
         "refresh_interval": "2s"
       },
       "mapping.nested_fields.limit": 50,
-      "mapping.total_fields.limit": 3000,
+      "mapping.total_fields.limit": 1000,
       "plugins.index_state_management.policy_id": "stream-findings-policy"
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
@@ -25,8 +25,7 @@
         "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000,
-      "plugins.index_state_management.policy_id": "stream-metrics-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-metrics-agents"
+      "plugins.index_state_management.policy_id": "stream-metrics-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-comms.json
@@ -19,8 +19,7 @@
         "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000,
-      "plugins.index_state_management.policy_id": "stream-metrics-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-metrics-comms-v4"
+      "plugins.index_state_management.policy_id": "stream-metrics-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-normalization.json
@@ -23,8 +23,7 @@
         "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000,
-      "plugins.index_state_management.policy_id": "stream-metrics-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-metrics-normalization"
+      "plugins.index_state_management.policy_id": "stream-metrics-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/plugins/setup/src/main/resources/templates/streams/raw.json
+++ b/plugins/setup/src/main/resources/templates/streams/raw.json
@@ -21,8 +21,7 @@
       },
       "mapping.nested_fields.limit": 10,
       "mapping.total_fields.limit": 1000,
-      "plugins.index_state_management.policy_id": "stream-raw-events-policy",
-      "plugins.index_state_management.rollover_alias": "wazuh-events-raw-v5"
+      "plugins.index_state_management.policy_id": "stream-raw-events-policy"
     },
     "mappings": {
       "date_detection": false,

--- a/wcs/ai-assistant/sessions/fields/template-settings-legacy.json
+++ b/wcs/ai-assistant/sessions/fields/template-settings-legacy.json
@@ -4,7 +4,6 @@
   ],
   "order": 1,
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-ai-assistant-sessions",
     "plugins.index_state_management.policy_id": "ai-assistant-sessions-policy",
     "index": {
       "codec": "zstd",

--- a/wcs/ai-assistant/sessions/fields/template-settings.json
+++ b/wcs/ai-assistant/sessions/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-ai-assistant-sessions",
       "plugins.index_state_management.policy_id": "ai-assistant-sessions-policy",
       "index": {
         "codec": "zstd",

--- a/wcs/stateless/active-responses/fields/template-settings-legacy.json
+++ b/wcs/stateless/active-responses/fields/template-settings-legacy.json
@@ -5,7 +5,6 @@
   "order": 1,
   "data_stream": {},
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-active-responses",
     "plugins.index_state_management.policy_id": "stream-active-responses-policy",
     "mapping.nested_fields.limit": 10,
     "index": {

--- a/wcs/stateless/active-responses/fields/template-settings.json
+++ b/wcs/stateless/active-responses/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-active-responses",
       "plugins.index_state_management.policy_id": "stream-active-responses-policy",
       "mapping.nested_fields.limit": 10,
       "index": {

--- a/wcs/stateless/events/findings/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/findings/fields/template-settings-legacy.json
@@ -4,7 +4,6 @@
   ],
   "order": 1,
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-findings-v5",
     "plugins.index_state_management.policy_id": "stream-findings-policy",
     "mapping.total_fields.limit": 3000,
     "index": {

--- a/wcs/stateless/events/findings/fields/template-settings.json
+++ b/wcs/stateless/events/findings/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-findings-v5",
       "plugins.index_state_management.policy_id": "stream-findings-policy",
       "mapping.total_fields.limit": 3000,
       "index": {

--- a/wcs/stateless/events/main/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/main/fields/template-settings-legacy.json
@@ -4,7 +4,6 @@
   ],
   "order": 1,
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-events-v5",
     "plugins.index_state_management.policy_id": "stream-events-policy",
     "index": {
       "codec": "zstd",

--- a/wcs/stateless/events/main/fields/template-settings.json
+++ b/wcs/stateless/events/main/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-events-v5",
       "plugins.index_state_management.policy_id": "stream-events-policy",
       "index": {
         "codec": "zstd",

--- a/wcs/stateless/events/raw/fields/template-settings-legacy.json
+++ b/wcs/stateless/events/raw/fields/template-settings-legacy.json
@@ -4,7 +4,6 @@
   ],
   "order": 1,
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-events-raw-v5",
     "plugins.index_state_management.policy_id": "stream-raw-events-policy",
     "mapping.nested_fields.limit": 10,
     "index": {

--- a/wcs/stateless/events/raw/fields/template-settings.json
+++ b/wcs/stateless/events/raw/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-events-raw-v5",
       "plugins.index_state_management.policy_id": "stream-raw-events-policy",
       "mapping.nested_fields.limit": 10,
       "index": {

--- a/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings-legacy.json
@@ -5,7 +5,6 @@
   "order": 1,
   "data_stream": {},
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-metrics-agents",
     "plugins.index_state_management.policy_id": "stream-metrics-policy",
     "index": {
       "codec": "zstd",

--- a/wcs/stateless/metrics/agents/fields/template-settings.json
+++ b/wcs/stateless/metrics/agents/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-metrics-agents",
       "plugins.index_state_management.policy_id": "stream-metrics-policy",
       "index": {
         "codec": "zstd",

--- a/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings-legacy.json
@@ -5,7 +5,6 @@
   "order": 1,
   "data_stream": {},
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-metrics-comms-v4",
     "plugins.index_state_management.policy_id": "stream-metrics-policy",
     "index": {
       "codec": "zstd",

--- a/wcs/stateless/metrics/comms/fields/template-settings.json
+++ b/wcs/stateless/metrics/comms/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-metrics-comms-v4",
       "plugins.index_state_management.policy_id": "stream-metrics-policy",
       "index": {
         "codec": "zstd",

--- a/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings-legacy.json
@@ -5,7 +5,6 @@
   "order": 1,
   "data_stream": {},
   "settings": {
-    "plugins.index_state_management.rollover_alias": "wazuh-metrics-normalization",
     "plugins.index_state_management.policy_id": "stream-metrics-policy",
     "index": {
       "codec": "zstd",

--- a/wcs/stateless/metrics/engine/fields/template-settings.json
+++ b/wcs/stateless/metrics/engine/fields/template-settings.json
@@ -6,7 +6,6 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "plugins.index_state_management.rollover_alias": "wazuh-metrics-normalization",
       "plugins.index_state_management.policy_id": "stream-metrics-policy",
       "index": {
         "codec": "zstd",


### PR DESCRIPTION
## Description

ISM (Index State Management) produces recurring ERROR logs for all data stream backing indices:

```
[ERROR][o.o.i.i.ManagedIndexRunner] Failed to save ManagedIndexMetaData for [index=.ds-wazuh-metrics-normalization-000001]
[ERROR][o.o.i.i.ManagedIndexRunner] Failed to update ManagedIndexMetaData after executing the Step : attempt_rollover
```

The root cause is the `plugins.index_state_management.rollover_alias` setting present in all data stream index templates. ISM's `AttemptRolloverStep` checks this setting first: if present, it attempts alias-based rollover and validates that the alias exists on the index. Since data streams do not use aliases, this validation fails. ISM only falls through to the correct data stream rollover path when `rollover_alias` is absent.

Closes #1388

## Proposed Changes

- Removed `plugins.index_state_management.rollover_alias` from all 8 data stream template JSON files.
- Removed the dynamic `rollover_alias` override in `StreamIndex.createTemplate()`.
- Removed `rollover_alias` from all 16 WCS upstream `template-settings.json` and `template-settings-legacy.json` source files to prevent re-introduction on schema generation.
- Left `content/ioc.json` unchanged, as it is a regular alias-backed index where `rollover_alias` is correct.

### Results and Evidence

- Build passes: `./gradlew build -x check`
- `grep -r "rollover_alias" plugins/setup/src/main/resources/templates/streams/` returns no matches.
- `grep -r "rollover_alias" plugins/setup/src/main/resources/templates/content/ioc.json` still returns a match (expected).

### Artifacts Affected

- `wazuh-indexer-setup` plugin (setup plugin ZIP).

### Configuration Changes

- The `plugins.index_state_management.rollover_alias` index setting is no longer applied to new data stream backing indices.
- Existing backing indices retain the old setting in their metadata until they age out per the ISM delete policy. To fix immediately on a running cluster, either clear the setting or force a rollover:
  ```
  PUT .ds-<data-stream>-000001/_settings
  {"index.plugins.index_state_management.rollover_alias": null}
  ```
  ```
  POST <data-stream>/_rollover
  ```

### Documentation Updates

N/A

### Tests Introduced

N/A — the change removes a misconfigured setting from static JSON templates and a code block that propagated it. Existing `StreamIndexTests` and `DataStreamsIT` do not assert on `rollover_alias`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
