### PR TITLE
Reject promotions that would leave a detector without enabled rules

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupService.java
@@ -90,11 +90,13 @@ public class DetectorLookupService {
      *
      * <p>Disabled detectors are filtered out: a stopped detector needs no protection.
      *
-     * <p>Best-effort: if the detectors index cannot be read (for example, it does not exist yet), an
-     * empty list is returned so a promotion is never blocked by a lookup problem.
+     * <p>A failed search is propagated to the caller and fails the promotion: it must not be let
+     * through on a guard that could not read its inputs. A cluster with no detectors index yet is not
+     * one of those failures, because the search uses {@code LENIENT_EXPAND_OPEN} and gets an empty
+     * result instead of an error.
      *
      * @param ruleIds the content-manager rule ids being promoted.
-     * @param listener receives the affected detectors.
+     * @param listener receives the affected detectors, or the failure that prevented reading them.
      */
     public void findDetectorsUsingRules(
             Set<String> ruleIds, ActionListener<List<DetectorRules>> listener) {
@@ -138,7 +140,7 @@ public class DetectorLookupService {
                         },
                         e -> {
                             log.warn(Constants.W_LOG_DETECTOR_LOOKUP_FAILED, e.getMessage());
-                            listener.onResponse(Collections.emptyList());
+                            listener.onFailure(e);
                         }));
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupService.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.transport.client.Client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.utils.Constants;
+
+/**
+ * Reads the data needed to decide whether a promotion would leave a detector without enabled rules:
+ * the detectors currently running and the {@code enabled} state of rules in a given space.
+ *
+ * <p>Contains no decision logic; see {@link
+ * com.wazuh.contentmanager.cti.catalog.utils.DetectorRuleGuard}.
+ */
+public class DetectorLookupService {
+
+    private static final Logger log = LogManager.getLogger(DetectorLookupService.class);
+
+    private static final int MAX_RESULTS = 10000;
+
+    /**
+     * Security Analytics detectors index. Read-only: content-manager never writes to it, and cannot
+     * reference the constant from security-analytics because only its {@code commons} module is on
+     * the compile classpath.
+     */
+    private static final String DETECTORS_INDEX = ".opensearch-sap-detectors-config";
+
+    private static final String CUSTOM_RULES_PATH = "detector.inputs.detector_input.custom_rules";
+
+    private final Client client;
+
+    /**
+     * @param client the OpenSearch client.
+     */
+    public DetectorLookupService(Client client) {
+        this.client = client;
+    }
+
+    /**
+     * A detector and the custom rules it references.
+     *
+     * @param id the detector document id.
+     * @param name the detector name, used in user-facing messages.
+     * @param enabled whether the detector is running.
+     * @param ruleIds the content-manager rule ids referenced through {@code custom_rules}.
+     */
+    public record DetectorRules(String id, String name, boolean enabled, List<String> ruleIds) {}
+
+    /**
+     * Returns the enabled detectors that reference any of the given rules, with the custom rules each
+     * one references.
+     *
+     * <p>The nested query narrows the result server-side. Because {@code custom_rules.id} is mapped
+     * as {@code text}, the match is analysed and can return detectors that merely share a token of a
+     * UUID; those are discarded by an exact intersection check. The match never misses a real
+     * reference, so no detector is silently skipped.
+     *
+     * <p>Disabled detectors are filtered out: a stopped detector needs no protection.
+     *
+     * <p>Best-effort: if the detectors index cannot be read (for example, it does not exist yet), an
+     * empty list is returned so a promotion is never blocked by a lookup problem.
+     *
+     * @param ruleIds the content-manager rule ids being promoted.
+     * @param listener receives the affected detectors.
+     */
+    public void findDetectorsUsingRules(
+            Set<String> ruleIds, ActionListener<List<DetectorRules>> listener) {
+        if (ruleIds.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+
+        BoolQueryBuilder anyRule = QueryBuilders.boolQuery().minimumShouldMatch(1);
+        for (String ruleId : ruleIds) {
+            anyRule.should(QueryBuilders.matchQuery(CUSTOM_RULES_PATH + ".id", ruleId));
+        }
+
+        SearchRequest request =
+                new SearchRequest(DETECTORS_INDEX)
+                        .source(
+                                new SearchSourceBuilder()
+                                        .query(QueryBuilders.nestedQuery(CUSTOM_RULES_PATH, anyRule, ScoreMode.None))
+                                        .fetchSource(
+                                                new String[] {
+                                                    "detector.name", "detector.enabled", CUSTOM_RULES_PATH + ".id"
+                                                },
+                                                null)
+                                        .size(MAX_RESULTS))
+                        .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        this.client.search(
+                request,
+                ActionListener.wrap(
+                        response -> {
+                            List<DetectorRules> detectors = new ArrayList<>();
+                            for (SearchHit hit : response.getHits()) {
+                                DetectorRules parsed = parseDetector(hit);
+                                if (parsed != null
+                                        && parsed.enabled()
+                                        && parsed.ruleIds().stream().anyMatch(ruleIds::contains)) {
+                                    detectors.add(parsed);
+                                }
+                            }
+                            listener.onResponse(detectors);
+                        },
+                        e -> {
+                            log.warn(Constants.W_LOG_DETECTOR_LOOKUP_FAILED, e.getMessage());
+                            listener.onResponse(Collections.emptyList());
+                        }));
+    }
+
+    /** Extracts the name, enabled flag and referenced custom rule ids from a detector document. */
+    @SuppressWarnings("unchecked")
+    private static DetectorRules parseDetector(SearchHit hit) {
+        Map<String, Object> source = hit.getSourceAsMap();
+        Object detectorObj = source == null ? null : source.get(Constants.KEY_DETECTOR);
+        if (!(detectorObj instanceof Map)) {
+            return null;
+        }
+        Map<String, Object> detector = (Map<String, Object>) detectorObj;
+
+        boolean enabled = Boolean.TRUE.equals(detector.get(Constants.KEY_ENABLED));
+        Object name = detector.get(Constants.KEY_NAME);
+
+        List<String> ruleIds = new ArrayList<>();
+        Object inputsObj = detector.get("inputs");
+        if (inputsObj instanceof List) {
+            for (Object inputObj : (List<Object>) inputsObj) {
+                if (!(inputObj instanceof Map)) {
+                    continue;
+                }
+                Object detectorInputObj = ((Map<String, Object>) inputObj).get("detector_input");
+                if (!(detectorInputObj instanceof Map)) {
+                    continue;
+                }
+                Object customRulesObj = ((Map<String, Object>) detectorInputObj).get("custom_rules");
+                if (!(customRulesObj instanceof List)) {
+                    continue;
+                }
+                for (Object ruleObj : (List<Object>) customRulesObj) {
+                    if (ruleObj instanceof Map) {
+                        Object id = ((Map<String, Object>) ruleObj).get(Constants.KEY_ID);
+                        if (id != null) {
+                            ruleIds.add(id.toString());
+                        }
+                    }
+                }
+            }
+        }
+
+        return new DetectorRules(
+                hit.getId(), name == null ? hit.getId() : name.toString(), enabled, ruleIds);
+    }
+
+    /**
+     * Returns the {@code enabled} state of the given rules within a space. A rule whose document has
+     * no {@code enabled} field counts as enabled, matching the convention used elsewhere. Rules that
+     * do not exist in the space are simply absent from the result.
+     *
+     * @param ruleIds the content-manager rule ids to look up.
+     * @param space the space to read from.
+     * @param listener receives rule id to enabled state.
+     */
+    public void fetchRuleEnabledStates(
+            Set<String> ruleIds, Space space, ActionListener<Map<String, Boolean>> listener) {
+        if (ruleIds.isEmpty()) {
+            listener.onResponse(Collections.emptyMap());
+            return;
+        }
+
+        SearchRequest request =
+                new SearchRequest(Constants.INDEX_RULES)
+                        .source(
+                                new SearchSourceBuilder()
+                                        .query(
+                                                QueryBuilders.boolQuery()
+                                                        .must(QueryBuilders.termsQuery(Constants.Q_DOCUMENT_ID, ruleIds))
+                                                        .must(
+                                                                QueryBuilders.termQuery(Constants.Q_SPACE_NAME, space.toString())))
+                                        .fetchSource(
+                                                new String[] {Constants.Q_DOCUMENT_ID, Constants.Q_DOCUMENT_ENABLED}, null)
+                                        .size(MAX_RESULTS));
+
+        this.client.search(
+                request,
+                ActionListener.wrap(
+                        response -> {
+                            Map<String, Boolean> states = new HashMap<>();
+                            for (SearchHit hit : response.getHits()) {
+                                Map<String, Object> source = hit.getSourceAsMap();
+                                Object documentObj = source == null ? null : source.get(Constants.KEY_DOCUMENT);
+                                if (!(documentObj instanceof Map)) {
+                                    continue;
+                                }
+                                @SuppressWarnings("unchecked")
+                                Map<String, Object> document = (Map<String, Object>) documentObj;
+                                Object id = document.get(Constants.KEY_ID);
+                                if (id == null) {
+                                    continue;
+                                }
+                                states.put(
+                                        id.toString(), !Boolean.FALSE.equals(document.get(Constants.KEY_ENABLED)));
+                            }
+                            listener.onResponse(states);
+                        },
+                        listener::onFailure));
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/DetectorRuleGuard.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/DetectorRuleGuard.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.utils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Decides whether promoting a set of rule changes would leave a detector with no enabled rules.
+ *
+ * <p>A detector compiles its enabled rules into an alerting monitor. If every rule it references
+ * ends up disabled, the monitor is removed and the detector stops producing findings while still
+ * appearing configured. This guard lets the promotion be rejected before that happens.
+ */
+public final class DetectorRuleGuard {
+
+    private DetectorRuleGuard() {}
+
+    /**
+     * Returns whether the promotion would take a detector from having at least one enabled rule to
+     * having none. A detector that already had none is not considered, since the promotion does not
+     * make its situation worse.
+     *
+     * @param detectorRuleIds the rule ids referenced by the detector.
+     * @param currentEnabled enabled state of those rules in the target space, before the promotion. A
+     *     missing entry counts as disabled.
+     * @param incomingEnabled enabled state carried by the promotion, keyed by rule id. Only contains
+     *     the rules included in the changeset.
+     * @param removedRuleIds rule ids the promotion deletes.
+     * @return {@code true} when the promotion must be rejected for this detector.
+     */
+    public static boolean wouldLeaveDetectorEmpty(
+            List<String> detectorRuleIds,
+            Map<String, Boolean> currentEnabled,
+            Map<String, Boolean> incomingEnabled,
+            Set<String> removedRuleIds) {
+
+        long before =
+                detectorRuleIds.stream().filter(id -> Boolean.TRUE.equals(currentEnabled.get(id))).count();
+        if (before == 0) {
+            return false;
+        }
+
+        long after =
+                detectorRuleIds.stream()
+                        .filter(id -> !removedRuleIds.contains(id))
+                        .filter(
+                                id ->
+                                        incomingEnabled.containsKey(id)
+                                                ? Boolean.TRUE.equals(incomingEnabled.get(id))
+                                                : Boolean.TRUE.equals(currentEnabled.get(id)))
+                        .count();
+
+        return after == 0;
+    }
+}

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
@@ -39,12 +39,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.action.PostPromoteAction;
@@ -1377,12 +1379,6 @@ public class TransportPostPromoteAction
             return;
         }
 
-        // Removals are accounted for, but today they cannot reach this check: deleting a rule
-        // already strips its id from every detector that referenced it, because Security Analytics
-        // matches references by content-manager document id and that id is shared by the copy of
-        // the rule in every space. By the time the removal is promoted, the detector no longer
-        // references the rule and the lookup below returns nothing. The accounting is kept so the
-        // guard still holds if that cascade is ever made space-aware.
         Set<String> changedRuleIds = new HashSet<>();
         Set<String> removedRuleIds = new HashSet<>();
         for (SpaceDiff.OperationItem item : ruleChanges) {
@@ -1415,7 +1411,7 @@ public class TransportPostPromoteAction
                                                             ActionListener.wrap(
                                                                     incomingEnabled ->
                                                                             listener.onResponse(
-                                                                                    firstRejection(
+                                                                                    rejectionMessage(
                                                                                             affected,
                                                                                             currentEnabled,
                                                                                             incomingEnabled,
@@ -1427,32 +1423,86 @@ public class TransportPostPromoteAction
     }
 
     /**
-     * Returns the rejection message for the first detector the promotion would empty, or {@code null}
+     * Returns the rejection message naming every detector the promotion would empty, or {@code null}
      * when none would be.
+     *
+     * <p>A promotion carries the whole space diff, so a single one can empty several detectors, each
+     * through a different rule. All of them are reported together, otherwise the user would fix one
+     * per attempt without knowing how many are left. The listing is ordered by detector name so the
+     * same promotion always produces the same message.
+     *
+     * @param detectors the enabled detectors referencing the promoted rules.
+     * @param currentEnabled enabled state of those detectors' rules in the target space.
+     * @param incomingEnabled enabled state carried by the promotion.
+     * @param removedRuleIds rule ids the promotion deletes.
+     * @return the message to return as {@code 400}, or {@code null} to let the promotion through.
      */
-    private static String firstRejection(
+    static String rejectionMessage(
             List<DetectorLookupService.DetectorRules> detectors,
             Map<String, Boolean> currentEnabled,
             Map<String, Boolean> incomingEnabled,
             Set<String> removedRuleIds) {
+
+        List<EmptiedDetector> emptied = new ArrayList<>();
         for (DetectorLookupService.DetectorRules detector : detectors) {
             if (DetectorRuleGuard.wouldLeaveDetectorEmpty(
                     detector.ruleIds(), currentEnabled, incomingEnabled, removedRuleIds)) {
-                String culprit =
-                        detector.ruleIds().stream()
-                                .filter(
-                                        id ->
-                                                Boolean.TRUE.equals(currentEnabled.get(id))
-                                                        && (removedRuleIds.contains(id)
-                                                                || Boolean.FALSE.equals(incomingEnabled.get(id))))
-                                .findFirst()
-                                .orElse("");
-                return String.format(
-                        Locale.ROOT, Constants.E_400_PROMOTION_EMPTIES_DETECTOR, culprit, detector.name());
+                emptied.add(
+                        new EmptiedDetector(
+                                detector.name(),
+                                culpritRule(detector, currentEnabled, incomingEnabled, removedRuleIds)));
             }
         }
-        return null;
+
+        if (emptied.isEmpty()) {
+            return null;
+        }
+        emptied.sort(Comparator.comparing(EmptiedDetector::detectorName));
+
+        if (emptied.size() == 1) {
+            EmptiedDetector only = emptied.get(0);
+            return String.format(
+                    Locale.ROOT,
+                    Constants.E_400_PROMOTION_EMPTIES_DETECTOR,
+                    only.culpritRule(),
+                    only.detectorName());
+        }
+
+        String listing =
+                emptied.stream()
+                        .map(
+                                item ->
+                                        String.format(
+                                                Locale.ROOT,
+                                                "[%s] by disabling rule [%s]",
+                                                item.detectorName(),
+                                                item.culpritRule()))
+                        .collect(Collectors.joining(", "));
+        return String.format(
+                Locale.ROOT, Constants.E_400_PROMOTION_EMPTIES_DETECTORS, emptied.size(), listing);
     }
+
+    /**
+     * Returns the first rule of the detector that the promotion takes away, which is the one worth
+     * naming to the user.
+     */
+    private static String culpritRule(
+            DetectorLookupService.DetectorRules detector,
+            Map<String, Boolean> currentEnabled,
+            Map<String, Boolean> incomingEnabled,
+            Set<String> removedRuleIds) {
+        return detector.ruleIds().stream()
+                .filter(
+                        id ->
+                                Boolean.TRUE.equals(currentEnabled.get(id))
+                                        && (removedRuleIds.contains(id)
+                                                || Boolean.FALSE.equals(incomingEnabled.get(id))))
+                .findFirst()
+                .orElse("");
+    }
+
+    /** A detector the promotion would empty, with the rule that empties it. */
+    private record EmptiedDetector(String detectorName, String culpritRule) {}
 
     // ── Inner classes ────────────────────────────────────────────────────────
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportPostPromoteAction.java
@@ -52,8 +52,10 @@ import com.wazuh.contentmanager.action.PostPromoteRequest;
 import com.wazuh.contentmanager.action.ReloadEngineContentAction;
 import com.wazuh.contentmanager.action.ReloadEngineContentRequest;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.service.DetectorLookupService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
+import com.wazuh.contentmanager.cti.catalog.utils.DetectorRuleGuard;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.SpaceDiff;
 import com.wazuh.contentmanager.utils.Constants;
@@ -91,6 +93,7 @@ public class TransportPostPromoteAction
     private final EngineService engine;
     private final SecurityAnalyticsService securityAnalyticsService;
     private final Client client;
+    private final DetectorLookupService detectorLookupService;
 
     @Inject
     public TransportPostPromoteAction(
@@ -105,6 +108,7 @@ public class TransportPostPromoteAction
         this.engine = engine;
         this.securityAnalyticsService = securityAnalyticsService;
         this.client = client;
+        this.detectorLookupService = new DetectorLookupService(client);
     }
 
     // ── Entry point ──────────────────────────────────────────────────────────
@@ -131,7 +135,18 @@ public class TransportPostPromoteAction
             SpaceDiff spaceDiff = MAPPER.readValue(body, SpaceDiff.class);
             this.validatePromoteRequest(spaceDiff);
 
-            this.gatherPromotionDataAsync(spaceDiff, listener);
+            this.validateNoDetectorLeftEmptyAsync(
+                    spaceDiff,
+                    ActionListener.wrap(
+                            rejection -> {
+                                if (rejection != null) {
+                                    log.warn(Constants.W_LOG_VALIDATION_FAILED, rejection);
+                                    listener.onResponse(new MessageStatusResponse(rejection, RestStatus.BAD_REQUEST));
+                                    return;
+                                }
+                                this.gatherPromotionDataAsync(spaceDiff, listener);
+                            },
+                            e -> respondWithError(listener, e)));
         } catch (IllegalArgumentException e) {
             log.warn(Constants.W_LOG_VALIDATION_FAILED, e.getMessage());
             listener.onResponse(new MessageStatusResponse(e.getMessage(), RestStatus.BAD_REQUEST));
@@ -1334,6 +1349,109 @@ public class TransportPostPromoteAction
                 throw new IllegalArgumentException(Constants.E_400_INVALID_PROMOTION_OPERATION_FOR_POLICY);
             }
         }
+    }
+
+    /**
+     * Rejects a promotion that would leave a running detector with no enabled rules.
+     *
+     * <p>Only applies when promoting into {@code custom}, the space detectors resolve their rules
+     * from. The decision is made on the resulting state, so an update that does not change a rule's
+     * {@code enabled} flag never blocks, and a detector that already had no enabled rules is left
+     * alone.
+     *
+     * @param spaceDiff the requested promotion.
+     * @param listener receives the rejection message, or {@code null} when the promotion may proceed.
+     */
+    private void validateNoDetectorLeftEmptyAsync(
+            SpaceDiff spaceDiff, ActionListener<String> listener) {
+        Space sourceSpace = spaceDiff.getSpace();
+        if (sourceSpace == null || sourceSpace.promote() != Space.CUSTOM) {
+            listener.onResponse(null);
+            return;
+        }
+
+        List<SpaceDiff.OperationItem> ruleChanges =
+                spaceDiff.getChanges() == null ? null : spaceDiff.getChanges().getRules();
+        if (ruleChanges == null || ruleChanges.isEmpty()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        // Removals are accounted for, but today they cannot reach this check: deleting a rule
+        // already strips its id from every detector that referenced it, because Security Analytics
+        // matches references by content-manager document id and that id is shared by the copy of
+        // the rule in every space. By the time the removal is promoted, the detector no longer
+        // references the rule and the lookup below returns nothing. The accounting is kept so the
+        // guard still holds if that cascade is ever made space-aware.
+        Set<String> changedRuleIds = new HashSet<>();
+        Set<String> removedRuleIds = new HashSet<>();
+        for (SpaceDiff.OperationItem item : ruleChanges) {
+            changedRuleIds.add(item.getId());
+            if (item.getOperation() == SpaceDiff.Operation.REMOVE) {
+                removedRuleIds.add(item.getId());
+            }
+        }
+
+        this.detectorLookupService.findDetectorsUsingRules(
+                changedRuleIds,
+                ActionListener.wrap(
+                        affected -> {
+                            if (affected.isEmpty()) {
+                                listener.onResponse(null);
+                                return;
+                            }
+
+                            Set<String> allRuleIds = new HashSet<>();
+                            affected.forEach(detector -> allRuleIds.addAll(detector.ruleIds()));
+
+                            this.detectorLookupService.fetchRuleEnabledStates(
+                                    allRuleIds,
+                                    Space.CUSTOM,
+                                    ActionListener.wrap(
+                                            currentEnabled ->
+                                                    this.detectorLookupService.fetchRuleEnabledStates(
+                                                            changedRuleIds,
+                                                            sourceSpace,
+                                                            ActionListener.wrap(
+                                                                    incomingEnabled ->
+                                                                            listener.onResponse(
+                                                                                    firstRejection(
+                                                                                            affected,
+                                                                                            currentEnabled,
+                                                                                            incomingEnabled,
+                                                                                            removedRuleIds)),
+                                                                    listener::onFailure)),
+                                            listener::onFailure));
+                        },
+                        listener::onFailure));
+    }
+
+    /**
+     * Returns the rejection message for the first detector the promotion would empty, or {@code null}
+     * when none would be.
+     */
+    private static String firstRejection(
+            List<DetectorLookupService.DetectorRules> detectors,
+            Map<String, Boolean> currentEnabled,
+            Map<String, Boolean> incomingEnabled,
+            Set<String> removedRuleIds) {
+        for (DetectorLookupService.DetectorRules detector : detectors) {
+            if (DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                    detector.ruleIds(), currentEnabled, incomingEnabled, removedRuleIds)) {
+                String culprit =
+                        detector.ruleIds().stream()
+                                .filter(
+                                        id ->
+                                                Boolean.TRUE.equals(currentEnabled.get(id))
+                                                        && (removedRuleIds.contains(id)
+                                                                || Boolean.FALSE.equals(incomingEnabled.get(id))))
+                                .findFirst()
+                                .orElse("");
+                return String.format(
+                        Locale.ROOT, Constants.E_400_PROMOTION_EMPTIES_DETECTOR, culprit, detector.name());
+            }
+        }
+        return null;
     }
 
     // ── Inner classes ────────────────────────────────────────────────────────

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -83,7 +83,12 @@ public class Constants {
             "Integration [%s] not found in the '%s' space.";
     public static final String E_400_PROMOTION_EMPTIES_DETECTOR =
             "Rule [%s] cannot be promoted because it would leave detector [%s] without enabled rules. "
-                    + "Delete the detector if you want to stop it.";
+                    + "Disable or delete the detector, or keep one of its rules enabled.";
+
+    public static final String E_400_PROMOTION_EMPTIES_DETECTORS =
+            "This promotion would leave %d detectors without enabled rules: %s. "
+                    + "Disable or delete them, or keep one of their rules enabled.";
+
     public static final String E_404_RESOURCE_NOT_FOUND = "Resource not found.";
     public static final String E_412_UNPROTECTED_CREDENTIALS_INDEX =
             "Registration is disabled because the '"

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -81,6 +81,9 @@ public class Constants {
             "Logtest is only supported for the 'test', 'custom' and 'standard' spaces. Received space: '%s'.";
     public static final String E_400_INTEGRATION_NOT_FOUND =
             "Integration [%s] not found in the '%s' space.";
+    public static final String E_400_PROMOTION_EMPTIES_DETECTOR =
+            "Rule [%s] cannot be promoted because it would leave detector [%s] without enabled rules. "
+                    + "Delete the detector if you want to stop it.";
     public static final String E_404_RESOURCE_NOT_FOUND = "Resource not found.";
     public static final String E_412_UNPROTECTED_CREDENTIALS_INDEX =
             "Registration is disabled because the '"
@@ -126,6 +129,8 @@ public class Constants {
     public static final String W_LOG_RESOURCE_NOT_FOUND = "{} [{}] not found.";
     public static final String W_LOG_EXTERNAL_NOT_FOUND =
             "Resource {} [{}] not found in external service, continuing deletion.";
+    public static final String W_LOG_DETECTOR_LOOKUP_FAILED =
+            "Could not read detectors while validating promotion: {}";
     public static final String D_LOG_SAP_SEND = "Sending {} [{}] with ID [{}] to Security Analytics.";
     public static final String D_LOG_SAP_DELETED = "{} deleted successfully (document.id={}{}).";
     public static final String D_LOG_SAP_DELETE_ASYNC =

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupServiceTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.service;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponseSections;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.Client;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/** Unit tests for {@link DetectorLookupService}. */
+public class DetectorLookupServiceTests extends OpenSearchTestCase {
+
+    private Client client;
+    private DetectorLookupService service;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        this.client = mock(Client.class);
+        this.service = new DetectorLookupService(this.client);
+    }
+
+    /** Builds a SearchResponse whose hits carry the given raw JSON sources. */
+    private SearchResponse searchResponseOf(String... sources) {
+        SearchHit[] hits = new SearchHit[sources.length];
+        for (int i = 0; i < sources.length; i++) {
+            SearchHit hit = new SearchHit(i, String.valueOf(i), null, null);
+            hit.sourceRef(new BytesArray(sources[i]));
+            hits[i] = hit;
+        }
+        SearchHits searchHits =
+                new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponseSections sections =
+                new SearchResponseSections(searchHits, null, null, false, null, null, 1);
+        return new SearchResponse(sections, null, 1, 1, 0, 100, null, null);
+    }
+
+    /** Stubs client.search to answer with the given response. */
+    @SuppressWarnings("unchecked")
+    private void stubSearch(SearchResponse response) {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<SearchResponse> listener =
+                                    (ActionListener<SearchResponse>) invocation.getArguments()[1];
+                            listener.onResponse(response);
+                            return null;
+                        })
+                .when(this.client)
+                .search(any(SearchRequest.class), any(ActionListener.class));
+    }
+
+    /** Enabled detectors referencing one of the requested rules are returned with their rule ids. */
+    public void testFindDetectorsUsingRulesReturnsRuleIds() {
+        stubSearch(
+                searchResponseOf(
+                        "{\"detector\":{\"name\":\"d1\",\"enabled\":true,\"inputs\":[{\"detector_input\":"
+                                + "{\"custom_rules\":[{\"id\":\"r1\"},{\"id\":\"r2\"}]}}]}}"));
+
+        AtomicReference<List<DetectorLookupService.DetectorRules>> result = new AtomicReference<>();
+        this.service.findDetectorsUsingRules(
+                Set.of("r1"), ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+
+        assertEquals(1, result.get().size());
+        assertEquals("d1", result.get().get(0).name());
+        assertEquals(List.of("r1", "r2"), result.get().get(0).ruleIds());
+    }
+
+    /** Disabled detectors are filtered out: a stopped detector needs no protection. */
+    public void testFindDetectorsUsingRulesSkipsDisabledOnes() {
+        stubSearch(
+                searchResponseOf(
+                        "{\"detector\":{\"name\":\"off\",\"enabled\":false,\"inputs\":[{\"detector_input\":"
+                                + "{\"custom_rules\":[{\"id\":\"r1\"}]}}]}}"));
+
+        AtomicReference<List<DetectorLookupService.DetectorRules>> result = new AtomicReference<>();
+        this.service.findDetectorsUsingRules(
+                Set.of("r1"), ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+
+        assertTrue(result.get().isEmpty());
+    }
+
+    /**
+     * The nested query runs against a {@code text} field, so it can return detectors that merely
+     * share a UUID token. Those must be discarded by the intersection check.
+     */
+    public void testFindDetectorsUsingRulesDiscardsOverMatches() {
+        stubSearch(
+                searchResponseOf(
+                        "{\"detector\":{\"name\":\"unrelated\",\"enabled\":true,\"inputs\":[{\"detector_input\":"
+                                + "{\"custom_rules\":[{\"id\":\"other\"}]}}]}}"));
+
+        AtomicReference<List<DetectorLookupService.DetectorRules>> result = new AtomicReference<>();
+        this.service.findDetectorsUsingRules(
+                Set.of("r1"), ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+
+        assertTrue(result.get().isEmpty());
+    }
+
+    /** An empty id set short-circuits without querying. */
+    public void testFindDetectorsUsingRulesWithNoIds() {
+        AtomicReference<List<DetectorLookupService.DetectorRules>> result = new AtomicReference<>();
+        this.service.findDetectorsUsingRules(
+                Set.of(), ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+
+        assertTrue(result.get().isEmpty());
+    }
+
+    /** A missing detectors index yields an empty list rather than an error. */
+    @SuppressWarnings("unchecked")
+    public void testFindDetectorsUsingRulesToleratesMissingIndex() {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<SearchResponse> listener =
+                                    (ActionListener<SearchResponse>) invocation.getArguments()[1];
+                            listener.onFailure(new RuntimeException("index_not_found_exception"));
+                            return null;
+                        })
+                .when(this.client)
+                .search(any(SearchRequest.class), any(ActionListener.class));
+
+        AtomicReference<List<DetectorLookupService.DetectorRules>> result = new AtomicReference<>();
+        this.service.findDetectorsUsingRules(
+                Set.of("r1"), ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+
+        assertTrue(result.get().isEmpty());
+    }
+
+    /** Rule states are keyed by document id, defaulting to enabled when the field is absent. */
+    public void testFetchRuleEnabledStates() {
+        stubSearch(
+                searchResponseOf(
+                        "{\"document\":{\"id\":\"r1\",\"enabled\":false}}", "{\"document\":{\"id\":\"r2\"}}"));
+
+        AtomicReference<Map<String, Boolean>> result = new AtomicReference<>();
+        this.service.fetchRuleEnabledStates(
+                Set.of("r1", "r2"),
+                Space.CUSTOM,
+                ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+
+        assertFalse(result.get().get("r1"));
+        assertTrue(result.get().get("r2"));
+    }
+
+    /** An empty id set short-circuits without querying. */
+    public void testFetchRuleEnabledStatesWithNoIds() {
+        AtomicReference<Map<String, Boolean>> result = new AtomicReference<>();
+        this.service.fetchRuleEnabledStates(
+                Set.of(), Space.CUSTOM, ActionListener.wrap(result::set, e -> fail(e.getMessage())));
+
+        assertTrue(result.get().isEmpty());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/DetectorLookupServiceTests.java
@@ -138,24 +138,43 @@ public class DetectorLookupServiceTests extends OpenSearchTestCase {
         assertTrue(result.get().isEmpty());
     }
 
-    /** A missing detectors index yields an empty list rather than an error. */
-    @SuppressWarnings("unchecked")
+    /**
+     * A cluster with no detectors yet answers with no hits, not with an error: the search is issued
+     * with {@code LENIENT_EXPAND_OPEN}, which resolves a missing index to an empty result.
+     */
     public void testFindDetectorsUsingRulesToleratesMissingIndex() {
-        doAnswer(
-                        invocation -> {
-                            ActionListener<SearchResponse> listener =
-                                    (ActionListener<SearchResponse>) invocation.getArguments()[1];
-                            listener.onFailure(new RuntimeException("index_not_found_exception"));
-                            return null;
-                        })
-                .when(this.client)
-                .search(any(SearchRequest.class), any(ActionListener.class));
+        stubSearch(searchResponseOf());
 
         AtomicReference<List<DetectorLookupService.DetectorRules>> result = new AtomicReference<>();
         this.service.findDetectorsUsingRules(
                 Set.of("r1"), ActionListener.wrap(result::set, e -> fail(e.getMessage())));
 
         assertTrue(result.get().isEmpty());
+    }
+
+    /**
+     * Any other search failure is propagated. Returning an empty list would read as "no detector
+     * references these rules" and let a promotion through on a guard that never ran.
+     */
+    @SuppressWarnings("unchecked")
+    public void testFindDetectorsUsingRulesPropagatesSearchFailures() {
+        doAnswer(
+                        invocation -> {
+                            ActionListener<SearchResponse> listener =
+                                    (ActionListener<SearchResponse>) invocation.getArguments()[1];
+                            listener.onFailure(new RuntimeException("shard failure"));
+                            return null;
+                        })
+                .when(this.client)
+                .search(any(SearchRequest.class), any(ActionListener.class));
+
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        this.service.findDetectorsUsingRules(
+                Set.of("r1"),
+                ActionListener.wrap(r -> fail("the failure should not be swallowed"), failure::set));
+
+        assertNotNull(failure.get());
+        assertEquals("shard failure", failure.get().getMessage());
     }
 
     /** Rule states are keyed by document id, defaulting to enabled when the field is absent. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/utils/DetectorRuleGuardTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/utils/DetectorRuleGuardTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.utils;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Unit tests for {@link DetectorRuleGuard}. */
+public class DetectorRuleGuardTests extends OpenSearchTestCase {
+
+    /** Disabling one rule out of three leaves two enabled: allowed. */
+    public void testAllowsWhenOtherRulesStayEnabled() {
+        assertFalse(
+                DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                        List.of("a", "b", "c"),
+                        Map.of("a", true, "b", true, "c", true),
+                        Map.of("a", false),
+                        Set.of()));
+    }
+
+    /** Disabling the only enabled rule empties the detector: blocked. */
+    public void testBlocksWhenLastEnabledRuleIsDisabled() {
+        assertTrue(
+                DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                        List.of("a", "b"), Map.of("a", true, "b", false), Map.of("a", false), Set.of()));
+    }
+
+    /** An update that does not change the enabled flag must not block. */
+    public void testAllowsUpdateThatKeepsRuleEnabled() {
+        assertFalse(
+                DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                        List.of("a", "b"), Map.of("a", true, "b", false), Map.of("a", true), Set.of()));
+    }
+
+    /** Disabling one rule while enabling another in the same promotion is allowed. */
+    public void testAllowsSwapWithinSamePromotion() {
+        assertFalse(
+                DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                        List.of("a", "b"),
+                        Map.of("a", true, "b", false),
+                        Map.of("a", false, "b", true),
+                        Set.of()));
+    }
+
+    /** A detector already without enabled rules is not made worse: allowed. */
+    public void testAllowsWhenDetectorWasAlreadyEmpty() {
+        assertFalse(
+                DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                        List.of("a", "b"), Map.of("a", false, "b", false), Map.of("a", false), Set.of()));
+    }
+
+    /** Removing the only enabled rule empties the detector: blocked. */
+    public void testBlocksWhenLastEnabledRuleIsRemoved() {
+        assertTrue(
+                DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                        List.of("a", "b"), Map.of("a", true, "b", false), Map.of(), Set.of("a")));
+    }
+
+    /** A rule with no recorded state counts as disabled, never as a phantom enabled rule. */
+    public void testTreatsUnknownRuleStateAsDisabled() {
+        assertTrue(
+                DetectorRuleGuard.wouldLeaveDetectorEmpty(
+                        List.of("a", "ghost"), Map.of("a", true), Map.of("a", false), Set.of()));
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportPostPromoteActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportPostPromoteActionTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.transport;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.wazuh.contentmanager.cti.catalog.service.DetectorLookupService.DetectorRules;
+
+/** Unit tests for the rejection message built by {@link TransportPostPromoteAction}. */
+public class TransportPostPromoteActionTests extends OpenSearchTestCase {
+
+    private static DetectorRules detector(String name, String... ruleIds) {
+        return new DetectorRules(name, name, true, List.of(ruleIds));
+    }
+
+    /** Nothing would be emptied, so the promotion proceeds. */
+    public void testNoRejectionWhenEveryDetectorKeepsARule() {
+        String message =
+                TransportPostPromoteAction.rejectionMessage(
+                        List.of(detector("keeps-one", "a", "b")),
+                        Map.of("a", true, "b", true),
+                        Map.of("a", false),
+                        Set.of());
+
+        assertNull(message);
+    }
+
+    /** A single emptied detector keeps the singular wording, naming the rule and the detector. */
+    public void testSingleDetectorIsNamedWithItsRule() {
+        String message =
+                TransportPostPromoteAction.rejectionMessage(
+                        List.of(detector("critical", "a")), Map.of("a", true), Map.of("a", false), Set.of());
+
+        assertNotNull(message);
+        assertTrue(message, message.contains("detector [critical]"));
+        assertTrue(message, message.contains("Rule [a]"));
+        assertFalse(message, message.contains("detectors"));
+    }
+
+    /**
+     * A promotion carrying several rule changes can empty several detectors at once, each through a
+     * different rule. All of them must be reported, so the user is not left fixing one per attempt.
+     */
+    public void testEveryEmptiedDetectorIsReportedWithItsOwnRule() {
+        String message =
+                TransportPostPromoteAction.rejectionMessage(
+                        List.of(detector("config-critical", "a"), detector("audit-critical", "b")),
+                        Map.of("a", true, "b", true),
+                        Map.of("a", false, "b", false),
+                        Set.of());
+
+        assertNotNull(message);
+        assertTrue(message, message.contains("2 detectors"));
+        assertTrue(message, message.contains("[audit-critical] by disabling rule [b]"));
+        assertTrue(message, message.contains("[config-critical] by disabling rule [a]"));
+    }
+
+    /** Detectors that survive the promotion are left out of the message. */
+    public void testSurvivingDetectorsAreNotReported() {
+        String message =
+                TransportPostPromoteAction.rejectionMessage(
+                        List.of(detector("survives", "a", "b"), detector("emptied", "a")),
+                        Map.of("a", true, "b", true),
+                        Map.of("a", false),
+                        Set.of());
+
+        assertNotNull(message);
+        assertTrue(message, message.contains("detector [emptied]"));
+        assertFalse(message, message.contains("survives"));
+    }
+
+    /**
+     * The listing is ordered by detector name, so the same promotion always reports the same text.
+     */
+    public void testListingIsDeterministic() {
+        List<DetectorRules> oneOrder = List.of(detector("zeta", "a"), detector("alpha", "b"));
+        List<DetectorRules> otherOrder = List.of(detector("alpha", "b"), detector("zeta", "a"));
+        Map<String, Boolean> current = Map.of("a", true, "b", true);
+        Map<String, Boolean> incoming = Map.of("a", false, "b", false);
+
+        assertEquals(
+                TransportPostPromoteAction.rejectionMessage(oneOrder, current, incoming, Set.of()),
+                TransportPostPromoteAction.rejectionMessage(otherOrder, current, incoming, Set.of()));
+    }
+
+    /** A removal is reported as the culprit just like a disable. */
+    public void testRemovedRuleIsReportedAsTheCulprit() {
+        String message =
+                TransportPostPromoteAction.rejectionMessage(
+                        List.of(detector("critical", "a")), Map.of("a", true), Map.of(), Set.of("a"));
+
+        assertNotNull(message);
+        assertTrue(message, message.contains("Rule [a]"));
+        assertTrue(message, message.contains("detector [critical]"));
+    }
+}


### PR DESCRIPTION
## Description

A promotion into `custom` can leave a detector with no enabled rules, and when it does the detector stops without saying so. Its rules are what get compiled into the alerting monitor, so taking the last enabled one away deletes the monitor and the workflow while the detector stays listed reporting `enabled: true`.

Security Analytics does raise the error, but it never reaches the user. Two layers absorb it, each for a good reason: wazuh/wazuh-indexer-security-analytics#275 downgrades it to a warning so an unrelated detector cannot fail a rule update, and Content Manager's SAP sync is best-effort so a transient problem cannot tumble a whole promotion. The promotion returns `200`.

Detecting it afterwards would mean breaking one of those two, so this rejects the promotion up front.

Relates to #1394. Depends on wazuh/wazuh-indexer-security-analytics#275.

## Proposed Changes

**The check**, in three pieces:

- `DetectorRuleGuard` is the decision, for one detector: does this promotion take it from more than zero enabled rules to zero? It reads the resulting state rather than the operation type, so an update that does not touch `enabled` never blocks and a detector already at zero is left alone.
- `DetectorLookupService` gathers the inputs: the enabled detectors referencing the changed rules, and those rules' `enabled` state in `custom` and in the source space. Plain index reads, because content-manager compiles only against `security-analytics-commons`, which exposes no read action.
- `TransportPostPromoteAction.validateNoDetectorLeftEmptyAsync` is the hook. It runs before the gathering phase, so a rejection leaves nothing to roll back, and only for promotions into `custom`; `draft → test` is never blocked.

**What it reports.** Every detector the promotion would empty, each with the rule that empties it, ordered by detector name. One promotion carries the whole diff and can empty several detectors at once, so naming only the first would have the user fixing them one attempt at a time. The message says what to do: *"Disable or delete the detector, or keep one of its rules enabled."*

**What it lets through.** Detectors the user already stopped: a disabled detector produces nothing either way, and blocking rule changes on its account would forbid a legitimate flow. Rule removals do block, and they now reach the check, because the Security Analytics side made rule deletion space-aware: a detector's reference survives until the `custom` copy goes, which is what the promotion does.

### Results and Evidence

Verified live end-to-end with both plugins deployed. Attaching the validation script and step-by-step Dev Tools guide to this comment.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `DetectorRuleGuardTests` : one case per decision branch, from the last rule being disabled to a removal and an unknown rule state counting as disabled.
- `DetectorLookupServiceTests` : both lookups against a mocked client, including the over-match discarded by the intersection check and a missing detectors index tolerated as empty.
- `TransportPostPromoteActionTests` : the rejection message, with several emptied detectors each named with their own rule, surviving detectors left out, and a deterministic listing order.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
