### PR TITLE
Give the cluster time to go green in the integration tests

### DIFF
--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
@@ -22,6 +22,7 @@ import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -85,7 +86,7 @@ public class SpaceInitializationIT extends OpenSearchIntegTestCase {
      * space: draft, test, custom), regardless of how many times the workflow runs.
      */
     public void testOnSyncCompleteDoesNotDuplicateSpaces() throws Exception {
-        this.ensureGreen();
+        this.ensureGreen(TimeValue.timeValueMinutes(2));
 
         // Create all content indices required by onSyncComplete
         this.createContentIndices();

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/StandardSpaceHashRecoveryIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/StandardSpaceHashRecoveryIT.java
@@ -24,6 +24,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
@@ -94,7 +95,7 @@ public class StandardSpaceHashRecoveryIT extends OpenSearchIntegTestCase {
      * behind — is recovered, and the recovery is idempotent.
      */
     public void testMissingStandardSpaceHashIsRecalculated() throws Exception {
-        this.ensureGreen();
+        this.ensureGreen(TimeValue.timeValueMinutes(2));
         PluginSettings.getInstance(Settings.EMPTY);
 
         this.createPoliciesIndex();


### PR DESCRIPTION
## Description

`SpaceInitializationIT.testOnSyncCompleteDoesNotDuplicateSpaces` fails with `timed out waiting for
green state` on its first statement. The setup plugin creates around forty indices at node startup, one at a time, and each one takes the cluster through YELLOW, which outlasts the 30 second default of `ensureGreen()`. Nothing is unassigned, it is only slow (which is why it fails on some machines and not others).

Closes #1471

## Proposed Changes

`ensureGreen(TimeValue.timeValueMinutes(2))` on the two calls that open a test method and therefore
wait for the whole cluster to start:

- `SpaceInitializationIT.testOnSyncCompleteDoesNotDuplicateSpaces`
- `StandardSpaceHashRecoveryIT.testMissingStandardSpaceHashIsRecalculated`

The second one is included because the `integTest` cluster is shared by the whole task, so only the
first class to run pays the startup wait. 

The other two `ensureGreen()` calls in these classes are left alone: they wait for indices the test has just created, with the cluster already settled.

### Results and Evidence

Two minutes covers what I measured locally, with margin. It can be raised if CI needs it.

Before: `SpaceInitializationIT` fails at 30s with `timed out waiting for green state`.

After:

```
com.wazuh.contentmanager.SpaceInitializationIT       tests=1  failures=0  errors=0  time=87.555s
com.wazuh.contentmanager.StandardSpaceHashRecoveryIT tests=1  failures=0  errors=0  time=5.901s
```

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None, this fixes existing tests.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
