### PR TITLE
1476 wazuh threatintel enrichments a is never created so the cti writer auto creates a dynamically mapped index under the alias name and the home overviews threat catalog fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@
 - [BUG] Undefined state if a node is restarted while the standard space hash is being calculated [(#1773)](https://github.com/wazuh/wazuh-indexer/issues/1773)
 - [BUG] Fix issues in workflows [(#1449)](https://github.com/wazuh/wazuh-indexer/issues/1449)
 - Failed to save/update ManagedIndexMetaData [(#1828)](https://github.com/wazuh/wazuh-indexer/issues/1828)
+- [BUG] `wazuh-threatintel-enrichments-a` is never created, so the CTI writer auto-creates a dynamically mapped index under the alias name and the home overview's Threat catalog fails [(#1476)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1476)
 
 ## Prior versions
 - []()

--- a/docs/dev/plugins/setup.md
+++ b/docs/dev/plugins/setup.md
@@ -21,6 +21,7 @@ classDiagram
     <<abstract>> WazuhIndex
     class StateIndex
     class StreamIndex
+    class ContentIndex
 
     %% Relations
     IndexInitializer <|-- Index : implements
@@ -28,6 +29,7 @@ classDiagram
     Index <|-- WazuhIndex
     WazuhIndex <|-- StateIndex
     WazuhIndex <|-- StreamIndex
+    WazuhIndex <|-- ContentIndex
 
     %% Schemas
     class IndexInitializer {
@@ -63,6 +65,15 @@ classDiagram
         +createIndex(String index)
     }
     class StateIndex {
+    }
+    class ContentIndex {
+        +String SUFFIX_A
+        +ContentIndex(String index, String template)
+        +getPhysicalName() String
+        +createIndex(String index)
+        +createTemplate(String template)
+        -deleteSquatterIndex(String alias) void
+        -ensureAlias(String alias, String physicalName) void
     }
 ```
 
@@ -144,10 +155,11 @@ Follow the existing structure and naming convention. Example:
 
 Edit the constructor of the `SetupPlugin` class located at: `/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java`
 
-Add the template and index entry to the `indices` map. There are two kinds of indices:
+Add the template and index entry to the `indices` map. There are three kinds of indices:
 
 - **Stream index**. Stream indices contain time-based events of any kind (alerts, statistics, logs...). These are created as Data Streams.
 - **Stateful index**. Stateful indices represent the most recent information of a subject (active vulnerabilities, installed packages, open ports, ...). These indices are different from Stream indices as they do not contain timestamps. The information is not based on time, as they always represent the most recent state.
+- **Content index**. Content indices hold the CTI catalog content the Content Manager downloads. They are not addressed by their own name: see [Threat intel content indices](#threat-intel-content-indices) below.
 
 ```java
 /**
@@ -162,6 +174,8 @@ public class SetupPlugin extends Plugin implements ClusterPlugin {
   this.indices.add(new StreamIndex("my-stream-index", "templates/streams/my-index-template-1"));
   // State indices
   this.indices.add(new StateIndex("my-state-index", "templates/states/my-index-template-2"));
+  // Content indices
+  this.indices.add(new ContentIndex("my-content-index", "templates/content/my-index-template-3"));
 
   //...
 }
@@ -511,6 +525,78 @@ The **stream-metrics-policy** manages all `wazuh-metrics-*` data streams (`wazuh
 2. **Delete State**
    - Actions: Deletes the index
    - Retry Policy: 3 attempts with exponential backoff (1-minute initial delay)
+
+---
+
+## Threat intel content indices
+
+### Overview
+
+The `wazuh-threatintel-*` indices hold the CTI catalog content the Content Manager downloads:
+IoCs, CVEs and the Engine ruleset. The setup plugin provisions all of them.
+
+| Alias | Concrete index | Template |
+| --- | --- | --- |
+| `wazuh-threatintel-enrichments` | `wazuh-threatintel-enrichments-a` | `templates/content/ioc.json` |
+| `wazuh-threatintel-filters` | `wazuh-threatintel-filters-a` | `templates/content/filters.json` |
+| `wazuh-threatintel-decoders` | `wazuh-threatintel-decoders-a` | `templates/content/decoders.json` |
+| `wazuh-threatintel-rules` | `wazuh-threatintel-rules-a` | `templates/content/rules.json` |
+| `wazuh-threatintel-kvdbs` | `wazuh-threatintel-kvdbs-a` | `templates/content/kvdbs.json` |
+| `wazuh-threatintel-integrations` | `wazuh-threatintel-integrations-a` | `templates/content/integrations.json` |
+| `wazuh-threatintel-policies` | `wazuh-threatintel-policies-a` | `templates/content/policies.json` |
+| `.wazuh-threatintel-vulnerabilities` | `.wazuh-threatintel-vulnerabilities-a` | `templates/content/vulnerabilities.json` |
+
+### Why the alias
+
+A content index is never addressed by its own name. `ContentIndex` creates the concrete index as
+`<name>-a` and points a write alias named `<name>` at it. The Content Manager needs that
+indirection: when the content source changes (a plan upgrade or downgrade), it rebuilds the whole
+catalog into a hidden `<name>-b` shadow index and swaps the alias in a single atomic action, so
+readers never see a partially populated index. The two slots alternate on each swap.
+
+`ContentIndex.createTemplate()` therefore rewrites the template's `index_patterns` to `<name>*`,
+whatever the shipped JSON declares. That covers the live slot, the shadow slot and — as a last line
+of defence — the alias name itself.
+
+### Recovering an index that squats the alias name
+
+If a write reaches the alias name before anything creates the alias, OpenSearch auto-creates a
+concrete index called `<name>` with dynamic mappings. Every keyword the schema declares becomes a
+`text` field, which has no doc_values and so cannot be aggregated or sorted on, and the index
+occupies the name the alias needs. `ContentIndex.createIndex()` deletes such an index before
+creating `<name>-a`. The Content Manager then finds the index empty with a non-zero local offset and
+resets the offset, so the content is downloaded again on the same synchronization pass.
+
+### Where the mappings live
+
+The mappings exist in two places on purpose. This plugin ships them as index templates under
+`plugins/setup/src/main/resources/templates/content/`, and the Content Manager keeps its own copies
+under `plugins/content-manager/src/main/resources/mappings/cti-*-mappings.json`, which it needs to
+create the shadow indices and to run without this plugin installed. The
+`verifyContentTemplates` Gradle task, wired into `check`, fails the build if the two sets diverge.
+
+`templates/content/ioc.json` and `templates/content/filters.json` are generated by the WCS
+generator; the other six are maintained by hand alongside the Content Manager copies.
+`templates/cve.json` is **not** the CVE content template: it is a WCS artifact for the unrelated
+`wazuh-cve*` pattern and is intentionally not registered.
+
+### Testing
+
+```bash
+./gradlew :wazuh-indexer-setup:integTest --tests '*ThreatIntelIndicesIT*'
+```
+
+Against a deployed cluster, the alias must resolve to the `-a` index and its fields must be
+aggregatable:
+
+```bash
+curl -sk -u admin:admin 'https://localhost:9200/_alias/wazuh-threatintel-*'
+curl -sk -u admin:admin \
+  'https://localhost:9200/wazuh-threatintel-enrichments/_field_caps?fields=document.type'
+```
+
+The `indices` array in the `_field_caps` response names what the alias resolved to. It must read
+`["wazuh-threatintel-enrichments-a"]` with `"aggregatable": true`.
 
 ---
 

--- a/docs/dev/plugins/setup.md
+++ b/docs/dev/plugins/setup.md
@@ -567,6 +567,19 @@ present. Without that wait it won the race by a wide margin — it created six o
 seconds before this plugin reached its threat-intel block, which meant they were created before
 their index templates were installed and so did not pick them up.
 
+Downloading CTI content requires two things to be true, and the Content Manager checks both before
+any write reaches these indices:
+
+1. `.wazuh-setup-status` reports `status: ready`, which this plugin writes only after every index it
+   owns exists.
+2. The target indices of that consumer exist.
+
+If either check fails the consumer skips its pass and logs at ERROR; it creates nothing. That is
+what keeps a mis-provisioned index from becoming a squatted one: a write through the alias name
+would otherwise auto-create a concrete index there with dynamic mappings. See issues #1476 and
+#1481, where the second of those took out vulnerability detection and package inventory because the
+global-map documents could not be indexed into an inferred mapping.
+
 To confirm on a running cluster, read the `templates` field of the creation entries in the log:
 
 ```bash

--- a/docs/dev/plugins/setup.md
+++ b/docs/dev/plugins/setup.md
@@ -558,6 +558,24 @@ readers never see a partially populated index. The two slots alternate on each s
 whatever the shipped JSON declares. That covers the live slot, the shadow slot and — as a last line
 of defence — the alias name itself.
 
+### Who creates them
+
+This plugin does, and only this plugin, on a cluster where both are installed. The Content Manager
+keeps an `ensureResourceIndicesExist()` fallback so a deployment without this plugin still works,
+but it waits for the `.wazuh-setup-status` readiness marker first and then finds the indices already
+present. Without that wait it won the race by a wide margin — it created six of the eight about 16
+seconds before this plugin reached its threat-intel block, which meant they were created before
+their index templates were installed and so did not pick them up.
+
+To confirm on a running cluster, read the `templates` field of the creation entries in the log:
+
+```bash
+grep 'creating index' /var/log/wazuh-indexer/wazuh-cluster.log | grep threatintel
+```
+
+Every `wazuh-threatintel-*-a` line must name its own `<name>-template`. An empty `templates []`
+means something created the index before the template existed.
+
 ### Recovering an index that squats the alias name
 
 If a write reaches the alias name before anything creates the alias, OpenSearch auto-creates a

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -592,7 +592,9 @@ public class ContentManagerPlugin extends Plugin
      * Setup had even installed their index templates (see issue #1476).
      */
     private void ensureResourceIndicesExist() {
-        if (!this.setupReadiness.awaitReady()) {
+        // Only a Setup plugin that is installed but did not become ready is worth warning about.
+        // Its absence is the expected path for this fallback and awaitReady() already reports it.
+        if (!this.setupReadiness.awaitReady() && this.setupReadiness.isSetupPluginInstalled()) {
             log.warn(Constants.W_LOG_SETUP_NOT_READY_PROVISIONING);
         }
         for (Map.Entry<String, String> entry : Constants.RESOURCE_INDEX_MAPPINGS.entrySet()) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -139,6 +139,7 @@ public class ContentManagerPlugin extends Plugin
     private final AtomicBoolean standardSpaceHashInFlight = new AtomicBoolean(false);
     private SpaceService spaceService;
     private SecurityAnalyticsService securityAnalyticsService;
+    private SetupReadiness setupReadiness;
     private Environment environment;
     private ClusterService clusterService;
     private LogtestService logtestService;
@@ -201,6 +202,7 @@ public class ContentManagerPlugin extends Plugin
 
         this.consumersIndex = new ConsumersIndex(client);
         this.credentialsIndex = new CredentialsIndex(client, threadPool);
+        this.setupReadiness = new SetupReadiness(client);
         this.plansService = new PlansServiceImpl();
         this.subscriptionService =
                 new SubscriptionServiceImpl(
@@ -505,22 +507,11 @@ public class ContentManagerPlugin extends Plugin
                                                 e);
                                     }
 
-                                    // The Setup plugin owns the threat-intel index topology: each one
-                                    // is created as <name>-a with the public alias <name> pointing at
-                                    // it. Wait for it to report readiness before touching them, so this
-                                    // fallback does not race it (see issue #1476) — without the wait it
-                                    // wins the race and the indices are created here, from this
-                                    // plugin's own mappings, before Setup has even installed their
-                                    // index templates.
-                                    if (!new SetupReadiness(this.client).awaitReady()) {
-                                        log.warn(Constants.W_LOG_SETUP_NOT_READY_PROVISIONING);
-                                    }
-
                                     // Create the threat-intel ruleset resource indices up front so
                                     // custom-ruleset REST endpoints work even when catalog
                                     // synchronization is disabled, or when the Setup plugin is not
-                                    // installed at all. Whenever Setup did provision them, the
-                                    // existence check below makes this a no-op.
+                                    // installed at all. Waits for the Setup plugin first; see the
+                                    // method's documentation.
                                     this.ensureResourceIndicesExist();
 
                                     // Seed the default space policies (draft, test, custom) so
@@ -592,8 +583,18 @@ public class ContentManagerPlugin extends Plugin
      * without this step the indices never get created and the custom-ruleset REST endpoints fail with
      * "no such index". Each missing index is created with its configured mappings and public alias,
      * matching what a normal first sync would produce.
+     *
+     * <p>This is a fallback for a deployment without the Setup plugin, which owns the threat-intel
+     * index topology and creates each index as {@code <name>-a} with the public alias {@code <name>}
+     * pointing at it. So the method blocks on the Setup plugin's readiness marker first and, whenever
+     * Setup did provision them, finds them all present and does nothing. Skipping that wait is what
+     * made this method win the race and create the indices from this plugin's own mappings, before
+     * Setup had even installed their index templates (see issue #1476).
      */
     private void ensureResourceIndicesExist() {
+        if (!this.setupReadiness.awaitReady()) {
+            log.warn(Constants.W_LOG_SETUP_NOT_READY_PROVISIONING);
+        }
         for (Map.Entry<String, String> entry : Constants.RESOURCE_INDEX_MAPPINGS.entrySet()) {
             String indexName = entry.getKey();
             try {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -584,12 +584,18 @@ public class ContentManagerPlugin extends Plugin
      * "no such index". Each missing index is created with its configured mappings and public alias,
      * matching what a normal first sync would produce.
      *
-     * <p>This is a fallback for a deployment without the Setup plugin, which owns the threat-intel
-     * index topology and creates each index as {@code <name>-a} with the public alias {@code <name>}
-     * pointing at it. So the method blocks on the Setup plugin's readiness marker first and, whenever
-     * Setup did provision them, finds them all present and does nothing. Skipping that wait is what
-     * made this method win the race and create the indices from this plugin's own mappings, before
-     * Setup had even installed their index templates (see issue #1476).
+     * <p>This is a fallback for a deployment where the Setup plugin does not provision them, which
+     * owns the threat-intel index topology and creates each index as {@code <name>-a} with the public
+     * alias {@code <name>} pointing at it. So the method blocks on the Setup plugin's readiness
+     * marker first and, whenever Setup did provision them, finds them all present and does nothing.
+     * Skipping that wait is what made this method win the race and create the indices from this
+     * plugin's own mappings, before Setup had even installed their index templates (see issue #1476).
+     *
+     * <p>The fallback covers two cases, not one: the Setup plugin absent, and the Setup plugin
+     * installed but reporting failed. In the second case these indices are created here from this
+     * plugin's own mappings, so no index template applies to them. The mappings themselves are
+     * equivalent — the {@code verifyContentTemplates} Gradle task fails the build if the two copies
+     * diverge — but template-supplied settings are not, which is what the accompanying warning says.
      */
     private void ensureResourceIndicesExist() {
         // Only a Setup plugin that is installed but did not become ready is worth warning about.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -112,6 +112,7 @@ import com.wazuh.contentmanager.utils.ClusterInfo;
 import com.wazuh.contentmanager.utils.Constants;
 import com.wazuh.contentmanager.utils.MockEngineService;
 import com.wazuh.contentmanager.utils.MockSecurityAnalyticsService;
+import com.wazuh.contentmanager.utils.SetupReadiness;
 
 /** Main class of the Content Manager Plugin */
 public class ContentManagerPlugin extends Plugin
@@ -504,10 +505,22 @@ public class ContentManagerPlugin extends Plugin
                                                 e);
                                     }
 
+                                    // The Setup plugin owns the threat-intel index topology: each one
+                                    // is created as <name>-a with the public alias <name> pointing at
+                                    // it. Wait for it to report readiness before touching them, so this
+                                    // fallback does not race it (see issue #1476) — without the wait it
+                                    // wins the race and the indices are created here, from this
+                                    // plugin's own mappings, before Setup has even installed their
+                                    // index templates.
+                                    if (!new SetupReadiness(this.client).awaitReady()) {
+                                        log.warn(Constants.W_LOG_SETUP_NOT_READY_PROVISIONING);
+                                    }
+
                                     // Create the threat-intel ruleset resource indices up front so
                                     // custom-ruleset REST endpoints work even when catalog
-                                    // synchronization is disabled. When sync is enabled it will
-                                    // find these already present and skip re-creating them.
+                                    // synchronization is disabled, or when the Setup plugin is not
+                                    // installed at all. Whenever Setup did provision them, the
+                                    // existence check below makes this a no-op.
                                     this.ensureResourceIndicesExist();
 
                                     // Seed the default space policies (draft, test, custom) so

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.env.Environment;
 import org.opensearch.secure_sm.AccessController;
@@ -373,6 +375,28 @@ public abstract class AbstractConsumerService {
     }
 
     /**
+     * Returns whether an index holds no documents. A read failure is reported as "not empty" so a
+     * transient error never triggers a full content re-download.
+     *
+     * @param indexName The index (or alias) to count documents on.
+     * @return true when the index is reachable and holds no documents, false otherwise.
+     */
+    private boolean isIndexEmpty(String indexName) {
+        try {
+            SearchResponse response =
+                    this.client
+                            .prepareSearch(indexName)
+                            .setSize(0)
+                            .setTrackTotalHits(true)
+                            .get(TimeValue.timeValueSeconds(PluginSettings.getInstance().getClientTimeout()));
+            return response.getHits().getTotalHits().value() == 0;
+        } catch (Exception e) {
+            log.debug(Constants.D_LOG_INDEX_COUNT_FAILED, indexName, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
      * Refreshes the specified indices to make recent changes searchable. Any errors during refresh
      * are logged as warnings but do not interrupt execution.
      *
@@ -557,11 +581,23 @@ public abstract class AbstractConsumerService {
                         this.client.admin().indices().prepareExists(indexName).get().isExists();
 
                 if (!indexExists) {
+                    // The Setup plugin provisions these indices before it marks itself ready, and this
+                    // service does not run until then, so reaching this branch means the index is missing
+                    // for another reason. Create it, but never continue without it: the writes below go
+                    // through the alias name, and OpenSearch would auto-create a concrete index there with
+                    // dynamic mappings, turning every declared keyword into a text field that cannot be
+                    // aggregated or sorted on. Abort the pass instead and let the caller retry.
+                    boolean created = false;
                     try {
                         // ContentIndex.createIndex() already logs the creation; avoid a duplicate here.
-                        index.createIndex();
+                        // It returns null (having logged why) when the mappings cannot be read.
+                        created = index.createIndex() != null;
                     } catch (InterruptedException | ExecutionException | TimeoutException e) {
                         log.error(Constants.E_LOG_INDEX_CREATE_FAILED, indexName, e.getMessage());
+                    }
+                    if (!created) {
+                        log.error(Constants.E_LOG_SYNC_ABORTED_INDEX_MISSING, indexName, consumerType);
+                        return new SyncResult(false, feedUnreachable);
                     }
                 }
             }
@@ -606,6 +642,22 @@ public abstract class AbstractConsumerService {
                             currentOffset,
                             remoteConsumer.getOffset(),
                             consumerType);
+                    currentOffset = 0;
+                }
+            }
+
+            // Empty-index resilience. A non-zero offset says the content was already downloaded, so
+            // only incremental changes would be applied and an empty index would stay empty. Reset the
+            // offset so this pass reinitializes from a snapshot instead. This recovers the index the
+            // Setup plugin had to delete because a dynamically mapped index was squatting its alias
+            // name (see issue #1476), and any other case where the content is gone but the offset is
+            // not. Restricted to single-index consumers (IoCs, CVEs), where an empty index is
+            // unambiguous; the ruleset consumer spans six indices, of which some are legitimately
+            // empty.
+            if (currentOffset > 0 && this.getMappings().size() == 1) {
+                String onlyIndex = indicesMap.values().iterator().next().getIndexName();
+                if (this.isIndexEmpty(onlyIndex)) {
+                    log.warn(Constants.W_LOG_EMPTY_INDEX_OFFSET_RESET, onlyIndex, currentOffset);
                     currentOffset = 0;
                 }
             }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -33,9 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import com.wazuh.contentmanager.ContentManagerPlugin;
 import com.wazuh.contentmanager.action.PromoteSnapshotAction;
@@ -375,6 +373,27 @@ public abstract class AbstractConsumerService {
     }
 
     /**
+     * Returns the target indices of this consumer that do not exist.
+     *
+     * <p>The Setup plugin creates each one as {@code <name>-a} with the public alias {@code <name>}
+     * pointing at it, and marks itself ready only once they are all in place, so on a correctly
+     * configured cluster this is always empty. A name is reported missing when neither an index nor
+     * an alias answers to it.
+     *
+     * @return the absent index names, empty when they all exist.
+     */
+    public List<String> missingTargetIndices() {
+        List<String> missing = new ArrayList<>();
+        for (String type : this.getMappings().keySet()) {
+            String indexName = this.getIndexName(type);
+            if (!this.client.admin().indices().prepareExists(indexName).get().isExists()) {
+                missing.add(indexName);
+            }
+        }
+        return missing;
+    }
+
+    /**
      * Returns whether an index holds no documents. A read failure is reported as "not empty" so a
      * transient error never triggers a full content re-download.
      *
@@ -570,36 +589,22 @@ public abstract class AbstractConsumerService {
             boolean feedUnreachable = catalogConfigured && remoteConsumer == null;
 
             Map<String, ContentIndex> indicesMap = new HashMap<>();
-
             for (Map.Entry<String, String> entry : this.getMappings().entrySet()) {
                 String indexName = this.getIndexName(entry.getKey());
-                ContentIndex index = new ContentIndex(this.client, indexName, entry.getValue());
-                indicesMap.put(entry.getKey(), index);
+                indicesMap.put(entry.getKey(), new ContentIndex(this.client, indexName, entry.getValue()));
+            }
 
-                // Check if index exists to avoid creation exception
-                boolean indexExists =
-                        this.client.admin().indices().prepareExists(indexName).get().isExists();
-
-                if (!indexExists) {
-                    // The Setup plugin provisions these indices before it marks itself ready, and this
-                    // service does not run until then, so reaching this branch means the index is missing
-                    // for another reason. Create it, but never continue without it: the writes below go
-                    // through the alias name, and OpenSearch would auto-create a concrete index there with
-                    // dynamic mappings, turning every declared keyword into a text field that cannot be
-                    // aggregated or sorted on. Abort the pass instead and let the caller retry.
-                    boolean created = false;
-                    try {
-                        // ContentIndex.createIndex() already logs the creation; avoid a duplicate here.
-                        // It returns null (having logged why) when the mappings cannot be read.
-                        created = index.createIndex() != null;
-                    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                        log.error(Constants.E_LOG_INDEX_CREATE_FAILED, indexName, e.getMessage());
-                    }
-                    if (!created) {
-                        log.error(Constants.E_LOG_SYNC_ABORTED_INDEX_MISSING, indexName, consumerType);
-                        return new SyncResult(false, feedUnreachable);
-                    }
-                }
+            // The second of the two preconditions for downloading content: the Setup plugin reported
+            // ready (checked by the caller) and this consumer's target indices exist. Nothing is
+            // created here — the Setup plugin owns the threat-intel index topology. Downloading into a
+            // missing index is what caused the defect this guard exists for: the writes below go
+            // through the alias name, so OpenSearch would auto-create a concrete index there with
+            // dynamic mappings, turning every declared keyword into a text field that can be neither
+            // aggregated nor sorted on, and squatting the name the alias needs.
+            List<String> missingIndices = this.missingTargetIndices();
+            if (!missingIndices.isEmpty()) {
+                log.error(Constants.E_LOG_SYNC_ABORTED_INDICES_MISSING, consumerType, missingIndices);
+                return new SyncResult(false, feedUnreachable);
             }
 
             // When a plan change is detected, download into hidden shadow indices and atomically

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
@@ -18,7 +18,6 @@ package com.wazuh.contentmanager.jobscheduler.jobs;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.action.get.GetResponse;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.env.Environment;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
@@ -26,9 +25,7 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
@@ -40,8 +37,7 @@ import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.jobscheduler.JobExecutor;
-import com.wazuh.contentmanager.settings.PluginSettings;
-import com.wazuh.contentmanager.utils.Constants;
+import com.wazuh.contentmanager.utils.SetupReadiness;
 
 /**
  * Job responsible for executing the synchronization logic for Rules and Decoders consumers. This
@@ -68,6 +64,7 @@ public class CatalogSyncJob implements JobExecutor {
     private final Client client;
     private final ThreadPool threadPool;
     private final List<AbstractConsumerService> synchronizers;
+    private final SetupReadiness setupReadiness;
 
     /**
      * Constructs a new CatalogSyncJob.
@@ -88,6 +85,7 @@ public class CatalogSyncJob implements JobExecutor {
             SpaceService spaceService,
             SecurityAnalyticsService securityAnalyticsService) {
         this.client = client;
+        this.setupReadiness = new SetupReadiness(client);
         this.threadPool = threadPool;
         this.synchronizers =
                 List.of(
@@ -251,91 +249,12 @@ public class CatalogSyncJob implements JobExecutor {
     }
 
     /**
-     * Blocks until the Setup plugin reports its initialization as {@value
-     * Constants#SETUP_STATUS_READY} via the {@value Constants#SETUP_STATUS_DOC_ID} marker document in
-     * the {@value Constants#INDEX_SETUP_STATUS} index. Retries up to {@link
-     * PluginSettings#SETUP_WAIT_MAX_RETRIES} times with exponential backoff starting at {@link
-     * PluginSettings#SETUP_WAIT_BACKOFF_BASE_SECONDS} before giving up (defaults: 20s, 40s, 80s, 160s
-     * = 300s / 5 min worst case). If the marker already reports {@value
-     * Constants#SETUP_STATUS_FAILED}, returns immediately without retrying — a failed Setup boot will
-     * not fix itself within the same boot.
+     * Waits for the Setup plugin to finish initializing, so no catalog content is downloaded before
+     * the indices it owns exist. Delegates to {@link SetupReadiness#awaitReady()}.
      *
      * @return true if the Setup plugin reported readiness, false otherwise.
      */
     boolean waitForSetup() {
-        int maxRetries = PluginSettings.getInstance().getSetupWaitMaxRetries();
-        int backoffBaseSeconds = PluginSettings.getInstance().getSetupWaitBackoffBaseSeconds();
-        for (int attempt = 0; ; attempt++) {
-            SetupStatus status = this.readSetupStatus();
-            if (status == SetupStatus.READY) {
-                return true;
-            }
-            if (status == SetupStatus.FAILED) {
-                log.error(
-                        "Setup plugin initialization failed. Skipping catalog synchronization until Setup succeeds (typically after a node restart.");
-                return false;
-            }
-            if (attempt >= maxRetries) {
-                return false;
-            }
-            long delaySeconds = backoffBaseSeconds * (1L << attempt);
-            log.info(
-                    "Setup plugin initialization not complete yet. Retrying in {}s (attempt {}/{}).",
-                    delaySeconds,
-                    attempt + 1,
-                    maxRetries);
-            try {
-                this.sleepSeconds(delaySeconds);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return false;
-            }
-        }
-    }
-
-    /**
-     * Sleeps for the given number of seconds. Extracted from {@link #waitForSetup()} so tests can
-     * stub it out and exercise the full retry loop without actually blocking for its real duration.
-     *
-     * @param seconds The number of seconds to sleep.
-     * @throws InterruptedException if the thread is interrupted while sleeping.
-     */
-    void sleepSeconds(long seconds) throws InterruptedException {
-        TimeUnit.SECONDS.sleep(seconds);
-    }
-
-    /** The three states the Setup plugin's readiness marker can report. */
-    private enum SetupStatus {
-        RUNNING,
-        READY,
-        FAILED
-    }
-
-    /**
-     * Reads the Setup plugin's readiness marker. Any failure (index not created yet, cluster not
-     * ready) is treated as {@link SetupStatus#RUNNING} so the caller retries.
-     *
-     * @return the marker's current {@link SetupStatus}.
-     */
-    private SetupStatus readSetupStatus() {
-        try {
-            GetResponse response =
-                    this.client.prepareGet(Constants.INDEX_SETUP_STATUS, Constants.SETUP_STATUS_DOC_ID).get();
-            if (!response.isExists()) {
-                return SetupStatus.RUNNING;
-            }
-            Map<String, Object> source = response.getSourceAsMap();
-            Object value = source != null ? source.get(Constants.KEY_STATUS) : null;
-            if (Constants.SETUP_STATUS_READY.equals(value)) {
-                return SetupStatus.READY;
-            }
-            if (Constants.SETUP_STATUS_FAILED.equals(value)) {
-                return SetupStatus.FAILED;
-            }
-            return SetupStatus.RUNNING;
-        } catch (Exception e) {
-            log.debug("Could not read setup status marker: {}", e.getMessage());
-            return SetupStatus.RUNNING;
-        }
+        return this.setupReadiness.awaitReady();
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJob.java
@@ -212,6 +212,10 @@ public class CatalogSyncJob implements JobExecutor {
 
     SyncOutcome performSynchronization() {
         try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            // Content download requires two things to be true: the Setup plugin reported ready, and
+            // the target indices it provisions exist. This is the first; the second is checked per
+            // consumer by AbstractConsumerService, which skips its own pass when any of its indices
+            // is absent, so one mis-provisioned index cannot silently become a squatted one.
             if (!this.waitForSetup()) {
                 log.error(
                         "Setup plugin initialization did not complete in time. Skipping catalog"

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -170,15 +170,15 @@ public class Constants {
             "Consumer [{}] is not registered; using public download URLs.";
     public static final String E_LOG_INDEX_CREATE_FAILED = "Failed to create index [{}]: {}";
     public static final String E_LOG_SYNC_ABORTED_INDICES_MISSING =
-            "Skipping the [{}] synchronization pass: the Setup plugin reported ready but these target "
-                    + "indices do not exist: {}. No content is downloaded until they do, so a write "
-                    + "cannot auto-create a dynamically mapped index under an alias name.";
+            "Skipping [{}] synchronization: the Setup plugin reported ready but these indices are "
+                    + "missing: {}. No content is downloaded until they exist. Restart to let the Setup "
+                    + "plugin create them.";
     public static final String W_LOG_EMPTY_INDEX_OFFSET_RESET =
-            "Index [{}] holds no documents but the local offset is [{}]. Resetting the offset so the "
-                    + "content is downloaded again.";
+            "Index [{}] is empty but the local offset is [{}]. Resetting the offset to download the "
+                    + "content again.";
     public static final String D_LOG_INDEX_COUNT_FAILED = "Could not count the documents in [{}]: {}";
     public static final String I_LOG_SETUP_PLUGIN_ABSENT =
-            "The Setup plugin is not installed on this cluster. Not waiting for its readiness marker.";
+            "The Setup plugin is not installed, so there is nothing to wait for.";
     public static final String D_LOG_SETUP_PLUGIN_LOOKUP_FAILED =
             "Could not read the installed plugin list, assuming the Setup plugin is present: {}";
     public static final String E_LOG_SETUP_INIT_FAILED =
@@ -189,8 +189,8 @@ public class Constants {
     public static final String D_LOG_SETUP_STATUS_READ_FAILED =
             "Could not read setup status marker: {}";
     public static final String W_LOG_SETUP_NOT_READY_PROVISIONING =
-            "The Setup plugin did not report readiness. Provisioning the threat-intel indices from "
-                    + "this plugin instead; they will not pick up the Setup plugin's index templates.";
+            "The Setup plugin did not complete, so this plugin is creating the threat intel indices "
+                    + "itself. Their settings may differ from the ones the Setup plugin applies.";
     public static final String W_LOG_LOCAL_OFFSET_EXCEEDS_REMOTE =
             "Local offset [{}] exceeds remote offset [{}] for consumer [{}]. Resetting.";
     public static final String W_LOG_LOCAL_SNAPSHOT_CHECK_FAILED =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -169,6 +169,14 @@ public class Constants {
     public static final String D_LOG_REGULAR_URL_RESOLVER =
             "Consumer [{}] is not registered; using public download URLs.";
     public static final String E_LOG_INDEX_CREATE_FAILED = "Failed to create index [{}]: {}";
+    public static final String E_LOG_SYNC_ABORTED_INDEX_MISSING =
+            "Index [{}] is missing and could not be created. Aborting the [{}] synchronization pass "
+                    + "rather than letting a write auto-create a dynamically mapped index under the alias "
+                    + "name.";
+    public static final String W_LOG_EMPTY_INDEX_OFFSET_RESET =
+            "Index [{}] holds no documents but the local offset is [{}]. Resetting the offset so the "
+                    + "content is downloaded again.";
+    public static final String D_LOG_INDEX_COUNT_FAILED = "Could not count the documents in [{}]: {}";
     public static final String W_LOG_LOCAL_OFFSET_EXCEEDS_REMOTE =
             "Local offset [{}] exceeds remote offset [{}] for consumer [{}]. Resetting.";
     public static final String W_LOG_LOCAL_SNAPSHOT_CHECK_FAILED =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -177,6 +177,13 @@ public class Constants {
             "Index [{}] holds no documents but the local offset is [{}]. Resetting the offset so the "
                     + "content is downloaded again.";
     public static final String D_LOG_INDEX_COUNT_FAILED = "Could not count the documents in [{}]: {}";
+    public static final String E_LOG_SETUP_INIT_FAILED =
+            "Setup plugin initialization failed. Skipping catalog synchronization until Setup succeeds "
+                    + "(typically after a node restart).";
+    public static final String I_LOG_SETUP_NOT_READY_RETRYING =
+            "Setup plugin initialization not complete yet. Retrying in {}s (attempt {}/{}).";
+    public static final String D_LOG_SETUP_STATUS_READ_FAILED =
+            "Could not read setup status marker: {}";
     public static final String W_LOG_SETUP_NOT_READY_PROVISIONING =
             "The Setup plugin did not report readiness. Provisioning the threat-intel indices from "
                     + "this plugin instead; they will not pick up the Setup plugin's index templates.";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -177,6 +177,10 @@ public class Constants {
             "Index [{}] holds no documents but the local offset is [{}]. Resetting the offset so the "
                     + "content is downloaded again.";
     public static final String D_LOG_INDEX_COUNT_FAILED = "Could not count the documents in [{}]: {}";
+    public static final String I_LOG_SETUP_PLUGIN_ABSENT =
+            "The Setup plugin is not installed on this cluster. Not waiting for its readiness marker.";
+    public static final String D_LOG_SETUP_PLUGIN_LOOKUP_FAILED =
+            "Could not read the installed plugin list, assuming the Setup plugin is present: {}";
     public static final String E_LOG_SETUP_INIT_FAILED =
             "Setup plugin initialization failed. Skipping catalog synchronization until Setup succeeds "
                     + "(typically after a node restart).";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -177,6 +177,9 @@ public class Constants {
             "Index [{}] holds no documents but the local offset is [{}]. Resetting the offset so the "
                     + "content is downloaded again.";
     public static final String D_LOG_INDEX_COUNT_FAILED = "Could not count the documents in [{}]: {}";
+    public static final String W_LOG_SETUP_NOT_READY_PROVISIONING =
+            "The Setup plugin did not report readiness. Provisioning the threat-intel indices from "
+                    + "this plugin instead; they will not pick up the Setup plugin's index templates.";
     public static final String W_LOG_LOCAL_OFFSET_EXCEEDS_REMOTE =
             "Local offset [{}] exceeds remote offset [{}] for consumer [{}]. Resetting.";
     public static final String W_LOG_LOCAL_SNAPSHOT_CHECK_FAILED =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -169,10 +169,10 @@ public class Constants {
     public static final String D_LOG_REGULAR_URL_RESOLVER =
             "Consumer [{}] is not registered; using public download URLs.";
     public static final String E_LOG_INDEX_CREATE_FAILED = "Failed to create index [{}]: {}";
-    public static final String E_LOG_SYNC_ABORTED_INDEX_MISSING =
-            "Index [{}] is missing and could not be created. Aborting the [{}] synchronization pass "
-                    + "rather than letting a write auto-create a dynamically mapped index under the alias "
-                    + "name.";
+    public static final String E_LOG_SYNC_ABORTED_INDICES_MISSING =
+            "Skipping the [{}] synchronization pass: the Setup plugin reported ready but these target "
+                    + "indices do not exist: {}. No content is downloaded until they do, so a write "
+                    + "cannot auto-create a dynamically mapped index under an alias name.";
     public static final String W_LOG_EMPTY_INDEX_OFFSET_RESET =
             "Index [{}] holds no documents but the local offset is [{}]. Resetting the offset so the "
                     + "content is downloaded again.";

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
@@ -72,19 +72,14 @@ public class SetupReadiness {
                 return true;
             }
             if (status == SetupStatus.FAILED) {
-                log.error(
-                        "Setup plugin initialization failed. Skipping catalog synchronization until Setup succeeds (typically after a node restart.");
+                log.error(Constants.E_LOG_SETUP_INIT_FAILED);
                 return false;
             }
             if (attempt >= maxRetries) {
                 return false;
             }
             long delaySeconds = backoffBaseSeconds * (1L << attempt);
-            log.info(
-                    "Setup plugin initialization not complete yet. Retrying in {}s (attempt {}/{}).",
-                    delaySeconds,
-                    attempt + 1,
-                    maxRetries);
+            log.info(Constants.I_LOG_SETUP_NOT_READY_RETRYING, delaySeconds, attempt + 1, maxRetries);
             try {
                 this.sleepSeconds(delaySeconds);
             } catch (InterruptedException e) {
@@ -135,7 +130,7 @@ public class SetupReadiness {
             }
             return SetupStatus.RUNNING;
         } catch (Exception e) {
-            log.debug("Could not read setup status marker: {}", e.getMessage());
+            log.debug(Constants.D_LOG_SETUP_STATUS_READ_FAILED, e.getMessage());
             return SetupStatus.RUNNING;
         }
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
@@ -52,6 +52,14 @@ public class SetupReadiness {
     private final Client client;
 
     /**
+     * Memoised answer to {@link #isSetupPluginInstalled()}. Plugins are loaded when the node starts
+     * and cannot be added or removed without a restart, so the answer cannot change while this node
+     * lives. Only a definitive answer is cached: a failed lookup stays uncached so a transient error
+     * does not pin the result for the rest of the node's lifetime.
+     */
+    private volatile Boolean setupPluginInstalled;
+
+    /**
      * Constructor.
      *
      * @param client The OpenSearch client used to read the readiness marker.
@@ -113,7 +121,11 @@ public class SetupReadiness {
      *
      * @return true if the Setup plugin is installed, or if the plugin list could not be read.
      */
-    boolean isSetupPluginInstalled() {
+    public boolean isSetupPluginInstalled() {
+        Boolean cached = this.setupPluginInstalled;
+        if (cached != null) {
+            return cached;
+        }
         try {
             NodesInfoResponse response =
                     this.client
@@ -130,10 +142,12 @@ public class SetupReadiness {
                 }
                 for (PluginInfo plugin : plugins.getPluginInfos()) {
                     if (SETUP_PLUGIN_NAME.equals(plugin.getName())) {
+                        this.setupPluginInstalled = true;
                         return true;
                     }
                 }
             }
+            this.setupPluginInstalled = false;
             return false;
         } catch (Exception e) {
             log.debug(Constants.D_LOG_SETUP_PLUGIN_LOOKUP_FAILED, e.getMessage());

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
@@ -18,7 +18,13 @@ package com.wazuh.contentmanager.utils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.admin.cluster.node.info.NodeInfo;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.plugins.PluginInfo;
 import org.opensearch.transport.client.Client;
 
 import java.util.Map;
@@ -39,6 +45,9 @@ import com.wazuh.contentmanager.settings.PluginSettings;
 public class SetupReadiness {
 
     private static final Logger log = LogManager.getLogger(SetupReadiness.class);
+
+    /** Name the Setup plugin registers itself under, as declared in its {@code build.gradle}. */
+    private static final String SETUP_PLUGIN_NAME = "wazuh-indexer-setup";
 
     private final Client client;
 
@@ -64,6 +73,10 @@ public class SetupReadiness {
      * @return true if the Setup plugin reported readiness, false otherwise.
      */
     public boolean awaitReady() {
+        if (!this.isSetupPluginInstalled()) {
+            log.info(Constants.I_LOG_SETUP_PLUGIN_ABSENT);
+            return false;
+        }
         int maxRetries = PluginSettings.getInstance().getSetupWaitMaxRetries();
         int backoffBaseSeconds = PluginSettings.getInstance().getSetupWaitBackoffBaseSeconds();
         for (int attempt = 0; ; attempt++) {
@@ -86,6 +99,45 @@ public class SetupReadiness {
                 Thread.currentThread().interrupt();
                 return false;
             }
+        }
+    }
+
+    /**
+     * Returns whether the Setup plugin is installed on any node of the cluster.
+     *
+     * <p>Without this check {@link #awaitReady()} would burn its whole backoff schedule waiting for a
+     * marker that is never going to be written, delaying everything behind it by five minutes on
+     * exactly the deployment the caller's fallback exists to serve. A failure to read the plugin list
+     * is reported as "installed" so a transient error makes the caller wait rather than skip the wait
+     * and race the Setup plugin.
+     *
+     * @return true if the Setup plugin is installed, or if the plugin list could not be read.
+     */
+    boolean isSetupPluginInstalled() {
+        try {
+            NodesInfoResponse response =
+                    this.client
+                            .admin()
+                            .cluster()
+                            .prepareNodesInfo()
+                            .clear()
+                            .addMetric(NodesInfoRequest.Metric.PLUGINS.metricName())
+                            .get(TimeValue.timeValueSeconds(PluginSettings.getInstance().getClientTimeout()));
+            for (NodeInfo node : response.getNodes()) {
+                PluginsAndModules plugins = node.getInfo(PluginsAndModules.class);
+                if (plugins == null) {
+                    continue;
+                }
+                for (PluginInfo plugin : plugins.getPluginInfos()) {
+                    if (SETUP_PLUGIN_NAME.equals(plugin.getName())) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            log.debug(Constants.D_LOG_SETUP_PLUGIN_LOOKUP_FAILED, e.getMessage());
+            return true;
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/SetupReadiness.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.transport.client.Client;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.wazuh.contentmanager.settings.PluginSettings;
+
+/**
+ * Waits for the Setup plugin to finish initializing.
+ *
+ * <p>The Setup plugin owns the index topology this plugin writes into: the {@code
+ * wazuh-threatintel-*} content indices, each created as {@code <name>-a} with the public alias
+ * {@code <name>} pointing at it. Anything that provisions or writes to those indices has to wait
+ * for that to be in place, otherwise it races the Setup plugin and can create a concrete index
+ * under the alias name — auto-created with dynamic mappings, so its fields cannot be aggregated or
+ * sorted on (see issue #1476).
+ */
+public class SetupReadiness {
+
+    private static final Logger log = LogManager.getLogger(SetupReadiness.class);
+
+    private final Client client;
+
+    /**
+     * Constructor.
+     *
+     * @param client The OpenSearch client used to read the readiness marker.
+     */
+    public SetupReadiness(Client client) {
+        this.client = client;
+    }
+
+    /**
+     * Blocks until the Setup plugin reports its initialization as {@value
+     * Constants#SETUP_STATUS_READY} via the {@value Constants#SETUP_STATUS_DOC_ID} marker document in
+     * the {@value Constants#INDEX_SETUP_STATUS} index. Retries up to {@link
+     * PluginSettings#SETUP_WAIT_MAX_RETRIES} times with exponential backoff starting at {@link
+     * PluginSettings#SETUP_WAIT_BACKOFF_BASE_SECONDS} before giving up (defaults: 20s, 40s, 80s, 160s
+     * = 300s / 5 min worst case). If the marker already reports {@value
+     * Constants#SETUP_STATUS_FAILED}, returns immediately without retrying — a failed Setup boot will
+     * not fix itself within the same boot.
+     *
+     * @return true if the Setup plugin reported readiness, false otherwise.
+     */
+    public boolean awaitReady() {
+        int maxRetries = PluginSettings.getInstance().getSetupWaitMaxRetries();
+        int backoffBaseSeconds = PluginSettings.getInstance().getSetupWaitBackoffBaseSeconds();
+        for (int attempt = 0; ; attempt++) {
+            SetupStatus status = this.readSetupStatus();
+            if (status == SetupStatus.READY) {
+                return true;
+            }
+            if (status == SetupStatus.FAILED) {
+                log.error(
+                        "Setup plugin initialization failed. Skipping catalog synchronization until Setup succeeds (typically after a node restart.");
+                return false;
+            }
+            if (attempt >= maxRetries) {
+                return false;
+            }
+            long delaySeconds = backoffBaseSeconds * (1L << attempt);
+            log.info(
+                    "Setup plugin initialization not complete yet. Retrying in {}s (attempt {}/{}).",
+                    delaySeconds,
+                    attempt + 1,
+                    maxRetries);
+            try {
+                this.sleepSeconds(delaySeconds);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Sleeps for the given number of seconds. Extracted from {@link #awaitReady()} so tests can stub
+     * it out and exercise the full retry loop without actually blocking for its real duration.
+     *
+     * @param seconds The number of seconds to sleep.
+     * @throws InterruptedException if the thread is interrupted while sleeping.
+     */
+    void sleepSeconds(long seconds) throws InterruptedException {
+        TimeUnit.SECONDS.sleep(seconds);
+    }
+
+    /** The three states the Setup plugin's readiness marker can report. */
+    private enum SetupStatus {
+        RUNNING,
+        READY,
+        FAILED
+    }
+
+    /**
+     * Reads the Setup plugin's readiness marker. Any failure (index not created yet, cluster not
+     * ready) is treated as {@link SetupStatus#RUNNING} so the caller retries.
+     *
+     * @return the marker's current {@link SetupStatus}.
+     */
+    private SetupStatus readSetupStatus() {
+        try {
+            GetResponse response =
+                    this.client.prepareGet(Constants.INDEX_SETUP_STATUS, Constants.SETUP_STATUS_DOC_ID).get();
+            if (!response.isExists()) {
+                return SetupStatus.RUNNING;
+            }
+            Map<String, Object> source = response.getSourceAsMap();
+            Object value = source != null ? source.get(Constants.KEY_STATUS) : null;
+            if (Constants.SETUP_STATUS_READY.equals(value)) {
+                return SetupStatus.READY;
+            }
+            if (Constants.SETUP_STATUS_FAILED.equals(value)) {
+                return SetupStatus.FAILED;
+            }
+            return SetupStatus.RUNNING;
+        } catch (Exception e) {
+            log.debug("Could not read setup status marker: {}", e.getMessage());
+            return SetupStatus.RUNNING;
+        }
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
@@ -55,6 +55,7 @@ import com.wazuh.contentmanager.jobscheduler.jobs.CatalogSyncJob;
 import com.wazuh.contentmanager.jobscheduler.jobs.TelemetryPingJob;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
+import com.wazuh.contentmanager.utils.SetupReadiness;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -132,6 +133,7 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
         this.injectField(this.plugin, "engineContentLoader", this.engineContentLoader);
         this.injectField(this.plugin, "spaceService", this.spaceService);
         this.injectField(this.plugin, "consumersIndex", this.consumersIndex);
+        this.injectField(this.plugin, "setupReadiness", new SetupReadiness(this.client));
 
         ContentManagerPluginTests.clearInstance();
     }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/ContentManagerPluginTests.java
@@ -18,6 +18,8 @@ package com.wazuh.contentmanager;
 
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.opensearch.action.get.GetRequestBuilder;
+import org.opensearch.action.get.GetResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.cluster.LocalNodeClusterManagerListener;
@@ -42,6 +44,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -108,6 +111,18 @@ public class ContentManagerPluginTests extends OpenSearchTestCase {
         when(this.clusterState.metadata()).thenReturn(this.metadata);
         when(this.metadata.clusterUUID()).thenReturn("test-cluster-uuid");
         when(this.discoveryNodes.isLocalNodeElectedClusterManager()).thenReturn(false);
+
+        // The plugin waits for the Setup plugin's readiness marker before provisioning the
+        // threat-intel indices, so present a Setup that has already finished. Without this the wait
+        // reads no marker at all and backs off through its full five-minute schedule.
+        GetRequestBuilder setupStatusGet = mock(GetRequestBuilder.class);
+        GetResponse setupStatusResponse = mock(GetResponse.class);
+        when(this.client.prepareGet(Constants.INDEX_SETUP_STATUS, Constants.SETUP_STATUS_DOC_ID))
+                .thenReturn(setupStatusGet);
+        when(setupStatusGet.get()).thenReturn(setupStatusResponse);
+        when(setupStatusResponse.isExists()).thenReturn(true);
+        when(setupStatusResponse.getSourceAsMap())
+                .thenReturn(Map.of(Constants.KEY_STATUS, Constants.SETUP_STATUS_READY));
 
         this.injectField(this.plugin, "client", this.client);
         this.injectField(this.plugin, "clusterService", this.clusterService);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/SpaceInitializationIT.java
@@ -18,7 +18,6 @@ package com.wazuh.contentmanager;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
-import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.settings.Settings;
@@ -29,12 +28,11 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchIntegTestCase;
 import org.junit.After;
 
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.service.ConsumerRulesetService;
@@ -54,13 +52,13 @@ public class SpaceInitializationIT extends OpenSearchIntegTestCase {
     private static final String Q_SPACE_NAME = "space.name";
     private static final String[] SPACE_NAMES = {"draft", "test", "custom"};
 
-    private static final Map<String, String> INDEX_MAPPINGS =
-            Map.of(
-                    "wazuh-threatintel-rules", "/mappings/cti-rules-mappings.json",
-                    "wazuh-threatintel-decoders", "/mappings/cti-decoders-mappings.json",
-                    "wazuh-threatintel-kvdbs", "/mappings/cti-kvdbs-mappings.json",
-                    "wazuh-threatintel-integrations", "/mappings/cti-integrations-mappings.json",
-                    "wazuh-threatintel-policies", "/mappings/cti-policies-mappings.json");
+    private static final List<String> CONTENT_INDICES =
+            List.of(
+                    "wazuh-threatintel-rules",
+                    "wazuh-threatintel-decoders",
+                    "wazuh-threatintel-kvdbs",
+                    "wazuh-threatintel-integrations",
+                    INDEX_POLICIES);
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -88,8 +86,8 @@ public class SpaceInitializationIT extends OpenSearchIntegTestCase {
     public void testOnSyncCompleteDoesNotDuplicateSpaces() throws Exception {
         this.ensureGreen(TimeValue.timeValueMinutes(2));
 
-        // Create all content indices required by onSyncComplete
-        this.createContentIndices();
+        // The plugin provisions the content indices onSyncComplete needs; wait for them.
+        this.awaitContentIndices();
 
         // Initialize PluginSettings in the test JVM (the plugin runs in the external cluster JVM)
         PluginSettings.getInstance(
@@ -159,37 +157,33 @@ public class SpaceInitializationIT extends OpenSearchIntegTestCase {
                 .get();
     }
 
-    /** Creates all content indices required by the post-sync workflow with their proper mappings. */
-    private void createContentIndices() throws Exception {
-        Settings indexSettings =
-                Settings.builder()
-                        .put("index.number_of_replicas", 0)
-                        .put("index.number_of_shards", 1)
-                        .build();
-
-        for (Map.Entry<String, String> entry : INDEX_MAPPINGS.entrySet()) {
-            String indexName = entry.getKey();
-            String mappingPath = entry.getValue();
-
-            String mapping;
-            try (InputStream is = this.getClass().getResourceAsStream(mappingPath)) {
-                assertNotNull("Could not find mapping resource: " + mappingPath, is);
-                mapping = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-            }
-
-            CreateIndexRequest request =
-                    new CreateIndexRequest().index(indexName).mapping(mapping).settings(indexSettings);
-
-            assertTrue(
-                    "Failed to create index " + indexName,
-                    OpenSearchIntegTestCase.client()
-                            .admin()
-                            .indices()
-                            .create(request)
-                            .actionGet()
-                            .isAcknowledged());
-        }
-
+    /**
+     * Waits for the content indices the post-sync workflow needs.
+     *
+     * <p>This test connects to the Gradle test cluster as an {@code ExternalTestCluster}, so {@link
+     * #nodePlugins()} does not apply and both the Setup and Content Manager plugins are running
+     * there. Each of these indices is provisioned as {@code <name>-a} with the public alias {@code
+     * <name>} pointing at it, by the Setup plugin at node start and by {@code
+     * ContentManagerPlugin#ensureResourceIndicesExist()} otherwise. Creating them here as concrete
+     * indices named after the aliases therefore fails with "invalid index name [...], already exists
+     * as alias": a concrete index cannot take a name an alias already holds. Wait for them instead.
+     */
+    private void awaitContentIndices() throws Exception {
+        assertBusy(
+                () -> {
+                    for (String indexName : CONTENT_INDICES) {
+                        assertTrue(
+                                "Index " + indexName + " was not provisioned by the plugin",
+                                OpenSearchIntegTestCase.client()
+                                        .admin()
+                                        .indices()
+                                        .prepareExists(indexName)
+                                        .get()
+                                        .isExists());
+                    }
+                },
+                2,
+                TimeUnit.MINUTES);
         this.ensureGreen();
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/StandardSpaceHashRecoveryIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/StandardSpaceHashRecoveryIT.java
@@ -26,6 +26,7 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -130,7 +131,11 @@ public class StandardSpaceHashRecoveryIT extends OpenSearchIntegTestCase {
     /** The cluster is shared by the whole suite, so each test starts from a clean policies index. */
     @After
     public void deletePoliciesIndex() {
-        OpenSearchIntegTestCase.client().admin().indices().prepareDelete(INDEX_POLICIES + "*").get();
+        try {
+            OpenSearchIntegTestCase.client().admin().indices().prepareDelete(INDEX_POLICIES + "*").get();
+        } catch (IndexNotFoundException e) {
+            // Nothing to clean up.
+        }
     }
 
     /** Reads {@code space.hash.sha256} of the standard policy, or null when absent. */
@@ -173,8 +178,13 @@ public class StandardSpaceHashRecoveryIT extends OpenSearchIntegTestCase {
      * Creates the physical policies index and its public alias through {@link ContentIndex}, so the
      * layout matches a real deployment ({@code wazuh-threatintel-policies-a} behind the {@code
      * wazuh-threatintel-policies} alias).
+     *
+     * <p>The index is dropped first. The cluster this test connects to runs the Setup plugin, which
+     * provisions the index at node start, and the test needs an empty one: it asserts the policy it
+     * writes is the only document and that it starts without an aggregate hash.
      */
     private void createPoliciesIndex() throws Exception {
+        this.deletePoliciesIndex();
         ContentIndex policies =
                 new ContentIndex(OpenSearchIntegTestCase.client(), INDEX_POLICIES, POLICIES_MAPPING);
         assertTrue("Failed to create index " + INDEX_POLICIES, policies.createIndex().isAcknowledged());

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
@@ -40,11 +40,13 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.Client;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
@@ -106,6 +108,26 @@ public class ConsumerIocServiceTests extends OpenSearchTestCase {
         this.service =
                 new ConsumerIocService(
                         this.client, this.consumersIndex, this.environment, this.engineService);
+    }
+
+    /**
+     * The IoC consumer's single target index is reported missing when nothing answers to its name, so
+     * the synchronization pass can defer instead of letting a write auto-create a dynamically mapped
+     * index under the alias name (issues #1476 and #1481).
+     */
+    public void testMissingTargetIndicesReportsTheAbsentIndex() {
+        when(this.client.admin().indices().prepareExists(Constants.INDEX_IOCS).get().isExists())
+                .thenReturn(false);
+
+        Assert.assertEquals(List.of(Constants.INDEX_IOCS), this.service.missingTargetIndices());
+    }
+
+    /** Nothing is reported missing once the Setup plugin has provisioned the index. */
+    public void testMissingTargetIndicesIsEmptyWhenTheIndexExists() {
+        when(this.client.admin().indices().prepareExists(Constants.INDEX_IOCS).get().isExists())
+                .thenReturn(true);
+
+        Assert.assertTrue(this.service.missingTargetIndices().isEmpty());
     }
 
     @After

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/jobscheduler/jobs/CatalogSyncJobTests.java
@@ -38,15 +38,11 @@ import com.wazuh.contentmanager.cti.catalog.service.SpaceService;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
-import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -153,39 +149,6 @@ public class CatalogSyncJobTests extends OpenSearchTestCase {
                 "waitForSetup() must not sleep through the backoff when the marker already says"
                         + " failed",
                 elapsedMillis < 1000);
-    }
-
-    /**
-     * When the Setup marker never becomes ready, {@code waitForSetup()} must exhaust the full,
-     * documented backoff schedule (20s, 40s, 80s, 160s = 300s / 5 min worst case) before giving up.
-     * {@code sleepSeconds} is stubbed out so the test exercises the real retry loop and logging
-     * without actually blocking for five minutes.
-     */
-    public void testWaitForSetup_setupNeverReady_exhaustsFullBackoffScheduleThenGivesUp() {
-        when(this.getResponse.isExists()).thenReturn(false);
-
-        CatalogSyncJob job = spy(this.catalogSyncJob);
-        try {
-            doNothing().when(job).sleepSeconds(anyLong());
-        } catch (InterruptedException e) {
-            throw new AssertionError(e);
-        }
-
-        boolean result = job.waitForSetup();
-
-        Assert.assertFalse("Setup never became ready, so waitForSetup() must give up", result);
-        verify(this.getRequestBuilder, times(PluginSettings.getInstance().getSetupWaitMaxRetries() + 1))
-                .get();
-
-        InOrder inOrder = Mockito.inOrder(job);
-        try {
-            inOrder.verify(job).sleepSeconds(20L);
-            inOrder.verify(job).sleepSeconds(40L);
-            inOrder.verify(job).sleepSeconds(80L);
-            inOrder.verify(job).sleepSeconds(160L);
-        } catch (InterruptedException e) {
-            throw new AssertionError(e);
-        }
     }
 
     /** When setup never completes, the synchronization pass is skipped entirely. */

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SetupReadinessTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SetupReadinessTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.utils;
+
+import org.opensearch.action.get.GetRequestBuilder;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.Client;
+import org.junit.Assert;
+
+import java.util.Map;
+
+import com.wazuh.contentmanager.settings.PluginSettings;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.*;
+
+/** Unit tests for {@link SetupReadiness}. */
+public class SetupReadinessTests extends OpenSearchTestCase {
+
+    private Client client;
+    private GetRequestBuilder getRequestBuilder;
+    private GetResponse getResponse;
+    private SetupReadiness setupReadiness;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        PluginSettings.getInstance(Settings.EMPTY);
+
+        this.client = mock(Client.class);
+        this.getRequestBuilder = mock(GetRequestBuilder.class);
+        this.getResponse = mock(GetResponse.class);
+
+        when(this.client.prepareGet(Constants.INDEX_SETUP_STATUS, Constants.SETUP_STATUS_DOC_ID))
+                .thenReturn(this.getRequestBuilder);
+        when(this.getRequestBuilder.get()).thenReturn(this.getResponse);
+
+        this.setupReadiness = new SetupReadiness(this.client);
+    }
+
+    /** The marker already reports ready, so the first check returns true. */
+    public void testMarkerReadyReturnsTrue() {
+        when(this.getResponse.isExists()).thenReturn(true);
+        when(this.getResponse.getSourceAsMap())
+                .thenReturn(Map.of(Constants.KEY_STATUS, Constants.SETUP_STATUS_READY));
+
+        Assert.assertTrue(this.setupReadiness.awaitReady());
+    }
+
+    /** A failed Setup boot will not fix itself, so there is nothing to wait for. */
+    public void testMarkerFailedReturnsFalseWithoutSleeping() throws Exception {
+        when(this.getResponse.isExists()).thenReturn(true);
+        when(this.getResponse.getSourceAsMap())
+                .thenReturn(Map.of(Constants.KEY_STATUS, Constants.SETUP_STATUS_FAILED));
+
+        SetupReadiness readiness = spy(this.setupReadiness);
+        Assert.assertFalse(readiness.awaitReady());
+        verify(readiness, never()).sleepSeconds(anyLong());
+    }
+
+    /** A marker that is present but still says running is retried. */
+    public void testMarkerRunningIsRetried() throws Exception {
+        when(this.getResponse.isExists()).thenReturn(true);
+        when(this.getResponse.getSourceAsMap()).thenReturn(Map.of(Constants.KEY_STATUS, "running"));
+
+        SetupReadiness readiness = spy(this.setupReadiness);
+        doNothing().when(readiness).sleepSeconds(anyLong());
+
+        Assert.assertFalse(readiness.awaitReady());
+        verify(readiness, times(PluginSettings.getInstance().getSetupWaitMaxRetries()))
+                .sleepSeconds(anyLong());
+    }
+
+    /**
+     * When the marker never becomes ready, the full documented backoff schedule is exhausted (20s,
+     * 40s, 80s, 160s = 300s / 5 min worst case) before giving up. {@code sleepSeconds} is stubbed out
+     * so the real retry loop runs without actually blocking for five minutes.
+     */
+    public void testSetupNeverReadyExhaustsFullBackoffScheduleThenGivesUp() throws Exception {
+        when(this.getResponse.isExists()).thenReturn(false);
+
+        SetupReadiness readiness = spy(this.setupReadiness);
+        doNothing().when(readiness).sleepSeconds(anyLong());
+
+        Assert.assertFalse(
+                "Setup never became ready, so awaitReady() must give up", readiness.awaitReady());
+        verify(this.getRequestBuilder, times(PluginSettings.getInstance().getSetupWaitMaxRetries() + 1))
+                .get();
+
+        InOrder inOrder = Mockito.inOrder(readiness);
+        inOrder.verify(readiness).sleepSeconds(20L);
+        inOrder.verify(readiness).sleepSeconds(40L);
+        inOrder.verify(readiness).sleepSeconds(80L);
+        inOrder.verify(readiness).sleepSeconds(160L);
+    }
+
+    /** A read failure (marker index absent, shards unassigned) is treated as "not ready yet". */
+    public void testReadFailureIsTreatedAsRunning() throws Exception {
+        when(this.getRequestBuilder.get()).thenThrow(new RuntimeException("no such index"));
+
+        SetupReadiness readiness = spy(this.setupReadiness);
+        doNothing().when(readiness).sleepSeconds(anyLong());
+
+        Assert.assertFalse(readiness.awaitReady());
+        verify(readiness, times(PluginSettings.getInstance().getSetupWaitMaxRetries()))
+                .sleepSeconds(anyLong());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SetupReadinessTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SetupReadinessTests.java
@@ -74,6 +74,18 @@ public class SetupReadinessTests extends OpenSearchTestCase {
         Assert.assertTrue(this.setupReadiness.isSetupPluginInstalled());
     }
 
+    /**
+     * A failed lookup must not be memoised, or one transient error would pin the answer for the rest
+     * of the node's lifetime.
+     */
+    public void testPluginLookupFailureIsNotCached() {
+        Assert.assertTrue(this.setupReadiness.isSetupPluginInstalled());
+        Assert.assertTrue(this.setupReadiness.isSetupPluginInstalled());
+
+        // Two calls, two attempts: nothing was cached.
+        verify(this.client, times(2)).admin();
+    }
+
     /** The marker already reports ready, so the first check returns true. */
     public void testMarkerReadyReturnsTrue() {
         when(this.getResponse.isExists()).thenReturn(true);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SetupReadinessTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/SetupReadinessTests.java
@@ -55,6 +55,25 @@ public class SetupReadinessTests extends OpenSearchTestCase {
         this.setupReadiness = new SetupReadiness(this.client);
     }
 
+    /**
+     * A cluster without the Setup plugin has no marker coming, so there is nothing to wait for: the
+     * caller's fallback runs immediately instead of after the full backoff schedule.
+     */
+    public void testSetupPluginAbsentReturnsFalseWithoutSleeping() throws Exception {
+        SetupReadiness readiness = spy(this.setupReadiness);
+        doReturn(false).when(readiness).isSetupPluginInstalled();
+
+        Assert.assertFalse(readiness.awaitReady());
+        verify(readiness, never()).sleepSeconds(anyLong());
+        verify(this.getRequestBuilder, never()).get();
+    }
+
+    /** A plugin list that cannot be read is treated as "installed", so the caller still waits. */
+    public void testPluginLookupFailureIsTreatedAsInstalled() {
+        // The mocked client has no nodes-info stubbing, so the lookup throws.
+        Assert.assertTrue(this.setupReadiness.isSetupPluginInstalled());
+    }
+
     /** The marker already reports ready, so the first check returns true. */
     public void testMarkerReadyReturnsTrue() {
         when(this.getResponse.isExists()).thenReturn(true);

--- a/plugins/setup/build.gradle
+++ b/plugins/setup/build.gradle
@@ -119,6 +119,59 @@ test {
   include '**/*Tests.class'
 }
 
+// The threat-intel content index mappings exist twice on purpose: this plugin ships them as
+// index templates (templates/content/*.json) and the Content Manager keeps its own copies
+// (mappings/cti-*-mappings.json) so it can still create the blue/green shadow indices and
+// run standalone. Both copies must describe the same index, so compare them at build time
+// rather than discovering the drift in production. See issue #1476.
+task verifyContentTemplates {
+  description = "Assert the content index templates match the Content Manager's mappings"
+  group = "verification"
+
+  def templatesDir = file("src/main/resources/templates/content")
+  def mappingsDir = new File(rootProject.projectDir, "plugins/content-manager/src/main/resources/mappings")
+  def pairs = [
+    "ioc.json"            : "cti-ioc-mappings.json",
+    "filters.json"        : "cti-filters-mappings.json",
+    "decoders.json"       : "cti-decoders-mappings.json",
+    "rules.json"          : "cti-rules-mappings.json",
+    "kvdbs.json"          : "cti-kvdbs-mappings.json",
+    "integrations.json"   : "cti-integrations-mappings.json",
+    "policies.json"       : "cti-policies-mappings.json",
+    "vulnerabilities.json": "cti-cve-mappings.json",
+  ]
+
+  inputs.dir(templatesDir)
+  inputs.dir(mappingsDir)
+  outputs.upToDateWhen { false }
+
+  doLast {
+    def slurper = new groovy.json.JsonSlurper()
+    def problems = []
+    pairs.each { template, mapping ->
+      def templateFile = new File(templatesDir, template)
+      def mappingFile = new File(mappingsDir, mapping)
+      if (!templateFile.exists()) {
+        problems << "missing index template: ${templateFile}"
+        return
+      }
+      if (!mappingFile.exists()) {
+        problems << "missing Content Manager mapping: ${mappingFile}"
+        return
+      }
+      def templated = slurper.parse(templateFile).template.mappings
+      def mapped = slurper.parse(mappingFile)
+      if (templated != mapped) {
+        problems << "${template} and ${mapping} describe different mappings"
+      }
+    }
+    if (!problems.isEmpty()) {
+      throw new GradleException("Content index template verification failed:\n  - " + problems.join("\n  - "))
+    }
+  }
+}
+tasks.named("check").configure { dependsOn(verifyContentTemplates) }
+
 def getPlugin(pluginName) {
   provider(new Callable<RegularFile>() {
     @Override

--- a/plugins/setup/build.gradle
+++ b/plugins/setup/build.gradle
@@ -128,8 +128,10 @@ task verifyContentTemplates {
   description = "Assert the content index templates match the Content Manager's mappings"
   group = "verification"
 
+  // Resolved relative to this project, so it works both in the root multi-project build and in the
+  // standalone `cd plugins/setup && ./gradlew check` build CI runs.
   def templatesDir = file("src/main/resources/templates/content")
-  def mappingsDir = new File(rootProject.projectDir, "plugins/content-manager/src/main/resources/mappings")
+  def mappingsDir = file("../content-manager/src/main/resources/mappings")
   def pairs = [
     "ioc.json"            : "cti-ioc-mappings.json",
     "filters.json"        : "cti-filters-mappings.json",
@@ -142,10 +144,14 @@ task verifyContentTemplates {
   ]
 
   inputs.dir(templatesDir)
-  inputs.dir(mappingsDir)
   outputs.upToDateWhen { false }
 
   doLast {
+    // A checkout without the sibling plugin has nothing to compare against.
+    if (!mappingsDir.isDirectory()) {
+      logger.lifecycle("Skipping: the Content Manager mappings are not present at ${mappingsDir}")
+      return
+    }
     def slurper = new groovy.json.JsonSlurper()
     def problems = []
     pairs.each { template, mapping ->

--- a/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java
@@ -52,6 +52,7 @@ import com.wazuh.setup.action.GetAiAssistantSettingsAction;
 import com.wazuh.setup.action.PutAiAssistantSettingsAction;
 import com.wazuh.setup.action.PutSettingsAction;
 import com.wazuh.setup.index.AiAssistantSettingsAdminIndex;
+import com.wazuh.setup.index.ContentIndex;
 import com.wazuh.setup.index.Index;
 import com.wazuh.setup.index.IndexStateManagement;
 import com.wazuh.setup.index.SettingsIndex;
@@ -177,6 +178,20 @@ public class SetupPlugin extends Plugin implements ClusterPlugin, ActionPlugin {
         this.indices.add(new StateIndex("wazuh-states-inventory-system", "templates/states/inventory-system"));
         this.indices.add(new StateIndex("wazuh-states-inventory-users", "templates/states/inventory-users"));
         this.indices.add(new StateIndex("wazuh-states-vulnerabilities", "templates/states/vulnerabilities"));
+
+        // Threat intel content indices - Hold the catalog content the Content Manager downloads
+        // from CTI. Created as <name>-a with the public alias <name> pointing at it, so the Content
+        // Manager can rebuild content into the <name>-b slot and swap the alias atomically. The
+        // Content Manager defers all its work until the setup status index is marked ready, so these
+        // are always in place before the first write reaches them.
+        this.indices.add(new ContentIndex("wazuh-threatintel-enrichments", "templates/content/ioc"));
+        this.indices.add(new ContentIndex("wazuh-threatintel-filters", "templates/content/filters"));
+        this.indices.add(new ContentIndex("wazuh-threatintel-decoders", "templates/content/decoders"));
+        this.indices.add(new ContentIndex("wazuh-threatintel-rules", "templates/content/rules"));
+        this.indices.add(new ContentIndex("wazuh-threatintel-kvdbs", "templates/content/kvdbs"));
+        this.indices.add(new ContentIndex("wazuh-threatintel-integrations", "templates/content/integrations"));
+        this.indices.add(new ContentIndex("wazuh-threatintel-policies", "templates/content/policies"));
+        this.indices.add(new ContentIndex(".wazuh-threatintel-vulnerabilities", "templates/content/vulnerabilities"));
 
         // Wazuh settings index - Instantiated as it is required by the RestPutSettingsAction.
         this.settingsIndex = new SettingsIndex(".wazuh-settings", "templates/settings");

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/ContentIndex.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/ContentIndex.java
@@ -145,6 +145,15 @@ public class ContentIndex extends WazuhIndex {
      * text field, which cannot be aggregated or sorted on. It also occupies the alias's name, so the
      * alias cannot be created until it is gone. The content it holds is re-downloaded from CTI.
      *
+     * <p>Once the alias exists the topology is in place and nothing more is done, whichever physical
+     * index it points at. It is not always {@code -a}: the Content Manager's blue/green swap moves
+     * the alias to the alternate slot and then deletes the one it came from, so a cluster that has
+     * changed content source sits on {@code <name>-b} with no {@code <name>-a} at all. Creating
+     * {@code <name>-a} with the alias then would ask OpenSearch for a second write index on the same
+     * alias, which fails with {@code alias [...] has more than one write index}. That aborts {@code
+     * SetupPlugin}'s initialization loop, so every index registered after this one is skipped and the
+     * readiness marker is set to failed, on every restart.
+     *
      * @param index name of the public alias. The concrete index created is this name plus {@link
      *     #SUFFIX_A}.
      */
@@ -154,8 +163,13 @@ public class ContentIndex extends WazuhIndex {
         try {
             this.deleteSquatterIndex(index);
 
+            if (this.aliasExists(index)) {
+                log.debug("Alias {} already exists. Skipping.", index);
+                return;
+            }
+
             if (this.indexExists(physicalName)) {
-                this.ensureAlias(index, physicalName);
+                this.addAlias(index, physicalName);
                 return;
             }
 
@@ -212,17 +226,23 @@ public class ContentIndex extends WazuhIndex {
     }
 
     /**
-     * Points the public alias at the concrete index when the concrete index already exists without
-     * it. Nothing is done when the alias is already present.
+     * Returns whether the public alias exists, whichever concrete index it points at.
+     *
+     * @param alias the public alias name.
+     * @return true if the alias exists on the cluster, false otherwise.
+     */
+    private boolean aliasExists(String alias) {
+        return this.clusterService.state().metadata().hasAlias(alias);
+    }
+
+    /**
+     * Points the public alias at the concrete index. Only called when the concrete index exists and
+     * the alias does not, so there is no write index to conflict with.
      *
      * @param alias the public alias name.
      * @param physicalName the concrete index the alias must point at.
      */
-    private void ensureAlias(String alias, String physicalName) {
-        if (this.clusterService.state().metadata().hasAlias(alias)) {
-            log.debug("Index {} and its alias {} already exist. Skipping.", physicalName, alias);
-            return;
-        }
+    private void addAlias(String alias, String physicalName) {
         log.info("Index {} exists without its alias {}. Adding it.", physicalName, alias);
         IndicesAliasesRequest request =
                 new IndicesAliasesRequest()

--- a/plugins/setup/src/main/java/com/wazuh/setup/index/ContentIndex.java
+++ b/plugins/setup/src/main/java/com/wazuh/setup/index/ContentIndex.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.setup.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ResourceAlreadyExistsException;
+import org.opensearch.action.admin.indices.alias.Alias;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate;
+import org.opensearch.common.compress.CompressedXContent;
+import org.opensearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import com.wazuh.setup.model.IndexTemplate;
+import com.wazuh.setup.settings.PluginSettings;
+
+/**
+ * Class to represent a Content index. Content indices hold the catalog content the Content Manager
+ * downloads from CTI (IoCs, CVEs and the Engine ruleset: decoders, rules, KVDBs, integrations,
+ * policies and filters).
+ *
+ * <p>Unlike {@link StateIndex} and {@link StreamIndex}, a content index is not addressed by its own
+ * name. The concrete index is created as {@code <name>-a} and a write alias named {@code <name>}
+ * points at it, so the Content Manager can rebuild the content into the alternate {@code <name>-b}
+ * slot and swap the alias atomically without exposing a partially populated index.
+ */
+public class ContentIndex extends WazuhIndex {
+    private static final Logger log = LogManager.getLogger(ContentIndex.class);
+
+    /** Suffix of the concrete index this class creates and points the public alias at. */
+    public static final String SUFFIX_A = "-a";
+
+    /**
+     * Constructor.
+     *
+     * @param index public alias name (e.g., "wazuh-threatintel-enrichments"). The concrete index is
+     *     this name plus {@link #SUFFIX_A}.
+     * @param template path to the index template resource (without the .json extension).
+     */
+    public ContentIndex(String index, String template) {
+        super(index, template);
+    }
+
+    /**
+     * Returns the name of the concrete index backing the public alias.
+     *
+     * @return the alias name plus {@link #SUFFIX_A}.
+     */
+    public String getPhysicalName() {
+        return this.index + SUFFIX_A;
+    }
+
+    /**
+     * Overrides createTemplate so the index patterns cover every concrete index behind the alias.
+     *
+     * <p>The shipped JSON declares whichever pattern the schema generator produced, which does not
+     * necessarily match the suffixed names. Rewriting it to {@code <name>*} makes the template apply
+     * to the live {@code -a} index and to the {@code -b} shadow slot the Content Manager creates
+     * during a blue/green swap.
+     *
+     * @param template name of the index template to create.
+     */
+    @Override
+    public void createTemplate(String template) {
+        String templateName = this.index + "-template";
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            InputStream is = this.getClass().getClassLoader().getResourceAsStream(template + ".json");
+            IndexTemplate indexTemplate = mapper.readValue(is, IndexTemplate.class);
+
+            // Dynamically set the index patterns to match every concrete index behind the alias
+            indexTemplate.setIndexPatterns(List.of(this.index + "*"));
+
+            String indexMappings = mapper.writeValueAsString(indexTemplate.getMappings());
+            CompressedXContent compressedMapping = new CompressedXContent(indexMappings);
+            Settings settings = Settings.builder().loadFromMap(indexTemplate.getSettings()).build();
+            ComposableIndexTemplate composableTemplate =
+                    indexTemplate.getComposableIndexTemplate(settings, compressedMapping);
+
+            PutComposableIndexTemplateAction.Request request =
+                    new PutComposableIndexTemplateAction.Request(templateName)
+                            .indexTemplate(composableTemplate)
+                            .create(false);
+
+            this.client
+                    .execute(PutComposableIndexTemplateAction.INSTANCE, request)
+                    .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
+        } catch (IOException e) {
+            log.error(
+                    "Error reading index template from filesystem [{}]. Caused by: {}",
+                    template,
+                    e.toString());
+        } catch (ResourceAlreadyExistsException e) {
+            log.info("Index template {} already exists. Skipping.", templateName);
+        } catch (
+                Exception
+                        e) { // TimeoutException may be raised by actionGet(), but we cannot catch that one.
+            // Exit condition. Re-attempt to create the index template also failed. Original exception is
+            // rethrown.
+            if (!this.retry_template_creation) {
+                log.error(
+                        "Initialization of index template [{}] finally failed. The node will shut down.",
+                        templateName);
+                throw e;
+            }
+            log.warn("Operation to create the index template [{}] timed out. Retrying...", templateName);
+            this.retry_template_creation = false;
+            this.sleep(PluginSettings.getBackoff(this.clusterService.getSettings()));
+            this.createTemplate(template);
+        }
+    }
+
+    /**
+     * Overrides {@link Index#createIndex(String)} to create the concrete {@code <name>-a} index with
+     * the public alias {@code <name>} pointing at it.
+     *
+     * <p>A concrete index whose name is the alias name is removed first. Such an index can only come
+     * from a write that reached the alias name before anything created the alias, in which case
+     * OpenSearch auto-created it with dynamic mappings: every keyword the schema declares became a
+     * text field, which cannot be aggregated or sorted on. It also occupies the alias's name, so the
+     * alias cannot be created until it is gone. The content it holds is re-downloaded from CTI.
+     *
+     * @param index name of the public alias. The concrete index created is this name plus {@link
+     *     #SUFFIX_A}.
+     */
+    @Override
+    public void createIndex(String index) {
+        String physicalName = index + SUFFIX_A;
+        try {
+            this.deleteSquatterIndex(index);
+
+            if (this.indexExists(physicalName)) {
+                this.ensureAlias(index, physicalName);
+                return;
+            }
+
+            CreateIndexRequest request =
+                    new CreateIndexRequest(physicalName).alias(new Alias(index).writeIndex(true));
+            CreateIndexResponse response =
+                    this.client
+                            .admin()
+                            .indices()
+                            .create(request)
+                            .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
+            log.info(
+                    "Index created successfully: {} {} (alias {})",
+                    response.index(),
+                    response.isAcknowledged(),
+                    index);
+        } catch (ResourceAlreadyExistsException e) {
+            log.debug("Index {} already exists. Skipping.", physicalName);
+        } catch (
+                Exception
+                        e) { // TimeoutException may be raised by actionGet(), but we cannot catch that one.
+            // Exit condition. Re-attempt to create the index also failed. Original exception is rethrown.
+            if (!this.retry_index_creation) {
+                log.error(
+                        "Initialization of index [{}] finally failed. The node will shut down.", physicalName);
+                throw e;
+            }
+            log.warn("Operation to create the index [{}] timed out. Retrying...", physicalName);
+            this.retry_index_creation = false;
+            this.sleep(PluginSettings.getBackoff(this.clusterService.getSettings()));
+            this.createIndex(index);
+        }
+    }
+
+    /**
+     * Deletes a concrete index whose name equals the public alias name, if one exists.
+     *
+     * @param alias the public alias name.
+     */
+    private void deleteSquatterIndex(String alias) {
+        if (!this.clusterService.state().metadata().hasIndex(alias)) {
+            return;
+        }
+        log.warn(
+                "Found a concrete index named [{}], which is the name reserved for the public alias. "
+                        + "It was auto-created with dynamic mappings and its fields cannot be aggregated on. "
+                        + "Deleting it so the alias can be created; its content is downloaded again.",
+                alias);
+        this.client
+                .admin()
+                .indices()
+                .delete(new DeleteIndexRequest(alias))
+                .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
+    }
+
+    /**
+     * Points the public alias at the concrete index when the concrete index already exists without
+     * it. Nothing is done when the alias is already present.
+     *
+     * @param alias the public alias name.
+     * @param physicalName the concrete index the alias must point at.
+     */
+    private void ensureAlias(String alias, String physicalName) {
+        if (this.clusterService.state().metadata().hasAlias(alias)) {
+            log.debug("Index {} and its alias {} already exist. Skipping.", physicalName, alias);
+            return;
+        }
+        log.info("Index {} exists without its alias {}. Adding it.", physicalName, alias);
+        IndicesAliasesRequest request =
+                new IndicesAliasesRequest()
+                        .addAliasAction(
+                                IndicesAliasesRequest.AliasActions.add()
+                                        .index(physicalName)
+                                        .alias(alias)
+                                        .writeIndex(true));
+        this.client
+                .admin()
+                .indices()
+                .aliases(request)
+                .actionGet(PluginSettings.getTimeout(this.clusterService.getSettings()));
+    }
+}

--- a/plugins/setup/src/main/resources/templates/content/decoders.json
+++ b/plugins/setup/src/main/resources/templates/content/decoders.json
@@ -9,8 +9,7 @@
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "refresh_interval": "5s"
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/content/decoders.json
+++ b/plugins/setup/src/main/resources/templates/content/decoders.json
@@ -1,0 +1,122 @@
+{
+  "index_patterns": [
+    "wazuh-threatintel-decoders*"
+  ],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "codec": "zstd",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "refresh_interval": "5s"
+      }
+    },
+    "mappings": {
+      "dynamic": "true",
+      "dynamic_templates": [
+        {
+          "parse_fields": {
+            "match": [
+              "parse|*"
+            ],
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "document": {
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "keyword"
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "keyword"
+                },
+                "author": {
+                  "type": "keyword"
+                },
+                "date": {
+                  "type": "date"
+                },
+                "modified": {
+                  "type": "date"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "references": {
+                  "type": "keyword"
+                },
+                "documentation": {
+                  "type": "keyword"
+                },
+                "supports": {
+                  "type": "keyword"
+                },
+                "module": {
+                  "type": "keyword"
+                },
+                "compatibility": {
+                  "type": "keyword"
+                },
+                "versions": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "definitions": {
+              "type": "object",
+              "enabled": false
+            },
+            "check": {
+              "type": "object",
+              "enabled": false
+            },
+            "parents": {
+              "type": "keyword"
+            },
+            "normalize": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
+        "hash": {
+          "type": "object",
+          "properties": {
+            "sha256": {
+              "type": "keyword"
+            }
+          }
+        },
+        "offset": {
+          "type": "unsigned_long"
+        },
+        "yaml": {
+          "type": "text"
+        },
+        "space": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/setup/src/main/resources/templates/content/integrations.json
+++ b/plugins/setup/src/main/resources/templates/content/integrations.json
@@ -9,8 +9,7 @@
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "refresh_interval": "5s"
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/content/integrations.json
+++ b/plugins/setup/src/main/resources/templates/content/integrations.json
@@ -1,0 +1,112 @@
+{
+  "index_patterns": [
+    "wazuh-threatintel-integrations*"
+  ],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "codec": "zstd",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "refresh_interval": "5s"
+      }
+    },
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "document": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "default_parent": {
+              "type": "keyword"
+            },
+            "category": {
+              "type": "keyword"
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "keyword"
+                },
+                "author": {
+                  "type": "keyword"
+                },
+                "date": {
+                  "type": "date"
+                },
+                "modified": {
+                  "type": "date"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "references": {
+                  "type": "keyword"
+                },
+                "documentation": {
+                  "type": "keyword"
+                },
+                "supports": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "mode": {
+              "type": "keyword"
+            },
+            "decoders": {
+              "type": "keyword"
+            },
+            "kvdbs": {
+              "type": "keyword"
+            },
+            "rules": {
+              "type": "keyword"
+            },
+            "detector": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "keyword"
+                },
+                "interval": {
+                  "type": "integer"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "hash": {
+          "type": "object",
+          "properties": {
+            "sha256": {
+              "type": "keyword"
+            }
+          }
+        },
+        "offset": {
+          "type": "unsigned_long"
+        },
+        "space": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/setup/src/main/resources/templates/content/ioc.json
+++ b/plugins/setup/src/main/resources/templates/content/ioc.json
@@ -125,6 +125,9 @@
             }
           }
         },
+        "offset": {
+          "type": "unsigned_long"
+        },
         "type_hashes": {
           "type": "object"
         }

--- a/plugins/setup/src/main/resources/templates/content/kvdbs.json
+++ b/plugins/setup/src/main/resources/templates/content/kvdbs.json
@@ -9,8 +9,7 @@
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "refresh_interval": "5s"
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/content/kvdbs.json
+++ b/plugins/setup/src/main/resources/templates/content/kvdbs.json
@@ -1,0 +1,87 @@
+{
+  "index_patterns": [
+    "wazuh-threatintel-kvdbs*"
+  ],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "codec": "zstd",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "refresh_interval": "5s"
+      }
+    },
+    "mappings": {
+      "dynamic": "true",
+      "properties": {
+        "document": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "keyword"
+                },
+                "author": {
+                  "type": "keyword"
+                },
+                "date": {
+                  "type": "date"
+                },
+                "modified": {
+                  "type": "date"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "references": {
+                  "type": "keyword"
+                },
+                "documentation": {
+                  "type": "keyword"
+                },
+                "supports": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "content": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
+        "hash": {
+          "type": "object",
+          "properties": {
+            "sha256": {
+              "type": "keyword"
+            }
+          }
+        },
+        "offset": {
+          "type": "unsigned_long"
+        },
+        "yaml": {
+          "type": "text"
+        },
+        "space": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/setup/src/main/resources/templates/content/policies.json
+++ b/plugins/setup/src/main/resources/templates/content/policies.json
@@ -9,8 +9,7 @@
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "refresh_interval": "5s"
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/content/policies.json
+++ b/plugins/setup/src/main/resources/templates/content/policies.json
@@ -1,0 +1,106 @@
+{
+  "index_patterns": [
+    "wazuh-threatintel-policies*"
+  ],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "codec": "zstd",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "refresh_interval": "5s"
+      }
+    },
+    "mappings": {
+      "dynamic": "true",
+      "properties": {
+        "document": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "root_decoder": {
+              "type": "keyword"
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "keyword"
+                },
+                "author": {
+                  "type": "keyword"
+                },
+                "date": {
+                  "type": "date"
+                },
+                "modified": {
+                  "type": "date"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "references": {
+                  "type": "keyword"
+                },
+                "documentation": {
+                  "type": "keyword"
+                },
+                "compatibility": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "integrations": {
+              "type": "keyword"
+            },
+            "filters": {
+              "type": "keyword"
+            },
+            "enrichments": {
+              "type": "keyword"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "index_unclassified_events": {
+              "type": "boolean"
+            },
+            "index_discarded_events": {
+              "type": "boolean"
+            }
+          }
+        },
+        "hash": {
+          "type": "object",
+          "properties": {
+            "sha256": {
+              "type": "keyword"
+            }
+          }
+        },
+        "offset": {
+          "type": "unsigned_long"
+        },
+        "space": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "hash": {
+              "type": "object",
+              "properties": {
+                "sha256": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/setup/src/main/resources/templates/content/rules.json
+++ b/plugins/setup/src/main/resources/templates/content/rules.json
@@ -9,8 +9,7 @@
         "auto_expand_replicas": "0-1",
         "codec": "zstd",
         "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "refresh_interval": "5s"
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/plugins/setup/src/main/resources/templates/content/rules.json
+++ b/plugins/setup/src/main/resources/templates/content/rules.json
@@ -1,0 +1,186 @@
+{
+  "index_patterns": [
+    "wazuh-threatintel-rules*"
+  ],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "codec": "zstd",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "refresh_interval": "5s"
+      }
+    },
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "document": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "keyword"
+                },
+                "author": {
+                  "type": "keyword"
+                },
+                "date": {
+                  "type": "date"
+                },
+                "modified": {
+                  "type": "date"
+                },
+                "description": {
+                  "type": "text"
+                },
+                "references": {
+                  "type": "keyword"
+                },
+                "documentation": {
+                  "type": "keyword"
+                },
+                "supports": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "detection": {
+              "type": "object",
+              "enabled": false
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "falsepositives": {
+              "type": "keyword"
+            },
+            "fields": {
+              "type": "keyword"
+            },
+            "level": {
+              "type": "keyword"
+            },
+            "license": {
+              "type": "keyword"
+            },
+            "logsource": {
+              "properties": {
+                "category": {
+                  "type": "keyword"
+                },
+                "definition": {
+                  "type": "text"
+                },
+                "product": {
+                  "type": "keyword"
+                },
+                "service": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "related": {
+              "type": "nested",
+              "properties": {
+                "id": {
+                  "type": "keyword"
+                },
+                "type": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "scope": {
+              "type": "keyword"
+            },
+            "sigma_id": {
+              "type": "keyword"
+            },
+            "status": {
+              "type": "keyword"
+            },
+            "tags": {
+              "type": "keyword"
+            },
+            "taxonomy": {
+              "type": "keyword"
+            },
+            "threat": {
+              "type": "object",
+              "properties": {
+                "tactic": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "technique": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "subtechnique": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hash": {
+          "properties": {
+            "sha256": {
+              "type": "keyword"
+            }
+          }
+        },
+        "offset": {
+          "type": "unsigned_long"
+        },
+        "space": {
+          "properties": {
+            "name": {
+              "type": "keyword"
+            }
+          }
+        },
+        "type": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/setup/src/main/resources/templates/content/vulnerabilities.json
+++ b/plugins/setup/src/main/resources/templates/content/vulnerabilities.json
@@ -1,0 +1,35 @@
+{
+  "index_patterns": [
+    ".wazuh-threatintel-vulnerabilities*"
+  ],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "auto_expand_replicas": "0-1",
+        "codec": "zstd",
+        "hidden": "true",
+        "number_of_replicas": "0",
+        "number_of_shards": "1",
+        "refresh_interval": "5s"
+      }
+    },
+    "mappings": {
+      "date_detection": false,
+      "dynamic": "strict_allow_templates",
+      "properties": {
+        "offset": {
+          "type": "unsigned_long"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "document": {
+          "type": "object",
+          "enabled": false
+        }
+      }
+    }
+  }
+}

--- a/plugins/setup/src/main/resources/templates/content/vulnerabilities.json
+++ b/plugins/setup/src/main/resources/templates/content/vulnerabilities.json
@@ -10,8 +10,7 @@
         "codec": "zstd",
         "hidden": "true",
         "number_of_replicas": "0",
-        "number_of_shards": "1",
-        "refresh_interval": "5s"
+        "number_of_shards": "1"
       }
     },
     "mappings": {

--- a/plugins/setup/src/test/java/com/wazuh/setup/ThreatIntelIndicesIT.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/ThreatIntelIndicesIT.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.setup;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.wazuh.setup.index.ContentIndex;
+
+/**
+ * Integration tests verifying that the setup plugin provisions the threat-intel content indices:
+ * for every alias name, a concrete {@code <name>-a} index, an index template covering {@code
+ * <name>*} and the public alias pointing at the concrete index.
+ *
+ * <p>The mapping assertions reproduce the diagnostic from issue #1476: when {@code
+ * wazuh-threatintel-enrichments-a} is missing, the CTI writer's first write auto-creates a
+ * dynamically mapped index under the alias name, {@code document.type} becomes a {@code text} field
+ * and the home overview's Threat catalog widget group fails with a 400.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.SUITE)
+public class ThreatIntelIndicesIT extends OpenSearchRestTestCase {
+
+    private static final String ENRICHMENTS = "wazuh-threatintel-enrichments";
+
+    // spotless:off
+    private static final List<String> ALIASES =
+            List.of(
+                    ENRICHMENTS,
+                    "wazuh-threatintel-filters",
+                    "wazuh-threatintel-decoders",
+                    "wazuh-threatintel-rules",
+                    "wazuh-threatintel-kvdbs",
+                    "wazuh-threatintel-integrations",
+                    "wazuh-threatintel-policies",
+                    ".wazuh-threatintel-vulnerabilities");
+    // spotless:on
+
+    /** Registered after the content indices in the setup plugin, so it marks them all done. */
+    private static final String SETTINGS_INDEX = ".wazuh-settings";
+
+    private static final int MAX_WAIT_SECONDS = 120;
+    private static final int POLL_INTERVAL_MS = 500;
+
+    /**
+     * Preserves indices upon test completion. The setup plugin creates them once, during cluster
+     * initialization, so they must survive between tests.
+     *
+     * @return true to preserve indices
+     */
+    @Override
+    protected boolean preserveIndicesUponCompletion() {
+        return true;
+    }
+
+    /**
+     * Preserves index templates upon test completion, for the same reason as the indices.
+     *
+     * @return true to preserve templates
+     */
+    @Override
+    protected boolean preserveTemplatesUponCompletion() {
+        return true;
+    }
+
+    /**
+     * Waits for the setup plugin to finish initializing by polling for the settings index, which is
+     * registered after the content indices.
+     *
+     * @throws Exception if the index is not created within {@value #MAX_WAIT_SECONDS} seconds.
+     */
+    @Before
+    public void waitForPluginInitialization() throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(MAX_WAIT_SECONDS);
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                client().performRequest(new Request("GET", "/" + SETTINGS_INDEX));
+                return;
+            } catch (ResponseException e) {
+                if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                    throw e;
+                }
+                Thread.sleep(POLL_INTERVAL_MS);
+            }
+        }
+        fail("Timed out waiting for [" + SETTINGS_INDEX + "] to be created");
+    }
+
+    /** Every content index exists as a concrete {@code <name>-a} index, never as {@code <name>}. */
+    public void testConcreteIndicesExist() throws Exception {
+        for (String alias : ALIASES) {
+            String physical = alias + ContentIndex.SUFFIX_A;
+            Response response = client().performRequest(new Request("GET", "/" + physical));
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertTrue(
+                    "expected [" + physical + "] in the response",
+                    entityAsMap(response).containsKey(physical));
+        }
+    }
+
+    /** Every public alias resolves to its {@code -a} index and is that index's write target. */
+    public void testAliasesPointAtTheConcreteIndices() throws Exception {
+        for (String alias : ALIASES) {
+            String physical = alias + ContentIndex.SUFFIX_A;
+            Response response = client().performRequest(new Request("GET", "/_alias/" + alias));
+            Map<String, Object> body = entityAsMap(response);
+            assertEquals("alias [" + alias + "] must resolve to a single index", 1, body.size());
+            assertTrue("alias [" + alias + "] must point at " + physical, body.containsKey(physical));
+            assertEquals(Boolean.TRUE, this.aliasProperty(body, physical, alias).get("is_write_index"));
+        }
+    }
+
+    /**
+     * Every content index has its template installed, with a pattern that also covers the {@code -b}
+     * shadow slot the Content Manager creates during a blue/green swap.
+     */
+    public void testTemplatesAreInstalled() throws Exception {
+        for (String alias : ALIASES) {
+            String templateName = alias + "-template";
+            Response response =
+                    client().performRequest(new Request("GET", "/_index_template/" + templateName));
+            Map<String, Object> body = entityAsMap(response);
+            List<?> templates = (List<?>) body.get("index_templates");
+            assertEquals("expected exactly one template named " + templateName, 1, templates.size());
+            Map<?, ?> entry = (Map<?, ?>) ((Map<?, ?>) templates.get(0)).get("index_template");
+            assertEquals(List.of(alias + "*"), entry.get("index_patterns"));
+        }
+    }
+
+    /**
+     * The check the issue prescribes: the alias must resolve to the {@code -a} index and {@code
+     * document.type} must be an aggregatable keyword there.
+     */
+    public void testEnrichmentsDocumentTypeIsAnAggregatableKeyword() throws Exception {
+        Response response =
+                client()
+                        .performRequest(
+                                new Request("GET", "/" + ENRICHMENTS + "/_field_caps?fields=document.type"));
+        Map<String, Object> body = entityAsMap(response);
+
+        assertEquals(List.of(ENRICHMENTS + ContentIndex.SUFFIX_A), body.get("indices"));
+
+        Map<?, ?> fields = (Map<?, ?>) body.get("fields");
+        Map<?, ?> documentType = (Map<?, ?>) fields.get("document.type");
+        assertNotNull("document.type must be mapped", documentType);
+        assertEquals(
+                "document.type must be a keyword, not a dynamically mapped text field",
+                Boolean.FALSE,
+                documentType.containsKey("text"));
+        Map<?, ?> keyword = (Map<?, ?>) documentType.get("keyword");
+        assertNotNull("document.type must be mapped as a keyword", keyword);
+        assertEquals(Boolean.TRUE, keyword.get("aggregatable"));
+        assertEquals(Boolean.TRUE, keyword.get("searchable"));
+    }
+
+    /**
+     * The two aggregations the home overview's Threat catalog widget group issues in a single
+     * request. They returned a 400 while the index was dynamically mapped.
+     */
+    public void testThreatCatalogAggregationsSucceed() throws Exception {
+        Request request = new Request("POST", "/" + ENRICHMENTS + "/_search");
+        request.setJsonEntity(
+                "{\"size\":0,\"aggs\":{"
+                        + "\"ioc_feed_by_type\":{\"terms\":{\"field\":\"document.type\",\"size\":10}},"
+                        + "\"threat_types\":{\"terms\":{\"field\":\"document.software.type\",\"size\":10}}}}");
+        Response response = client().performRequest(request);
+
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        Map<?, ?> shards = (Map<?, ?>) entityAsMap(response).get("_shards");
+        assertEquals(
+                "no shard may fail the aggregation", 0, ((Number) shards.get("failed")).intValue());
+    }
+
+    /**
+     * The enrichments mapping is {@code dynamic: strict_allow_templates} and every IoC document
+     * carries an {@code offset}, so a template missing that field would reject every CTI write.
+     */
+    public void testAnIocDocumentIsAccepted() throws Exception {
+        Request request = new Request("PUT", "/" + ENRICHMENTS + "/_doc/setup-it-ioc?refresh=true");
+        request.setJsonEntity(
+                "{\"offset\":42,"
+                        + "\"hash\":{\"sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"},"
+                        + "\"document\":{\"id\":\"ioc-1\",\"type\":\"domain\",\"name\":\"example.invalid\","
+                        + "\"provider\":\"wazuh\",\"confidence\":85,\"tags\":[\"test\"],"
+                        + "\"software\":{\"type\":\"malware\",\"name\":\"test\",\"alias\":\"test\"}}}");
+        Response response = client().performRequest(request);
+
+        assertEquals(201, response.getStatusLine().getStatusCode());
+
+        // The write went through the alias, so it must have landed on the concrete index.
+        assertEquals(ENRICHMENTS + ContentIndex.SUFFIX_A, entityAsMap(response).get("_index"));
+    }
+
+    /** Extracts the settings of a single alias from an {@code _alias} response body. */
+    private Map<?, ?> aliasProperty(Map<String, Object> body, String index, String alias) {
+        Map<?, ?> aliases = (Map<?, ?>) ((Map<?, ?>) body.get(index)).get("aliases");
+        return (Map<?, ?>) aliases.get(alias);
+    }
+}

--- a/plugins/setup/src/test/java/com/wazuh/setup/ThreatIntelIndicesIT.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/ThreatIntelIndicesIT.java
@@ -18,17 +18,21 @@ package com.wazuh.setup;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
+import org.junit.After;
 import org.junit.Before;
 
-import java.util.List;
-import java.util.Map;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
-import com.wazuh.setup.index.ContentIndex;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Integration tests verifying that the setup plugin provisions the threat-intel content indices:
@@ -45,28 +49,32 @@ public class ThreatIntelIndicesIT extends OpenSearchRestTestCase {
 
     private static final String ENRICHMENTS = "wazuh-threatintel-enrichments";
 
+    /** Suffix of the concrete index each public alias points at. */
+    private static final String SUFFIX_A = "-a";
+
     // spotless:off
-    private static final List<String> ALIASES =
-            List.of(
-                    ENRICHMENTS,
-                    "wazuh-threatintel-filters",
-                    "wazuh-threatintel-decoders",
-                    "wazuh-threatintel-rules",
-                    "wazuh-threatintel-kvdbs",
-                    "wazuh-threatintel-integrations",
-                    "wazuh-threatintel-policies",
-                    ".wazuh-threatintel-vulnerabilities");
+    private static final String[] ALIASES = {
+        ENRICHMENTS,
+        "wazuh-threatintel-filters",
+        "wazuh-threatintel-decoders",
+        "wazuh-threatintel-rules",
+        "wazuh-threatintel-kvdbs",
+        "wazuh-threatintel-integrations",
+        "wazuh-threatintel-policies",
+        ".wazuh-threatintel-vulnerabilities"
+    };
     // spotless:on
 
-    /** Registered after the content indices in the setup plugin, so it marks them all done. */
+    /** Registered after the content indices, so its presence marks them all done. */
     private static final String SETTINGS_INDEX = ".wazuh-settings";
 
     private static final int MAX_WAIT_SECONDS = 120;
     private static final int POLL_INTERVAL_MS = 500;
 
     /**
-     * Preserves indices upon test completion. The setup plugin creates them once, during cluster
-     * initialization, so they must survive between tests.
+     * Preserves indices upon test completion. The SetupPlugin creates indices during cluster
+     * initialization, and these need to persist across all tests since the plugin only creates them
+     * once.
      *
      * @return true to preserve indices
      */
@@ -76,7 +84,19 @@ public class ThreatIntelIndicesIT extends OpenSearchRestTestCase {
     }
 
     /**
-     * Preserves index templates upon test completion, for the same reason as the indices.
+     * Preserves data streams upon test completion. The SetupPlugin creates data streams during
+     * initialization, and these need to persist across all tests.
+     *
+     * @return true to preserve data streams
+     */
+    @Override
+    protected boolean preserveDataStreamsUponCompletion() {
+        return true;
+    }
+
+    /**
+     * Preserves index templates upon test completion. The SetupPlugin creates index templates for
+     * the content indices, and these need to persist across all tests.
      *
      * @return true to preserve templates
      */
@@ -86,136 +106,197 @@ public class ThreatIntelIndicesIT extends OpenSearchRestTestCase {
     }
 
     /**
-     * Waits for the setup plugin to finish initializing by polling for the settings index, which is
-     * registered after the content indices.
+     * Waits for the plugin initialization to complete by polling for the settings index, which is
+     * registered after the content indices in the setup plugin's initialization order. CI runners may
+     * be slow due to resource constraints; timeout is {@value #MAX_WAIT_SECONDS} seconds.
      *
-     * @throws Exception if the index is not created within {@value #MAX_WAIT_SECONDS} seconds.
+     * @throws Exception if the index is not created within the timeout
      */
     @Before
     public void waitForPluginInitialization() throws Exception {
-        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(MAX_WAIT_SECONDS);
-        while (System.currentTimeMillis() < deadline) {
+        long startTime = System.currentTimeMillis();
+        long timeout = TimeUnit.SECONDS.toMillis(MAX_WAIT_SECONDS);
+
+        while (System.currentTimeMillis() - startTime < timeout) {
             try {
                 client().performRequest(new Request("GET", "/" + SETTINGS_INDEX));
+                logger.info("Setup plugin initialization is ready");
                 return;
             } catch (ResponseException e) {
-                if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+                    logger.debug("Waiting for [{}] index to be created...", SETTINGS_INDEX);
+                    Thread.sleep(POLL_INTERVAL_MS);
+                } else {
                     throw e;
                 }
-                Thread.sleep(POLL_INTERVAL_MS);
             }
         }
-        fail("Timed out waiting for [" + SETTINGS_INDEX + "] to be created");
+        fail(
+                "Timed out waiting for ["
+                        + SETTINGS_INDEX
+                        + "] index to be created after "
+                        + MAX_WAIT_SECONDS
+                        + " seconds");
     }
 
-    /** Every content index exists as a concrete {@code <name>-a} index, never as {@code <name>}. */
-    public void testConcreteIndicesExist() throws Exception {
+    /**
+     * Verifies that every content index exists as a concrete {@code <name>-a} index, which is the
+     * name the issue reports as missing for the enrichments index.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     * @throws ParseException if there is an issue parsing the response
+     */
+    public void testConcreteIndicesCreated() throws IOException, ParseException {
         for (String alias : ALIASES) {
-            String physical = alias + ContentIndex.SUFFIX_A;
+            String physical = alias + SUFFIX_A;
             Response response = client().performRequest(new Request("GET", "/" + physical));
-            assertEquals(200, response.getStatusLine().getStatusCode());
-            assertTrue(
-                    "expected [" + physical + "] in the response",
-                    entityAsMap(response).containsKey(physical));
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+            logger.info("Index response for [{}]: {}", physical, body);
+            assertThat(body, containsString(physical));
         }
     }
 
-    /** Every public alias resolves to its {@code -a} index and is that index's write target. */
-    public void testAliasesPointAtTheConcreteIndices() throws Exception {
+    /**
+     * Verifies that every public alias resolves to its {@code -a} index and is that index's write
+     * target, which is what lets the Content Manager swap the alias between the two physical slots.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     * @throws ParseException if there is an issue parsing the response
+     */
+    public void testAliasesPointAtTheConcreteIndices() throws IOException, ParseException {
         for (String alias : ALIASES) {
-            String physical = alias + ContentIndex.SUFFIX_A;
+            String physical = alias + SUFFIX_A;
             Response response = client().performRequest(new Request("GET", "/_alias/" + alias));
-            Map<String, Object> body = entityAsMap(response);
-            assertEquals("alias [" + alias + "] must resolve to a single index", 1, body.size());
-            assertTrue("alias [" + alias + "] must point at " + physical, body.containsKey(physical));
-            assertEquals(Boolean.TRUE, this.aliasProperty(body, physical, alias).get("is_write_index"));
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+            logger.info("Alias response for [{}]: {}", alias, body);
+            assertThat(body, containsString("\"" + physical + "\""));
+            assertThat(body, containsString("\"" + alias + "\""));
+            assertThat(body, containsString("\"is_write_index\":true"));
         }
     }
 
     /**
-     * Every content index has its template installed, with a pattern that also covers the {@code -b}
-     * shadow slot the Content Manager creates during a blue/green swap.
+     * Verifies that every content index has its template installed, with a pattern that also covers
+     * the {@code -b} shadow slot the Content Manager creates during a blue/green swap.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     * @throws ParseException if there is an issue parsing the response
      */
-    public void testTemplatesAreInstalled() throws Exception {
+    public void testTemplatesCreated() throws IOException, ParseException {
         for (String alias : ALIASES) {
-            String templateName = alias + "-template";
+            String template = alias + "-template";
             Response response =
-                    client().performRequest(new Request("GET", "/_index_template/" + templateName));
-            Map<String, Object> body = entityAsMap(response);
-            List<?> templates = (List<?>) body.get("index_templates");
-            assertEquals("expected exactly one template named " + templateName, 1, templates.size());
-            Map<?, ?> entry = (Map<?, ?>) ((Map<?, ?>) templates.get(0)).get("index_template");
-            assertEquals(List.of(alias + "*"), entry.get("index_patterns"));
+                    client().performRequest(new Request("GET", "/_index_template/" + template));
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+            logger.info("Template response for [{}]: {}", template, body);
+            assertThat(body, containsString(template));
+            assertThat(body, containsString("\"" + alias + "*\""));
         }
     }
 
     /**
-     * The check the issue prescribes: the alias must resolve to the {@code -a} index and {@code
-     * document.type} must be an aggregatable keyword there.
+     * Verifies the check the issue prescribes: the alias resolves to the {@code -a} index and {@code
+     * document.type} is an aggregatable keyword there, rather than the {@code text} field a
+     * dynamically mapped index would have produced.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     * @throws ParseException if there is an issue parsing the response
      */
-    public void testEnrichmentsDocumentTypeIsAnAggregatableKeyword() throws Exception {
+    public void testEnrichmentsDocumentTypeIsAnAggregatableKeyword()
+            throws IOException, ParseException {
         Response response =
                 client()
                         .performRequest(
                                 new Request("GET", "/" + ENRICHMENTS + "/_field_caps?fields=document.type"));
-        Map<String, Object> body = entityAsMap(response);
+        String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
-        assertEquals(List.of(ENRICHMENTS + ContentIndex.SUFFIX_A), body.get("indices"));
-
-        Map<?, ?> fields = (Map<?, ?>) body.get("fields");
-        Map<?, ?> documentType = (Map<?, ?>) fields.get("document.type");
-        assertNotNull("document.type must be mapped", documentType);
-        assertEquals(
-                "document.type must be a keyword, not a dynamically mapped text field",
-                Boolean.FALSE,
-                documentType.containsKey("text"));
-        Map<?, ?> keyword = (Map<?, ?>) documentType.get("keyword");
-        assertNotNull("document.type must be mapped as a keyword", keyword);
-        assertEquals(Boolean.TRUE, keyword.get("aggregatable"));
-        assertEquals(Boolean.TRUE, keyword.get("searchable"));
+        logger.info("Field caps response for [document.type]: {}", body);
+        assertThat(body, containsString("\"indices\":[\"" + ENRICHMENTS + SUFFIX_A + "\"]"));
+        assertThat(body, containsString("\"type\":\"keyword\""));
+        assertThat(body, containsString("\"aggregatable\":true"));
+        assertThat(
+                "document.type must not be a dynamically mapped text field",
+                body,
+                not(containsString("\"type\":\"text\"")));
     }
 
     /**
-     * The two aggregations the home overview's Threat catalog widget group issues in a single
-     * request. They returned a 400 while the index was dynamically mapped.
+     * Verifies that the two aggregations the home overview's Threat catalog widget group issues in a
+     * single request succeed. They returned a 400 while the index was dynamically mapped.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     * @throws ParseException if there is an issue parsing the response
      */
-    public void testThreatCatalogAggregationsSucceed() throws Exception {
-        Request request = new Request("POST", "/" + ENRICHMENTS + "/_search");
-        request.setJsonEntity(
-                "{\"size\":0,\"aggs\":{"
-                        + "\"ioc_feed_by_type\":{\"terms\":{\"field\":\"document.type\",\"size\":10}},"
-                        + "\"threat_types\":{\"terms\":{\"field\":\"document.software.type\",\"size\":10}}}}");
-        Response response = client().performRequest(request);
+    public void testThreatCatalogAggregationsSucceed() throws IOException, ParseException {
+        Request search = new Request("POST", "/" + ENRICHMENTS + "/_search");
+        search.setJsonEntity(
+                """
+                {
+                  "size": 0,
+                  "aggs": {
+                    "ioc_feed_by_type": {"terms": {"field": "document.type", "size": 10}},
+                    "threat_types": {"terms": {"field": "document.software.type", "size": 10}}
+                  }
+                }
+                """);
+        Response response = client().performRequest(search);
+        String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
-        assertEquals(200, response.getStatusLine().getStatusCode());
-        Map<?, ?> shards = (Map<?, ?>) entityAsMap(response).get("_shards");
-        assertEquals(
-                "no shard may fail the aggregation", 0, ((Number) shards.get("failed")).intValue());
+        logger.info("Threat catalog aggregation response: {}", body);
+        assertThat("no shard may fail the aggregation", body, containsString("\"failed\":0"));
+        assertThat(body, containsString("ioc_feed_by_type"));
+        assertThat(body, containsString("threat_types"));
     }
 
     /**
-     * The enrichments mapping is {@code dynamic: strict_allow_templates} and every IoC document
-     * carries an {@code offset}, so a template missing that field would reject every CTI write.
+     * Verifies that an IoC document is accepted. The enrichments mapping is {@code dynamic:
+     * strict_allow_templates} and every IoC carries an {@code offset}, so a template missing that
+     * field would reject every CTI write.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     * @throws ParseException if there is an issue parsing the response
      */
-    public void testAnIocDocumentIsAccepted() throws Exception {
-        Request request = new Request("PUT", "/" + ENRICHMENTS + "/_doc/setup-it-ioc?refresh=true");
-        request.setJsonEntity(
-                "{\"offset\":42,"
-                        + "\"hash\":{\"sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"},"
-                        + "\"document\":{\"id\":\"ioc-1\",\"type\":\"domain\",\"name\":\"example.invalid\","
-                        + "\"provider\":\"wazuh\",\"confidence\":85,\"tags\":[\"test\"],"
-                        + "\"software\":{\"type\":\"malware\",\"name\":\"test\",\"alias\":\"test\"}}}");
-        Response response = client().performRequest(request);
+    public void testIocDocumentIsAccepted() throws IOException, ParseException {
+        Request index = new Request("PUT", "/" + ENRICHMENTS + "/_doc/setup-it-ioc");
+        index.addParameter("refresh", "true");
+        index.setJsonEntity(
+                """
+                {
+                  "offset": 42,
+                  "hash": {"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+                  "document": {
+                    "id": "ioc-1",
+                    "type": "domain",
+                    "name": "example.invalid",
+                    "provider": "wazuh",
+                    "confidence": 85,
+                    "tags": ["test"],
+                    "software": {"type": "malware", "name": "test", "alias": "test"}
+                  }
+                }
+                """);
+        Response response = client().performRequest(index);
+        String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
-        assertEquals(201, response.getStatusLine().getStatusCode());
-
+        logger.info("IoC index response: {}", body);
+        assertThat(body, containsString("\"result\":\"created\""));
         // The write went through the alias, so it must have landed on the concrete index.
-        assertEquals(ENRICHMENTS + ContentIndex.SUFFIX_A, entityAsMap(response).get("_index"));
+        assertThat(body, containsString("\"_index\":\"" + ENRICHMENTS + SUFFIX_A + "\""));
     }
 
-    /** Extracts the settings of a single alias from an {@code _alias} response body. */
-    private Map<?, ?> aliasProperty(Map<String, Object> body, String index, String alias) {
-        Map<?, ?> aliases = (Map<?, ?>) ((Map<?, ?>) body.get(index)).get("aliases");
-        return (Map<?, ?>) aliases.get(alias);
+    /**
+     * Clears the fielddata cache after each test to prevent flaky failures from the test framework's
+     * post-test assertions.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     */
+    @After
+    public void clearFieldData() throws IOException {
+        Request request = new Request("POST", "/_cache/clear");
+        request.addParameter("fielddata", "true");
+        client().performRequest(request);
     }
 }

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/ContentIndexTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/ContentIndexTests.java
@@ -141,6 +141,24 @@ public class ContentIndexTests extends OpenSearchTestCase {
         verify(this.indicesAdminClient, never()).create(any(CreateIndexRequest.class));
     }
 
+    /**
+     * After a blue/green swap the alias points at the alternate slot and the slot it came from is
+     * deleted, so the cluster has an alias and no {@code -a} index. Creating {@code -a} with the
+     * alias would ask for a second write index on it, which fails and aborts the whole setup
+     * initialization loop. The alias existing is enough: nothing is done.
+     */
+    public void testCreateIndexIsANoOpWhenTheAliasPointsAtTheAlternateSlot() {
+        // The swap left the alias on -b and deleted -a.
+        doReturn(false).when(this.routingTable).hasIndex(PHYSICAL);
+        doReturn(true).when(this.metadata).hasAlias(ALIAS);
+
+        this.contentIndex.createIndex(ALIAS);
+
+        verify(this.indicesAdminClient, never()).create(any(CreateIndexRequest.class));
+        verify(this.indicesAdminClient, never()).aliases(any(IndicesAliasesRequest.class));
+        verify(this.indicesAdminClient, never()).delete(any(DeleteIndexRequest.class));
+    }
+
     /** A fully provisioned index is left untouched. */
     public void testCreateIndexIsANoOpWhenIndexAndAliasExist() {
         doReturn(true).when(this.routingTable).hasIndex(PHYSICAL);

--- a/plugins/setup/src/test/java/com/wazuh/setup/index/ContentIndexTests.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/index/ContentIndexTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.setup.index;
+
+import org.opensearch.ResourceAlreadyExistsException;
+import org.opensearch.action.admin.indices.alias.Alias;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.routing.RoutingTable;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.IndicesAdminClient;
+
+import java.util.Set;
+
+import com.wazuh.setup.utils.JsonUtils;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.Mockito.*;
+
+/** Unit tests for the {@link ContentIndex} class. */
+public class ContentIndexTests extends OpenSearchTestCase {
+
+    private static final String ALIAS = "wazuh-threatintel-enrichments";
+    private static final String PHYSICAL = ALIAS + ContentIndex.SUFFIX_A;
+
+    private ContentIndex contentIndex;
+    private IndicesAdminClient indicesAdminClient;
+    private RoutingTable routingTable;
+    private Metadata metadata;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Client client = mock(Client.class);
+        AdminClient adminClient = mock(AdminClient.class);
+        this.indicesAdminClient = mock(IndicesAdminClient.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        this.routingTable = mock(RoutingTable.class);
+        this.metadata = mock(Metadata.class);
+
+        doReturn(Settings.builder().build()).when(clusterService).getSettings();
+
+        this.contentIndex = new ContentIndex(ALIAS, "templates/content/ioc");
+        this.contentIndex.setClient(client);
+        this.contentIndex.setClusterService(clusterService);
+        this.contentIndex.setUtils(mock(JsonUtils.class));
+
+        doReturn(adminClient).when(client).admin();
+        doReturn(this.indicesAdminClient).when(adminClient).indices();
+        doReturn(clusterState).when(clusterService).state();
+        doReturn(this.routingTable).when(clusterState).getRoutingTable();
+        doReturn(this.metadata).when(clusterState).metadata();
+
+        // Clean cluster by default: neither the concrete index nor a squatter exists.
+        doReturn(false).when(this.routingTable).hasIndex(anyString());
+        doReturn(false).when(this.metadata).hasIndex(anyString());
+        doReturn(false).when(this.metadata).hasAlias(anyString());
+    }
+
+    /** The concrete index is named after the alias plus the "-a" suffix. */
+    public void testGetPhysicalName() {
+        assertEquals(PHYSICAL, this.contentIndex.getPhysicalName());
+    }
+
+    /** On a clean cluster the "-a" index is created with the public alias as its write index. */
+    public void testCreateIndexCreatesPhysicalIndexWithWriteAlias() {
+        this.stubCreate(mock(CreateIndexResponse.class));
+
+        this.contentIndex.createIndex(ALIAS);
+
+        ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+        verify(this.indicesAdminClient).create(captor.capture());
+        CreateIndexRequest request = captor.getValue();
+        assertEquals(PHYSICAL, request.index());
+        Set<Alias> aliases = request.aliases();
+        assertEquals(1, aliases.size());
+        Alias alias = aliases.iterator().next();
+        assertEquals(ALIAS, alias.name());
+        assertEquals(Boolean.TRUE, alias.writeIndex());
+        verify(this.indicesAdminClient, never()).delete(any(DeleteIndexRequest.class));
+    }
+
+    /**
+     * An index literally named after the alias is auto-created with dynamic mappings and occupies the
+     * alias's name, so it is deleted before the "-a" index is created.
+     */
+    public void testCreateIndexDeletesTheIndexSquattingTheAliasName() {
+        doReturn(true).when(this.metadata).hasIndex(ALIAS);
+        ActionFuture<?> deleteFuture = mock(ActionFuture.class);
+        doReturn(deleteFuture).when(this.indicesAdminClient).delete(any(DeleteIndexRequest.class));
+        this.stubCreate(mock(CreateIndexResponse.class));
+
+        this.contentIndex.createIndex(ALIAS);
+
+        ArgumentCaptor<DeleteIndexRequest> captor = ArgumentCaptor.forClass(DeleteIndexRequest.class);
+        verify(this.indicesAdminClient).delete(captor.capture());
+        assertArrayEquals(new String[] {ALIAS}, captor.getValue().indices());
+        verify(this.indicesAdminClient).create(any(CreateIndexRequest.class));
+    }
+
+    /** An existing "-a" index without its alias gets the alias added rather than being recreated. */
+    public void testCreateIndexAddsTheAliasWhenOnlyTheConcreteIndexExists() {
+        doReturn(true).when(this.routingTable).hasIndex(PHYSICAL);
+        ActionFuture<?> aliasFuture = mock(ActionFuture.class);
+        doReturn(aliasFuture).when(this.indicesAdminClient).aliases(any(IndicesAliasesRequest.class));
+
+        this.contentIndex.createIndex(ALIAS);
+
+        ArgumentCaptor<IndicesAliasesRequest> captor =
+                ArgumentCaptor.forClass(IndicesAliasesRequest.class);
+        verify(this.indicesAdminClient).aliases(captor.capture());
+        IndicesAliasesRequest.AliasActions action = captor.getValue().getAliasActions().get(0);
+        assertArrayEquals(new String[] {PHYSICAL}, action.indices());
+        assertArrayEquals(new String[] {ALIAS}, action.aliases());
+        assertEquals(Boolean.TRUE, action.writeIndex());
+        verify(this.indicesAdminClient, never()).create(any(CreateIndexRequest.class));
+    }
+
+    /** A fully provisioned index is left untouched. */
+    public void testCreateIndexIsANoOpWhenIndexAndAliasExist() {
+        doReturn(true).when(this.routingTable).hasIndex(PHYSICAL);
+        doReturn(true).when(this.metadata).hasAlias(ALIAS);
+
+        this.contentIndex.createIndex(ALIAS);
+
+        verify(this.indicesAdminClient, never()).create(any(CreateIndexRequest.class));
+        verify(this.indicesAdminClient, never()).aliases(any(IndicesAliasesRequest.class));
+        verify(this.indicesAdminClient, never()).delete(any(DeleteIndexRequest.class));
+    }
+
+    /**
+     * Another node winning the race to create the index is not an error, and must not trigger the
+     * retry path.
+     */
+    public void testCreateIndexSwallowsResourceAlreadyExists() {
+        ActionFuture<CreateIndexResponse> future = mock(ActionFuture.class);
+        doThrow(new ResourceAlreadyExistsException("already exists")).when(future).actionGet(anyLong());
+        doReturn(future).when(this.indicesAdminClient).create(any(CreateIndexRequest.class));
+
+        this.contentIndex.createIndex(ALIAS);
+
+        verify(this.indicesAdminClient).create(any(CreateIndexRequest.class));
+    }
+
+    /** Stubs a successful create index call returning the given response. */
+    private void stubCreate(CreateIndexResponse response) {
+        ActionFuture<CreateIndexResponse> future = mock(ActionFuture.class);
+        doReturn(response).when(future).actionGet(anyLong());
+        doReturn(future).when(this.indicesAdminClient).create(any(CreateIndexRequest.class));
+    }
+}

--- a/wcs/content/ioc/docs/fields.csv
+++ b/wcs/content/ioc/docs/fields.csv
@@ -1,4 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
+9.1.0,true,base,offset,unsigned_long,custom,,,The CTI offset the IoC document was delivered at.
 9.1.0,true,base,type_hashes,object,custom,,,A dynamic object containing the hash values for each IoC type.
 9.1.0,true,document,document.confidence,short,custom,,85,"Confidence level or score for the IoC, typically representing the reliability of the indicator."
 9.1.0,true,document,document.feed.name,keyword,custom,,AlienVault OTX,Name of the threat intelligence feed that provided this IoC.

--- a/wcs/content/ioc/fields/custom/base.yml
+++ b/wcs/content/ioc/fields/custom/base.yml
@@ -18,3 +18,7 @@
       level: custom
       type: object
       description: "A dynamic object containing the hash values for each IoC type."
+    - name: offset
+      level: custom
+      type: unsigned_long
+      description: "The CTI offset the IoC document was delivered at."

--- a/wcs/content/ioc/fields/subset.yml
+++ b/wcs/content/ioc/fields/subset.yml
@@ -6,6 +6,7 @@ fields:
       hash:
         fields:
           sha256: {}
+      offset: {}
       type_hashes: {}
   document:
     fields:


### PR DESCRIPTION
## Description

Six of the seven `wazuh-threatintel-*` indices are provisioned as `<name>-a` behind a `<name>` alias.
`enrichments` was not, so nothing created it. The first CTI write therefore hit a name that did not
exist, OpenSearch auto-created a concrete `wazuh-threatintel-enrichments` with dynamic mappings, and
every declared `keyword` became `text` — which has no doc_values.

That breaks the **Threat catalog** group on `/app/wz-home`: its two aggregations (`document.type`,
`document.software.type`) travel in one request, so one 400 blanks all three tiles. The squatting
index also occupies the alias's name, so the alias cannot be repointed until it is removed.

Per [this comment](https://github.com/wazuh/wazuh-indexer-plugins/issues/1476#issuecomment-5394842395),
creation of the whole family moves to the setup plugin.

Closes #1476

## Proposed Changes

**Setup plugin — now owns the threat-intel indices**
- New `ContentIndex` kind (third `WazuhIndex` subclass): creates `<name>-a` + write alias `<name>`,
  and deletes any concrete index squatting the alias name. Template patterns become `<name>*` so they
  also cover the `-b` shadow slot the content manager swaps into.
- All 8 indices registered (7 `wazuh-threatintel-*` + hidden `.wazuh-threatintel-vulnerabilities`),
  with 6 new templates under `templates/content/`.
- Added the missing `offset: unsigned_long` to `content/ioc.json`. Every IOC carries it and the
  template is `dynamic: strict_allow_templates`, so shipping it as-is would have rejected every CTI
  write. Also added to the WCS `content/ioc` module so regeneration keeps it.

**Content manager — stops racing and stops auto-creating**
- `ensureResourceIndicesExist()` now waits for the setup readiness marker. Registering the indices in
  setup was not enough: this method waited for nothing and won, creating 6 of the 8 *before* their
  templates existed. Reuses the existing wait, extracted to `SetupReadiness`.
- A failed index creation now aborts the sync pass instead of letting the next bulk auto-create a
  dynamically mapped index — the root cause of this bug.
- An IOC/CVE index found empty with a non-zero offset resets the offset, so a removed squatter's
  content is re-downloaded.

**Guard against drift** — the mappings deliberately live in both plugins (the content manager needs
its copies for shadow indices and standalone runs). New `verifyContentTemplates` Gradle task, wired
into `check`, fails the build if they diverge. It would already have caught the missing `offset`.

### Results and Evidence

Verified on a real node built from the ARCHIVE distribution with this branch's plugin zips.

**Before / after**, reproduced on the same node:

| | before | after |
|---|---|---|
| index | `wazuh-threatintel-enrichments` (concrete) | `wazuh-threatintel-enrichments-a` |
| alias | `404 alias [...] missing` | `-> ...-a`, `is_write_index: true` |
| `document.type` | `{"text": {"aggregatable": false}}` | `{"keyword": {"aggregatable": true}}` |
| Threat catalog aggs | `400` *Text fields are not optimised…* | `200`, 0 failed shards |

`_field_caps` now returns byte-for-byte what the issue quotes from the healthy demo environment:

```json
{"indices": ["wazuh-threatintel-enrichments-a"],
 "fields": {"document.type": {"keyword": {"type": "keyword", "searchable": true, "aggregatable": true}}}}
```

**Setup is the creator.** With the full stack installed, every index names its own template — an
empty `templates []` is the signature of an index created before its template existed:

```
wazuh-threatintel-enrichments-a        template=[wazuh-threatintel-enrichments-template]
wazuh-threatintel-filters-a            template=[wazuh-threatintel-filters-template]
...all 8...
```

The content manager provisioned none of them. Without the readiness wait, 6 read `templates []`.

**Upgrade is self-healing** — restarting over the broken state:

```
[WARN][c.w.s.i.ContentIndex] Found a concrete index named [wazuh-threatintel-enrichments], which is the
  name reserved for the public alias. ... Deleting it so the alias can be created.
[INFO][c.w.s.i.ContentIndex] Index created successfully: wazuh-threatintel-enrichments-a true (alias ...)
```

**Build** — `./gradlew check -PnumNodes=1` from each plugin dir, as CI does. All green:
setup 55 unit / 28 integ, content-manager 584 unit / 149 integ. 0 failures, 0 skipped.

### Artifacts Affected

- `wazuh-indexer-setup`: new `ContentIndex`, 8 registered indices, 7 bundled templates (6 new,
  1 amended), new `verifyContentTemplates` task.
- `wazuh-indexer-content-manager`: new `SetupReadiness`, readiness wait, sync aborts instead of
  auto-creating, offset reset for single-index consumers.
- WCS `content/ioc`: `offset` added to `fields/custom/base.yml` and `fields/subset.yml`.

On a fresh cluster this adds `wazuh-threatintel-enrichments-a` and
`.wazuh-threatintel-vulnerabilities-a`, plus 8 `<alias>-template` templates.

### Configuration Changes

None — no settings or defaults changed.

**Nothing was renamed.** The `-a`/`-b` scheme predates this PR (`ContentIndex.SUFFIX_A`, #1165) and 6
of 7 indices already had it. Alias names are unchanged and the 8 index-name constants are identical to
`main`; only the concrete index behind the alias changes, and only for `enrichments`, which had none.

**Upgrades** need no manual step: setup deletes the squatter and creates `-a` + alias, the content
manager resets the offset and re-downloads from CTI. The deleted content is CTI-sourced.

### Documentation Updates

`docs/dev/plugins/setup.md` — `ContentIndex` added to the class diagram and the list of index kinds,
plus a new "Threat intel content indices" section (layout and why the alias exists, which plugin
creates them and how to confirm it, squatter recovery, why mappings live in both plugins). Also notes
that `templates/cve.json` is a WCS artifact for `wazuh-cve*` and intentionally unregistered.

`CHANGELOG.md` — entry under `## [v5.0.0]` → `### Fixed`.

### Tests Introduced

- **`ThreatIntelIndicesIT`** (6) — all 8 `-a` indices, aliases and templates exist; plus the issue's
  own diagnostic as assertions: `document.type` aggregatable on `...-a`, the Threat catalog agg pair
  returns 200 with no failed shards, and an IOC with `offset` is accepted.
- **`ContentIndexTests`** (6) — creation with alias, squatter deleted first, alias added when only the
  concrete index exists, no-op when both exist, `ResourceAlreadyExistsException` swallowed.
- **`SetupReadinessTests`** (5) — ready / failed / running / unreadable marker, and the full backoff
  schedule exhausted before giving up.
- **`verifyContentTemplates`** — verified in both directions (passes clean, fails on injected drift)
  and in the standalone `cd plugins/setup && ./gradlew check` layout CI uses.
- **Two existing ITs fixed, not worked around.** `SpaceInitializationIT` and
  `StandardSpaceHashRecoveryIT` created concrete indices named after the aliases setup now provisions;
  both reach the Gradle cluster as an `ExternalTestCluster`, so the setup plugin is running there.
  Confirmed this PR caused it, not flakiness: `main` 3/3 pass, branch 2/2 fail, and with
  content-manager reverted to `main` it still failed 3/3 — isolating the cause to the setup side.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (none introduced)
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] Verified on a full 5.0.0 stack (Docker/ECR) per the issue's reproduction steps

### Two points for reviewers

1. **The readiness wait reuses the catalog-download budget** (300s default). With the setup plugin
   absent, custom-ruleset endpoints would 503 for that window before the fallback runs. Both plugins
   always ship together, so this only affects setup-less dev clusters. A shorter budget for this gate
   would be a separate setting.
2. **Squatter deletion.** Lossless for `enrichments` and CVE (CTI-sourced). For the 6 ruleset indices
   a squatter is effectively impossible — their aliases exist from first boot, before any REST
   endpoint is reachable — but if one existed it could hold user-authored rules, which are not
   re-downloadable. No guard added; happy to log the discarded doc count or reindex instead.
