### PR TITLE
Add VD component tests

### DIFF
--- a/.github/workflows/5_testcomponent_content_manager.yml
+++ b/.github/workflows/5_testcomponent_content_manager.yml
@@ -188,20 +188,29 @@ jobs:
                 if echo "${consumer_response}" | grep -q '"ready"'; then
                     ruleset_ready=true
                 fi
+                # The vulnerabilities consumer feeds .wazuh-threatintel-vulnerabilities,
+                # asserted by the vulnerabilities component tests.
+                vd_response=$(curl -s "$base/.wazuh-cti-consumers/_doc/cti:catalog:consumer:vulnerabilities?filter_path=_source.status")
+                echo "Vulnerabilities consumer response: ${vd_response}"
+                vd_ready=false
+                if echo "${vd_response}" | grep -q '"ready"'; then
+                    vd_ready=true
+                fi
                 sap_response=$(curl -s -w '\n%{http_code}' "$base/.opensearch-sap-pre-packaged-rules-config")
                 sap_code=$(echo "${sap_response}" | tail -1)
                 echo "SAP rules config response (HTTP ${sap_code})"
-                if [ "$ruleset_ready" = true ] && [ "$sap_code" = "200" ]; then
-                    echo "Ruleset consumer ready and SAP rules config present (${SECONDS}s)."
+                if [ "$ruleset_ready" = true ] && [ "$vd_ready" = true ] && [ "$sap_code" = "200" ]; then
+                    echo "Ruleset + vulnerabilities consumers ready and SAP rules config present (${SECONDS}s)."
                     break
                 fi
-                echo "Waiting — ruleset consumer ready: ${ruleset_ready}, SAP rules config: ${sap_code} (${SECONDS}s)..."
+                echo "Waiting — ruleset ready: ${ruleset_ready}, vulnerabilities ready: ${vd_ready}, SAP rules config: ${sap_code} (${SECONDS}s)..."
                 sleep 10
             done
 
-            if [ "$ruleset_ready" != true ] || [ "$sap_code" != "200" ]; then
+            if [ "$ruleset_ready" != true ] || [ "$vd_ready" != true ] || [ "$sap_code" != "200" ]; then
                 echo "Indexer content sync did not complete in time."
                 echo "--- Ruleset consumer ---"; curl -s "$base/.wazuh-cti-consumers/_doc/cti:catalog:consumer:ruleset" || true
+                echo "--- Vulnerabilities consumer ---"; curl -s "$base/.wazuh-cti-consumers/_doc/cti:catalog:consumer:vulnerabilities" || true
                 docker logs wazuh-indexer | tail -150
                 exit 1
             fi

--- a/tests/content-manager/lib/client.py
+++ b/tests/content-manager/lib/client.py
@@ -145,6 +145,38 @@ class CMClient:
         """Return the draft policy ``_source`` (or ``None`` if absent)."""
         return self.get_policy(C.SPACE_DRAFT)
 
+    # ── CTI consumers ─────────────────────────────────────────────────────
+
+    def consumer_status(self, consumer_type):
+        """Return a consumer's ``status`` string from ``.wazuh-cti-consumers``.
+
+        Returns ``None`` if the consumer document does not exist yet (the
+        consumer has not started) or carries no status field.
+        """
+        resp = self.get(f"/{C.INDEX_CONSUMERS}/_doc/{consumer_type}", params={"filter_path": "_source.status"})
+        if resp.status_code != 200:
+            return None
+        return resp.json().get("_source", {}).get("status")
+
+    # ── Aggregation helpers ───────────────────────────────────────────────
+
+    def terms_agg(self, index, field, size=10000):
+        """Return ``{value: doc_count}`` for a terms aggregation over ``field``."""
+        self.refresh(index)
+        body = {"size": 0, "aggs": {"values": {"terms": {"field": field, "size": size}}}}
+        resp = self.post(f"/{index}/_search", json=body)
+        assert resp.status_code == 200, f"terms agg {index}.{field} -> {resp.status_code}: {resp.text}"
+        buckets = resp.json()["aggregations"]["values"]["buckets"]
+        return {b["key"]: b["doc_count"] for b in buckets}
+
+    def cardinality_agg(self, index, field):
+        """Return the cardinality (distinct count) of ``field`` in ``index``."""
+        self.refresh(index)
+        body = {"size": 0, "aggs": {"unique_count": {"cardinality": {"field": field}}}}
+        resp = self.post(f"/{index}/_search", json=body)
+        assert resp.status_code == 200, f"cardinality agg {index}.{field} -> {resp.status_code}: {resp.text}"
+        return resp.json()["aggregations"]["unique_count"]["value"]
+
     # ── Findings pipeline (Security Analytics + Alerting) ──────────────────
 
     def create_detector(self, payload):

--- a/tests/content-manager/lib/constants.py
+++ b/tests/content-manager/lib/constants.py
@@ -34,6 +34,24 @@ INDEX_KVDBS = "wazuh-threatintel-kvdbs"
 INDEX_DECODERS = "wazuh-threatintel-decoders"
 INDEX_FILTERS = "wazuh-threatintel-filters"
 INDEX_ENRICHMENTS = "wazuh-threatintel-enrichments"
+INDEX_VULNERABILITIES = ".wazuh-threatintel-vulnerabilities"
+
+# CTI consumers index.
+INDEX_CONSUMERS = ".wazuh-cti-consumers"
+CONSUMER_VULNERABILITIES = "cti:catalog:consumer:vulnerabilities"
+CONSUMER_RULESET = "cti:catalog:consumer:ruleset"
+CONSUMER_STATUS_READY = "ready"
+
+# Document types the vulnerabilities consumer must load.
+VULNERABILITY_REQUIRED_TYPES = [
+    "OSCPE-GLOBAL",
+    "FEED-GLOBAL",
+    "CNA-MAPPING-GLOBAL",
+    "TID",
+    "CVE",
+]
+# Minimum number of distinct ``type`` values expected in the index.
+VULNERABILITY_MIN_DISTINCT_TYPES = 7
 
 # Convenience map: resource type -> its index alias.
 RESOURCE_INDEX = {

--- a/tests/content-manager/pytest.ini
+++ b/tests/content-manager/pytest.ini
@@ -9,3 +9,4 @@ markers =
     promote: promotion lifecycle coverage (mutates test/custom spaces irreversibly)
     logtest: engine-backed logtest coverage
     findings: end-to-end detector/findings generation (creates a SAP detector)
+    vulnerabilities: vulnerabilities consumer content checks (.wazuh-threatintel-vulnerabilities)

--- a/tests/content-manager/test_vulnerabilities_content.py
+++ b/tests/content-manager/test_vulnerabilities_content.py
@@ -1,0 +1,71 @@
+"""Vulnerabilities consumer content checks.
+
+Once the vulnerabilities consumer reaches ``ready``, its first sync must have
+loaded the expected document types into ``.wazuh-threatintel-vulnerabilities``.
+A regression there left the index missing whole document types (OSCPE-GLOBAL,
+FEED-GLOBAL, CNA-MAPPING-GLOBAL, TID, CVE) even though the consumer reported
+ready, so these tests assert the ``type`` distribution directly.
+
+The module fixture waits for ``cti:catalog:consumer:vulnerabilities`` to report
+``ready`` before any assertion runs; the CI workflow already blocks on content
+sync, so this is a bounded safety net rather than the primary wait.
+"""
+
+import time
+
+import pytest
+
+from lib import constants as C
+
+pytestmark = [pytest.mark.vulnerabilities]
+
+# How long to wait for the vulnerabilities consumer to become ready.
+_READY_TIMEOUT = 900
+_READY_POLL = 10
+
+
+@pytest.fixture(scope="module")
+def vulnerabilities_types(client):
+    """Wait for the vulnerabilities consumer to be ready, then return the
+    ``{type: doc_count}`` distribution of ``.wazuh-threatintel-vulnerabilities``."""
+    deadline = time.time() + _READY_TIMEOUT
+    last = None
+    while time.time() < deadline:
+        last = client.consumer_status(C.CONSUMER_VULNERABILITIES)
+        if last == C.CONSUMER_STATUS_READY:
+            break
+        time.sleep(_READY_POLL)
+    else:
+        pytest.fail(
+            f"vulnerabilities consumer '{C.CONSUMER_VULNERABILITIES}' did not reach "
+            f"'{C.CONSUMER_STATUS_READY}' within {_READY_TIMEOUT}s (last status: {last!r})"
+        )
+    return client.terms_agg(C.INDEX_VULNERABILITIES, "type")
+
+
+@pytest.mark.vulnerabilities
+@pytest.mark.parametrize("doc_type", C.VULNERABILITY_REQUIRED_TYPES)
+def test_required_type_present(vulnerabilities_types, doc_type):
+    """At least one document of each required type is present."""
+    count = vulnerabilities_types.get(doc_type, 0)
+    assert count >= 1, (
+        f"expected >= 1 document of type '{doc_type}' in {C.INDEX_VULNERABILITIES}, "
+        f"found {count}. Present types: {sorted(vulnerabilities_types)}"
+    )
+
+
+@pytest.mark.vulnerabilities
+def test_minimum_distinct_types(client, vulnerabilities_types):
+    """The index holds at least the expected number of distinct document types."""
+    # Assert on the same cardinality aggregation the issue references, and
+    # cross-check it against the terms buckets used by the per-type tests.
+    distinct = client.cardinality_agg(C.INDEX_VULNERABILITIES, "type")
+    assert distinct >= C.VULNERABILITY_MIN_DISTINCT_TYPES, (
+        f"expected >= {C.VULNERABILITY_MIN_DISTINCT_TYPES} distinct document types in "
+        f"{C.INDEX_VULNERABILITIES}, cardinality reported {distinct}. "
+        f"Present types: {sorted(vulnerabilities_types)}"
+    )
+    assert len(vulnerabilities_types) >= C.VULNERABILITY_MIN_DISTINCT_TYPES, (
+        f"terms aggregation returned only {len(vulnerabilities_types)} types: "
+        f"{sorted(vulnerabilities_types)}"
+    )


### PR DESCRIPTION
## Description

Adds new component test that guards the content of the `.wazuh-threatintel-vulnerabilities` index

The test enforces the two acceptance criteria from the issue:

- **≥ 1 document of each required type**: `OSCPE-GLOBAL`, `FEED-GLOBAL`,
  `CNA-MAPPING-GLOBAL`, `TID`, `CVE`.
- **≥ 7 distinct document types** in the index 

Closes #1482

## Proposed Changes

- `tests/content-manager/test_vulnerabilities_content.py`: New module with the tests
- `tests/content-manager/lib/client.py`: New helpers
- `tests/content-manager/lib/constants.py`: New constants
- `tests/content-manager/pytest.ini`: Add the new tests
- `.github/workflows/5_testcomponent_content_manager.yml`: Upload the workflow so it runs the new tests

### Results and Evidence

Validated locally before running the workflow

```json
{
  "aggregations": {
    "t": { "buckets": [
      { "key": "CVE",                "doc_count": 372115 },
      { "key": "TID",                "doc_count": 181 },
      { "key": "CNA-MAPPING-GLOBAL", "doc_count": 1 },
      { "key": "FEED-GLOBAL",        "doc_count": 1 },
      { "key": "OSCPE-GLOBAL",       "doc_count": 1 },
      { "key": "TCPE",               "doc_count": 1 },
      { "key": "TVENDORS",           "doc_count": 1 }
    ] },
    "u": { "value": 7 }
  }
}
```

Test run:

``` console
$ pytest test_vulnerabilities_content.py --base-url https://localhost:9200 --user admin --password admin -v

test_vulnerabilities_content.py::test_required_type_present[OSCPE-GLOBAL] PASSED [ 16%]
test_vulnerabilities_content.py::test_required_type_present[FEED-GLOBAL] PASSED [ 33%]
test_vulnerabilities_content.py::test_required_type_present[CNA-MAPPING-GLOBAL] PASSED [ 50%]
test_vulnerabilities_content.py::test_required_type_present[TID] PASSED  [ 66%]
test_vulnerabilities_content.py::test_required_type_present[CVE] PASSED  [ 83%]
test_vulnerabilities_content.py::test_minimum_distinct_types PASSED      [100%]

============================== 6 passed in 0.03s ===============================
```

### Artifacts Affected

NA

### Configuration Changes

NA

### Documentation Updates

NA

### Tests Introduced

- `test_required_type_present[OSCPE-GLOBAL|FEED-GLOBAL|CNA-MAPPING-GLOBAL|TID|CVE]`:  each required type has ≥ 1 document.
- `test_minimum_distinct_types`: `type` ≥ 7

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)