### PR TITLE
Add new WCS management skill

### DIFF
--- a/.claude/skills/wcs-management/REFERENCE.md
+++ b/.claude/skills/wcs-management/REFERENCE.md
@@ -1,0 +1,301 @@
+# WCS module reference
+
+Companion to `SKILL.md`. Copy-paste templates and the internals you need to
+author WCS inputs correctly.
+
+## Module anatomy
+
+```
+wcs/<family>/<module>/
+├── docs
+│   ├── fields.csv          # GENERATED — do not edit
+│   └── README.md           # hand-written (see README rules)
+├── event-generator
+│   └── event_generator.py  # hand-written; hyphen dir is the convention
+└── fields
+    ├── custom
+    │   └── <object>.yml     # custom fields grouped by object (wazuh.yml, state.yml, ...)
+    ├── mapping-settings.json
+    ├── subset.yml
+    ├── template-settings.json
+    └── template-settings-legacy.json
+```
+
+Everything under `wcs/<module>/mappings/**` is generated output (ECS tooling
+writes `beats/`, `csv/`, `ecs/`, `elasticsearch/composable/`,
+`elasticsearch/legacy/`). Never edit it.
+
+Reference module to imitate: `wcs/stateful/vulnerabilities/` (rich custom
+fields) and `wcs/cve/` (custom-object nesting + the short README style).
+
+## `subset.yml`
+
+Declares which ECS objects/fields (and custom objects) the module includes.
+`fields: "*"` pulls the whole object; a nested `fields:` map cherry-picks.
+
+```yaml
+---
+name: wazuh-<family>-<module>        # subset name; drives the generated subset path
+fields:
+  base:
+    fields:
+      message: {}                  # single ECS field
+  package:
+    fields: "*"                    # entire ECS object
+  host:
+    fields:
+      os:
+        fields:
+          full: ""
+          name: ""
+          version: ""
+  vulnerability:
+    fields:
+      id: {}
+      severity: {}
+      score:
+        fields:
+          base: {}
+          version: {}
+  state:
+    fields: "*"                    # a custom object defined in fields/custom/state.yml
+  wazuh:
+    fields:
+      cluster:
+        fields: "*"
+      schema:
+        fields: "*"
+```
+
+A custom object (one you define under `fields/custom/`) must also be listed in
+`subset.yml`, or the generator will not include it.
+
+## `fields/custom/<object>.yml`
+
+ECS-style field group. One file per object; the filename is the object name.
+
+Simple custom object (`state.yml`, `checksum.yml`, `wazuh.yml` pattern):
+
+```yaml
+---
+- name: state
+  title: State
+  description: >
+    State custom fields
+  fields:
+    - name: modified_at
+      type: date
+      level: custom
+      description: >
+        Date/time when the state was last modified.
+    - name: document_version
+      type: integer
+      level: custom
+      description: >
+        Version of the document.
+```
+
+Dotted sub-paths are allowed in a single entry (`wazuh.yml`):
+
+```yaml
+---
+- name: wazuh
+  title: Wazuh
+  description: >
+    Wazuh Inc. custom fields
+  fields:
+    - name: cluster.name
+      type: keyword
+      level: custom
+      description: >
+        Wazuh cluster name.
+    - name: schema.version
+      type: keyword
+      level: custom
+      description: >
+        Wazuh schema version.
+```
+
+**Reusable / remap mechanism** — how ECS `agent.*` ends up as `wazuh.agent.*`
+(this is what the "Destination Field" column of a module README records). The
+`reusable.expected` block nests the object under another:
+
+```yaml
+---
+- name: agent
+  reusable:
+    expected:
+      - { at: wazuh, as: agent }   # agent.* is mapped under wazuh.agent.*
+  title: Wazuh Agents
+  short: Wazuh Inc. custom fields.
+  type: group
+  group: 2
+  fields:
+    - name: groups
+      type: keyword
+      level: custom
+      description: >
+        List of groups the agent belongs to.
+      normalize:
+        - array
+      example: "[\"group1\", \"group2\"]"
+```
+
+Field entry keys you'll use: `name`, `type` (`keyword`, `date`, `integer`,
+`long`, `float`, `boolean`, `date_nanos`, …), `level: custom`, `description`
+(folded `>`), optional `normalize: [array]`, `example`.
+
+**Short description limit (generator will fail otherwise):** the ECS generator
+derives a `short` description from `description`, and `short` must be a single
+line **≤ 120 characters**. A long or multi-line `description` with no explicit
+`short` overflows that limit and the generation **fails**. Whenever a
+`description` is long or spans multiple lines, add a one-line `short:` summary
+alongside it:
+
+```yaml
+    - name: turns
+      type: object
+      level: custom
+      short: Conversation turns, stored verbatim to reconstruct the chat in the UI.
+      description: >
+        Conversation turns (author and content, plus any other data returned by
+        the AI provider). Shape varies by provider, so the object is unmapped:
+        stored in _source and returned as-is, but neither indexed nor searchable.
+```
+
+Keep `short` under 120 chars. This applies to both field entries and the
+group-level `description`/`short` at the top of a `custom/<object>.yml`.
+
+## `fields/mapping-settings.json`
+
+Almost always:
+
+```json
+{
+    "dynamic": "strict",
+    "date_detection": false
+}
+```
+
+## `fields/template-settings.json` (composable)
+
+`priority`, and settings nested under `template.settings`:
+
+```json
+{
+  "index_patterns": ["wazuh-<family>-<module>*"],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "codec": "zstd",
+        "gc_deletes": "15s",
+        "number_of_shards": "1",
+        "number_of_replicas": "0",
+        "auto_expand_replicas": "0-1",
+        "refresh_interval": "2s",
+        "query.default_field": [
+          "package.name",
+          "vulnerability.id",
+          "wazuh.cluster.name"
+        ]
+      }
+    }
+  }
+}
+```
+
+## `fields/template-settings-legacy.json` (legacy)
+
+Same values, different shape: `order` instead of `priority`, and `settings` at
+the **top level** (not nested under `template`):
+
+```json
+{
+  "index_patterns": ["wazuh-<family>-<module>*"],
+  "order": 1,
+  "settings": {
+    "index": {
+      "codec": "zstd",
+      "gc_deletes": "15s",
+      "number_of_shards": "1",
+      "number_of_replicas": "0",
+      "auto_expand_replicas": "0-1",
+      "refresh_interval": "2s",
+      "query.default_field": [
+        "package.name",
+        "vulnerability.id",
+        "wazuh.cluster.name"
+      ]
+    }
+  }
+}
+```
+
+Keep the two files in sync: `priority` ↔ `order`, and identical
+`index_patterns` / index settings / `query.default_field`.
+
+## README rules
+
+**Avoid mentioning ECS / Elastic Common Schema; say WCS (Wazuh Common Schema)**.
+Keep it short and redirect the detail to `fields.csv`. Model on `wcs/cve/docs/README.md`:
+
+```markdown
+## `wazuh-<index-name>` index data model
+
+### Fields summary
+
+The fields are based on <one line + link to the source issue/spec>.
+
+The detail of the fields can be found in csv file [<Name> Fields](fields.csv).
+```
+
+Do **not** reproduce the older, verbose `stateful/vulnerabilities/docs/README.md`
+(long ECS link list + full transition table) — that predates the rule.
+
+## Generator internals worth knowing
+
+- **`ECS_VERSION`** defaults to `v9.1.0` (`generate_schema.sh`); generated
+  output is versioned under `mappings/<ECS_VERSION>/`.
+- **Module → destination map** lives in `wcs/module_list.txt`, produced by
+  `update_module_list.sh`. Most modules map to a bare filename copied under
+  `plugins/setup/src/main/resources/templates/`.
+- **`internal-state`** is the exception: its generated template goes to
+  `plugins/content-manager/src/main/resources/mappings/internal-state-mapping.json`
+  (consumed by content-manager's CredentialsIndex), not to setup.
+- **Dynamic-template modules**: `stateless/events/main` and
+  `stateless/events/findings` are auto-converted from static `properties` to
+  `dynamic_templates` by `convert_to_dynamic_templates.py` inside
+  `generate_schema.sh` (keeps `mapping.total_fields.limit` from exhausting).
+  Editing `events/main` also triggers regeneration of all `stateless/events/*`.
+- **`EXCLUDED_FIELDS`** in `wcs/generator/images/generator.sh` drops unwanted
+  duplicate copies of a custom field from every module.
+- **`schema_sanitizer.py`** (`images/`) rewrites ECS source mappings to WCS
+  requirements at image-build time.
+- **OpenSearch compatibility**: the tooling renames `order`→`priority` and
+  nests `mappings`/`settings` under `template`, emitting
+  `elasticsearch/legacy/opensearch-template.json` (the file copied to setup).
+
+## Gotchas checklist
+
+- **Generated files** — never hand-edit `mappings/**`,
+  `plugins/setup/.../resources/templates/**`, `docs/fields.csv`,
+  `internal-state-mapping.json`.
+- **git detection** — `generate_schema.sh` diffs against `origin/main`; edits
+  must be in the working tree, and a new module's files + regenerated
+  `module_list.txt` must be **staged** or the module is invisible to the
+  generator.
+- **Two settings files** — `template-settings.json` and
+  `-legacy.json` must carry the same values in their two shapes.
+- **Limits are computed** — never hand-set `total_fields.limit` /
+  `nested_fields.limit` / `max_docvalue_fields_search`; run
+  `count_and_update_total_fields.sh` after generation.
+- **New module wiring** — required: `subset.yml`+`custom/` inputs and the
+  `update_module_list.sh` mapping (if not auto directory-scanned; needed for
+  generation). Optional: `SetupPlugin.java` registration — the runtime-install
+  step, done by default but the user may opt out ("I'll do the code").
+- **Short description ≤ 120 chars** — a long/multi-line `description` without a
+  single-line `short:` overflows the ECS `short` limit and **fails
+  generation**; add a `short:` one-liner (see `custom/<object>.yml` above).
+- **Docker required** — `generate_schema.sh` builds/runs a container that
+  clones the ECS repo; no Docker means no generation.

--- a/.claude/skills/wcs-management/SKILL.md
+++ b/.claude/skills/wcs-management/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: wcs-management
+description: Maintain and create Wazuh Common Schema (WCS) modules under wcs/ in wazuh-indexer-plugins. Use when asked to add a field to a WCS module, change a module's index/template settings, create a new WCS module, or regenerate WCS index templates. Covers the module anatomy, the ECS-subset + custom-field YAML dialect, the 3-step Docker generator pipeline (update_module_list.sh, generate_schema.sh, count_and_update_total_fields.sh), and the out-of-tree wiring (SetupPlugin.java, module_list). Never hand-edit generated templates.
+---
+
+# WCS module management
+
+The `wcs/` tree holds the Wazuh Common Schema: ~40 modules, each a folder of
+hand-authored **inputs** (subset + custom fields + settings) whose OpenSearch
+**index templates are generated**, never written by hand. This skill drives
+three recurring tasks:
+
+- **A** — add a field to an existing module
+- **B** — change a module's settings
+- **C** — create a new module
+
+Companion file: `REFERENCE.md` — module anatomy, copy-paste YAML/JSON
+templates, generator internals, README rules, and gotchas. Read it before
+authoring field or settings files.
+
+## Hard rule: never hand-edit generated files
+
+Edit only the inputs. These are **generated** — the pipeline overwrites them,
+so any manual edit is lost and wrong:
+
+- `wcs/<module>/mappings/**` (the whole tree)
+- `plugins/setup/src/main/resources/templates/**` (copied index templates)
+- `plugins/content-manager/src/main/resources/mappings/internal-state-mapping.json`
+- `wcs/<module>/docs/fields.csv`
+
+You edit: `fields/subset.yml`, `fields/custom/*.yml`,
+`fields/mapping-settings.json`, `fields/template-settings.json`,
+`fields/template-settings-legacy.json`, and the hand-written `docs/README.md`.
+
+## Locating a module
+
+**The user normally gives the full module path and target location up front**
+— e.g. "I want module `stateless/test `, output under
+`wcs/stateless/test`". Take that as the module path directly (relative to
+`wcs/`).
+
+Only when the path is missing or ambiguous, resolve a plain name
+("vulnerabilities", "cve", "packages") by globbing `wcs/**/fields/subset.yml`,
+then list the matches and ask which one. Families for reference:
+
+- `wcs/stateful/<...>` — state indices (`wazuh-states-*`); includes
+  `stateful/inventory/*` and `stateful/fim/*`.
+- `wcs/stateless/<...>` — data streams (events, metrics, active-responses).
+- `wcs/content/{ioc,filters}`, `wcs/settings`, `wcs/cve`,
+  `wcs/ai-assistant/sessions`, `wcs/internal-state`.
+
+## Workflow A — add a field to an existing module
+
+1. **Locate** the module.
+2. **Classify the field** and pick where it goes:
+   - **Custom field on an object that already has a `fields/custom/<object>.yml`**
+     (e.g. adding to `state`, `wazuh`, `package`): append the field entry to
+     that file. See `REFERENCE.md` for the entry shape.
+   - **Custom field on a new object**: create `fields/custom/<object>.yml`
+     **and** add that object to `fields/subset.yml` so the generator pulls it
+     in.
+   - **A plain ECS field already defined upstream in ECS**: add it to
+     `fields/subset.yml` only (no custom file needed) — cherry-pick it under
+     its object, or use `fields: "*"` to take the whole object.
+3. If the object is one that gets remapped under `wazuh.*` (see the `reusable`
+   mechanism in `REFERENCE.md`, e.g. `agent`), follow the existing object's
+   pattern rather than inventing a new mapping.
+4. **Regenerate** — run the pipeline (steps 2 + 3 of "Regeneration", below).
+   No `module_list` change is needed for an existing module.
+5. **Verify**: the field appears in the generated
+   `plugins/setup/.../resources/templates/...json` and in
+   `wcs/<module>/docs/fields.csv`.
+
+## Workflow B — change a module's settings
+
+Settings live in two files that must stay **in sync** — same values, but two
+shapes (composable vs legacy). See `REFERENCE.md` for the exact difference
+(`priority` + nested `template.settings` vs `order` + top-level `settings`).
+
+1. **Locate** the module.
+2. Edit `fields/template-settings.json` **and**
+   `fields/template-settings-legacy.json` with the requested change (index
+   settings, `query.default_field`, `index_patterns`, priority/order, …).
+3. If the change is a mapping-level setting (`dynamic`, `date_detection`),
+   edit `fields/mapping-settings.json` instead/also.
+4. Do **not** hand-set `mapping.total_fields.limit` /
+   `nested_fields.limit` / `index.max_docvalue_fields_search` — step 3 of the
+   pipeline computes those.
+5. **Regenerate** (steps 2 + 3). **Verify** the setting in the generated
+   template.
+
+## Workflow C — create a new module
+
+1. **Copy the closest existing module** as a base (same family — a state
+   module for a new state index, etc.). Rename the folder to the new module
+   name. **Delete** the copied `mappings/` tree and `docs/fields.csv` (those
+   regenerate).
+2. Edit the inputs for the new module:
+   - `fields/subset.yml` — set `name:` and the ECS/custom objects to include.
+   - `fields/custom/*.yml` — the custom fields, grouped by object.
+   - `fields/template-settings.json` + `-legacy.json` — set `index_patterns`,
+     priority/order, index settings, `query.default_field`.
+   - `fields/mapping-settings.json` — usually
+     `{ "dynamic": "strict", "date_detection": false }`.
+3. Write a short `docs/README.md` per the **README rules** in `REFERENCE.md`
+   (WCS not ECS, short, link to `fields.csv`; use `wcs/cve/docs/README.md` as
+   the model).
+4. **Add** `event-generator/event_generator.py` (hyphen dir) based on a
+   sibling module's generator.
+5. **Wire it in.** Two separate touch points — treat them differently:
+   - **`wcs/generator/update_module_list.sh`** — *required for generation, not
+     optional.* `stateful/inventory/*` and `stateful/fim/*` are auto
+     directory-scanned; every other family needs an entry in the relevant
+     `map_*_module` function. Without this the generator (step 1 below) never
+     sees the module, so the template can't be produced. Always do this when
+     you generate.
+   - **`plugins/setup/src/main/java/com/wazuh/setup/SetupPlugin.java`** — this
+     is the runtime-install registration (the "code"). Do it **by default**,
+     but **the user may opt out** ("only create the template, I'll do the
+     code"). Register the index with the matching type — `StateIndex` for
+     `wazuh-states-*`, `StreamIndex` for streams.
+
+   If it is unclear whether the user wants the `SetupPlugin.java` change, ask
+   before editing Java. The `update_module_list.sh` entry is not up for debate
+   when the goal is to generate a template.
+6. **Regenerate** — full pipeline including step 1, and **stage changes in
+   git** before step 2 (see the caveat below).
+7. **Verify**: module present in `wcs/module_list.txt`; index template
+   generated and copied under `plugins/setup/.../resources/templates/`;
+   `docs/fields.csv` created. (If `SetupPlugin.java` was wired, confirm it
+   compiles — but that step is optional, so it's not a success criterion when
+   the user opted out.)
+
+## Regeneration
+
+Run from anywhere in the repo (scripts self-locate the root). Requires Docker,
+Docker Compose, `jq`, `python3` (all present on this machine).
+
+```bash
+# 1. ONLY when adding/removing a module — rescan wcs/ into module_list.txt
+bash wcs/generator/update_module_list.sh
+
+# 2. Generate templates for modified modules and copy them into place
+bash wcs/generator/generate_schema.sh          # add -f to force ALL modules
+
+# 3. Fix field-count limits in the generated templates
+bash wcs/generator/count_and_update_total_fields.sh all --apply
+#    or a single module:
+bash wcs/generator/count_and_update_total_fields.sh <module> --apply
+```
+
+**Critical caveats:**
+
+- `generate_schema.sh` detects what to build via
+  `git diff --name-only origin/main`. Your edits must be in the working tree,
+  and — per the generator's own troubleshooting note — for a **new** module
+  the `update_module_list.sh` output (and the new files) must be **staged in
+  git** or the generator will not see the module.
+- Step 3 (`count_and_update_total_fields.sh`) runs **after** generation; it
+  recomputes and fixes the `total_fields` / `nested_fields` /
+  `max_docvalue_fields_search` limits that otherwise cause template errors.
+- Run `count_and_update_total_fields.sh <module>` (no `--apply`) first to see
+  proposed limits as a dry run.
+
+## Success check
+
+- New/changed fields appear in
+  `plugins/setup/src/main/resources/templates/<...>.json` and in
+  `wcs/<module>/docs/fields.csv`.
+- Limits in the template reflect the field count (step 3 ran).
+- For a new module: it is in `wcs/module_list.txt`. (Registration in
+  `SetupPlugin.java` is optional — only check it when the user asked for the
+  wiring.)
+
+Leave the changes uncommitted for the user to review. Do not commit or push
+unless asked.


### PR DESCRIPTION
## Description

This PR adds a Claude Code skill, **`wcs-management`**, that captures the knowledge needed to maintain and create Wazuh Common Schema (WCS) modules. 
It includes the module anatomy, the ECS-subset + custom-field YAML files, the 3-step Docker generator pipeline, the README rules, and the wiring

The skill drives the three recurring WCS tasks:

- **A**: Add a field to an existing module
- **B**: Change a module's settings
- **C**: Create a new module

Key behaviors:

- Generated artifacts are never hand-edited
- New-module wiring split into **required** (`subset`/`custom` inputs +
  `update_module_list.sh` mapping, needed for generation) and **optional**
  (`SetupPlugin.java` runtime-install registration — done by default, user
  may opt out).

## Proposed Changes

- New `.claude/skills/wcs-management/*` files


## Results and Evidence

All 3 workflows were executed and worked as expected:

**Case A**

Added a custom field `state.skill_test_field` to `wcs/stateful/vulnerabilities/fields/custom/state.yml`, regenerated, copied the template into place, ran the count script.

Field landed in the generated template and in `docs/fields.csv`.

**Case B**

Changed `refresh_interval` from `2s` to `5s` in both `template-settings.json` and `template-settings-legacy.json`, regenerated, copied.

Setting propagated to the generated setup template.

**Case C**

Created a minimal stream module with a custom `test` object, a self-contained `wazuh` object, a short WCS README, and both settings files. Wired it into `update_module_list.sh` and `SetupPlugin.java`, then ran the full pipeline.

Changes:
<img width="284" height="293" alt="image" src="https://github.com/user-attachments/assets/48cad5a5-7049-4ba1-90c0-77c5fe9a0bbf" />

The new index exists if we execute the setup plugin:
``` console
jorge@jorge-wazuh:~/wazuh/wazuh-indexer-plugins$ curl -XGET -ks -u admin:admin "http://localhost:9200/_cat/indices/*test*"
green open .ds-wazuh-test-000001 RKxeykwoRNeP5DOfsTWFgg 1 0 0 0 208b 208b
```

## Artifacts Affected

NA

## Configuration Changes

NA

## Documentation Updates

The skill contains the documentation

## Tests Introduced

NA

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)