### PR TITLE
Add mechanism to retry bulk writes after shed

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndex.java
@@ -43,13 +43,17 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.breaker.CircuitBreakingException;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 import java.io.IOException;
@@ -60,6 +64,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.wazuh.contentmanager.cti.catalog.model.*;
 import com.wazuh.contentmanager.cti.catalog.utils.JsonPatch;
@@ -84,6 +89,10 @@ public class ContentIndex {
     private static final long UPDATE_INITIAL_BACKOFF_MS = 1000;
     private static final long UPDATE_MAX_BACKOFF_MS = 30_000;
 
+    private static final int MAX_BULK_RETRIES = 3;
+    private static final long BULK_INITIAL_BACKOFF_MS = 1000;
+    private static final long BULK_MAX_BACKOFF_MS = 30_000;
+
     /** Maximum number of UPDATE offsets to batch into a single MultiGet + BulkRequest. */
     public static final int UPDATE_SUB_BATCH_SIZE = 50;
 
@@ -93,6 +102,14 @@ public class ContentIndex {
     private final Client client;
     private final PluginSettings pluginSettings;
     private final Semaphore semaphore;
+
+    /**
+     * Documents this instance failed to index and gave up on, either because the failure was not
+     * retryable or because the retry budget was exhausted. Callers loading a full snapshot must check
+     * this before advancing the consumer offset, otherwise the dropped documents are never
+     * backfilled.
+     */
+    private final AtomicLong droppedDocuments = new AtomicLong();
 
     /**
      * The public alias name (e.g., {@code "wazuh-threatintel-rules"}). All read operations use this
@@ -712,46 +729,184 @@ public class ContentIndex {
     }
 
     /**
-     * Executes a bulk request asynchronously.
+     * Executes a bulk request asynchronously, retrying the items the cluster sheds under load.
+     *
+     * <p>The indexer is deliberately configured to shed writes rather than exhaust the heap (see
+     * {@code indices.breaker.total.limit} in {@code opensearch.prod.yml}), so a rejected bulk is an
+     * expected, transient outcome that the client is responsible for re-submitting. Only the failed
+     * items are retried, with exponential backoff, up to {@link #MAX_BULK_RETRIES} attempts.
+     *
+     * <p>Items that fail for a non-retryable reason, and items still failing once the retry budget is
+     * exhausted, are counted in {@link #getDroppedDocuments()} so callers can avoid committing
+     * progress over an incomplete load.
+     *
+     * <p>The concurrency permit is held for the whole retry chain, so {@link
+     * #waitForPendingUpdates()} also waits for outstanding retries.
      *
      * @param bulkRequest The BulkRequest containing multiple index/delete operations.
      */
     public void executeBulk(BulkRequest bulkRequest) {
         try {
             this.semaphore.acquire();
-            this.client.bulk(
-                    bulkRequest,
-                    new ActionListener<>() {
-                        @Override
-                        public void onResponse(BulkResponse bulkResponse) {
-                            ContentIndex.this.semaphore.release();
-                            if (bulkResponse.hasFailures()) {
-                                log.warn(
-                                        Constants.W_LOG_BULK_INDEXING_FAILURES, bulkResponse.buildFailureMessage());
-                            }
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            ContentIndex.this.semaphore.release();
-                            log.error(Constants.E_LOG_BULK_INDEX_OPERATION_FAILED, e.getMessage());
-                        }
-                    });
         } catch (InterruptedException e) {
             log.error(Constants.E_LOG_SEMAPHORE_INTERRUPTED, e.getMessage());
             Thread.currentThread().interrupt();
+            return;
+        }
+        this.submitBulk(bulkRequest, 0, BULK_INITIAL_BACKOFF_MS);
+    }
+
+    /**
+     * Submits one attempt of a bulk request. Releases the concurrency permit acquired by {@link
+     * #executeBulk(BulkRequest)} once the request settles for good; a scheduled retry keeps holding
+     * it.
+     *
+     * @param bulkRequest The operations to submit on this attempt.
+     * @param attempt The zero-based attempt number.
+     * @param backoffMs The delay to apply before the next attempt, if one is needed.
+     */
+    private void submitBulk(BulkRequest bulkRequest, int attempt, long backoffMs) {
+        this.client.bulk(
+                bulkRequest,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(BulkResponse bulkResponse) {
+                        if (!bulkResponse.hasFailures()) {
+                            ContentIndex.this.semaphore.release();
+                            return;
+                        }
+
+                        BulkRequest retryRequest = new BulkRequest();
+                        int permanent = 0;
+                        String lastPermanentFailure = null;
+                        String lastRetryableFailure = null;
+
+                        for (BulkItemResponse item : bulkResponse.getItems()) {
+                            if (!item.isFailed()) {
+                                continue;
+                            }
+                            BulkItemResponse.Failure failure = item.getFailure();
+                            if (isRetryable(failure)) {
+                                retryRequest.add(bulkRequest.requests().get(item.getItemId()));
+                                lastRetryableFailure = item.getFailureMessage();
+                            } else {
+                                permanent++;
+                                lastPermanentFailure = item.getFailureMessage();
+                            }
+                        }
+
+                        if (permanent > 0) {
+                            ContentIndex.this.droppedDocuments.addAndGet(permanent);
+                            log.error(Constants.E_LOG_BULK_ITEMS_NOT_RETRYABLE, permanent, lastPermanentFailure);
+                        }
+
+                        if (retryRequest.numberOfActions() == 0) {
+                            ContentIndex.this.semaphore.release();
+                            return;
+                        }
+                        ContentIndex.this.retryOrDrop(retryRequest, attempt, backoffMs, lastRetryableFailure);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        if (isRetryable(e)) {
+                            ContentIndex.this.retryOrDrop(bulkRequest, attempt, backoffMs, e.getMessage());
+                            return;
+                        }
+                        ContentIndex.this.droppedDocuments.addAndGet(bulkRequest.numberOfActions());
+                        log.error(Constants.E_LOG_BULK_INDEX_OPERATION_FAILED, e.getMessage());
+                        ContentIndex.this.semaphore.release();
+                    }
+                });
+    }
+
+    /**
+     * Schedules another attempt for the shed operations, or gives up and counts them as dropped once
+     * the retry budget is exhausted. Releases the concurrency permit on every terminal path.
+     *
+     * @param retryRequest The operations still pending.
+     * @param attempt The zero-based attempt number that just failed.
+     * @param backoffMs The delay to apply before this retry.
+     * @param failureMessage The failure reported by the last attempt, for logging.
+     */
+    private void retryOrDrop(
+            BulkRequest retryRequest, int attempt, long backoffMs, String failureMessage) {
+        int pending = retryRequest.numberOfActions();
+
+        if (attempt >= MAX_BULK_RETRIES) {
+            this.droppedDocuments.addAndGet(pending);
+            log.error(Constants.E_LOG_BULK_RETRIES_EXHAUSTED, pending, MAX_BULK_RETRIES, failureMessage);
+            this.semaphore.release();
+            return;
+        }
+
+        log.warn(
+                Constants.W_LOG_BULK_RETRY_SCHEDULED, pending, attempt + 1, MAX_BULK_RETRIES, backoffMs);
+
+        long nextBackoffMs = Math.min(backoffMs * 2, BULK_MAX_BACKOFF_MS);
+        try {
+            this.client
+                    .threadPool()
+                    .schedule(
+                            () -> this.submitBulk(retryRequest, attempt + 1, nextBackoffMs),
+                            TimeValue.timeValueMillis(backoffMs),
+                            ThreadPool.Names.GENERIC);
+        } catch (Exception e) {
+            // The node is shutting down, or the scheduler refused the task: the permit must not leak.
+            this.droppedDocuments.addAndGet(pending);
+            log.error(Constants.E_LOG_BULK_RETRY_SCHEDULE_FAILED, pending, e.getMessage());
+            this.semaphore.release();
         }
     }
 
-    private static boolean isCircuitBreakerException(Exception e) {
-        Throwable cause = e;
+    /**
+     * Returns the number of documents this instance failed to index and gave up on since the last
+     * {@link #resetDroppedDocuments()}.
+     *
+     * @return The dropped document count.
+     */
+    public long getDroppedDocuments() {
+        return this.droppedDocuments.get();
+    }
+
+    /** Resets the dropped document counter. Call before starting a full snapshot load. */
+    public void resetDroppedDocuments() {
+        this.droppedDocuments.set(0);
+    }
+
+    /** Returns true if any cause in the chain is an instance of the given type. */
+    private static boolean hasCause(Throwable throwable, Class<? extends Throwable> type) {
+        Throwable cause = throwable;
         while (cause != null) {
-            if (cause instanceof CircuitBreakingException) {
+            if (type.isInstance(cause)) {
                 return true;
             }
             cause = cause.getCause();
         }
         return false;
+    }
+
+    private static boolean isCircuitBreakerException(Exception e) {
+        return hasCause(e, CircuitBreakingException.class);
+    }
+
+    /**
+     * Whether a failure is the cluster shedding load rather than rejecting the document itself.
+     * Circuit breaker trips and thread pool / indexing pressure rejections are transient and clear on
+     * their own, so the operation is worth re-submitting.
+     */
+    private static boolean isRetryable(Exception e) {
+        return hasCause(e, CircuitBreakingException.class)
+                || hasCause(e, OpenSearchRejectedExecutionException.class);
+    }
+
+    /** Per-item variant of {@link #isRetryable(Exception)}, which also honours the REST status. */
+    private static boolean isRetryable(BulkItemResponse.Failure failure) {
+        RestStatus status = failure.getStatus();
+        if (status == RestStatus.TOO_MANY_REQUESTS || status == RestStatus.SERVICE_UNAVAILABLE) {
+            return true;
+        }
+        return isRetryable(failure.getCause());
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -175,6 +175,8 @@ public class SnapshotServiceImpl implements SnapshotService {
         boolean success = false;
 
         try {
+            this.resetDroppedDocuments();
+
             // 1. Download Snapshot
             snapshotZip = this.snapshotClient.downloadFile(snapshotUrl);
             if (snapshotZip == null) {
@@ -215,7 +217,15 @@ public class SnapshotServiceImpl implements SnapshotService {
             } else {
                 this.cleanup(snapshotZip);
             }
-            // 3. Partial update of consumer state: bump local_offset to the snapshot offset and
+            // 3. Refuse to commit progress over a partial load: leaving local_offset where it is
+            // makes the next sync re-run the snapshot instead of silently skipping the gap.
+            long dropped = this.getDroppedDocuments();
+            if (dropped > 0) {
+                log.error(Constants.E_LOG_SNAPSHOT_INDEXING_INCOMPLETE, this.consumerType, dropped);
+                return false;
+            }
+
+            // 4. Partial update of consumer state: bump local_offset to the snapshot offset and
             // keep the remote_offset (set at t0 from RemoteConsumer.last_offset) so the
             // incremental update path can close the gap. Identity fields and status are preserved
             // from the t0 write.
@@ -380,6 +390,22 @@ public class SnapshotServiceImpl implements SnapshotService {
         return this.maxOffsetSeen;
     }
 
+    /** Clears the dropped-document counters before a load, so the tally covers this run only. */
+    private void resetDroppedDocuments() {
+        this.indicesMap.values().forEach(ContentIndex::resetDroppedDocuments);
+    }
+
+    /**
+     * Total documents the content indices gave up on during this load. A non-zero value means the
+     * snapshot is only partially indexed, so the consumer offset must not be advanced over the gap:
+     * incremental syncs resume from the offset and would never backfill the missing documents.
+     *
+     * @return the number of dropped documents across all content indices.
+     */
+    private long getDroppedDocuments() {
+        return this.indicesMap.values().stream().mapToLong(ContentIndex::getDroppedDocuments).sum();
+    }
+
     /**
      * Initializes content from a pre-packaged local snapshot zip file using consumer metadata from
      * the external {@code manifest.json} located in the snapshots' directory.
@@ -403,6 +429,8 @@ public class SnapshotServiceImpl implements SnapshotService {
         long startMs = System.currentTimeMillis();
 
         try {
+            this.resetDroppedDocuments();
+
             // 1. Clear indices
             this.indicesMap.values().forEach(ContentIndex::clear);
 
@@ -440,7 +468,15 @@ public class SnapshotServiceImpl implements SnapshotService {
                 localZip.getFileName(),
                 System.currentTimeMillis() - startMs);
 
-        // 4. Partial update of consumer state: bump local_offset to the highest offset observed
+        // 4. Refuse to commit progress over a partial load: leaving local_offset where it is
+        // makes the next sync re-run the snapshot instead of silently skipping the gap.
+        long dropped = this.getDroppedDocuments();
+        if (dropped > 0) {
+            log.error(Constants.E_LOG_SNAPSHOT_INDEXING_INCOMPLETE, this.consumerType, dropped);
+            return false;
+        }
+
+        // 5. Partial update of consumer state: bump local_offset to the highest offset observed
         // while indexing. Identity fields, is_public, status and remote_offset are owned by the
         // t0 write performed by AbstractConsumerService.writeInitialConsumer.
         return this.updateLocalOffset(this.maxOffsetSeen);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -209,7 +209,21 @@ public class SnapshotServiceImpl implements SnapshotService {
                         snapshotZip.getFileName(),
                         System.currentTimeMillis() - startMs);
             }
-            // Promote to stable or clean up temp
+
+            // 3. Refuse to commit a partial load, before touching stable or the offset. A dropped
+            // document means the snapshot did not index in full, so it must neither advance
+            // local_offset (the next sync would skip the gap) nor be promoted to stable: "stable"
+            // means a snapshot indexed in full at least once, and promoting a partial load would
+            // overwrite a good safety net with one the rollback path has just proven unloadable.
+            // Discarding the temp keeps any previously-good stable in place.
+            long dropped = this.getDroppedDocuments();
+            if (dropped > 0) {
+                log.error(Constants.E_LOG_SNAPSHOT_INDEXING_INCOMPLETE, this.consumerType, dropped);
+                this.cleanup(snapshotZip);
+                return false;
+            }
+
+            // 4. Promote to stable or clean up temp
             if (this.stablePath != null) {
                 if (!promoteToStable(snapshotZip, this.stablePath)) {
                     this.cleanup(snapshotZip);
@@ -217,15 +231,8 @@ public class SnapshotServiceImpl implements SnapshotService {
             } else {
                 this.cleanup(snapshotZip);
             }
-            // 3. Refuse to commit progress over a partial load: leaving local_offset where it is
-            // makes the next sync re-run the snapshot instead of silently skipping the gap.
-            long dropped = this.getDroppedDocuments();
-            if (dropped > 0) {
-                log.error(Constants.E_LOG_SNAPSHOT_INDEXING_INCOMPLETE, this.consumerType, dropped);
-                return false;
-            }
 
-            // 4. Partial update of consumer state: bump local_offset to the snapshot offset and
+            // 5. Partial update of consumer state: bump local_offset to the snapshot offset and
             // keep the remote_offset (set at t0 from RemoteConsumer.last_offset) so the
             // incremental update path can close the gap. Identity fields and status are preserved
             // from the t0 write.
@@ -456,24 +463,28 @@ public class SnapshotServiceImpl implements SnapshotService {
             return false;
         }
 
-        // 3. Promote to stable, delete source, or leave in place (rollback re-index)
-        if (this.stablePath != null && !localZip.equals(this.stablePath)) {
-            promoteToStable(localZip, this.stablePath);
-        } else if (this.stablePath == null) {
-            SnapshotServiceImpl.deleteSnapshot(localZip);
-        }
-
         log.debug(
                 Constants.D_LOG_SNAPSHOT_LOCAL_ELAPSED,
                 localZip.getFileName(),
                 System.currentTimeMillis() - startMs);
 
-        // 4. Refuse to commit progress over a partial load: leaving local_offset where it is
-        // makes the next sync re-run the snapshot instead of silently skipping the gap.
+        // 3. Refuse to commit a partial load, before touching stable or the offset. A dropped
+        // document means the snapshot did not index in full, so it must neither advance
+        // local_offset (the next sync would skip the gap) nor be promoted to stable. Returning
+        // here also leaves the source in place: a rollback reload (localZip == stablePath) keeps
+        // the stable untouched, and a packaged snapshot stays available for the next retry
+        // instead of overwriting a good stable with a load proven unable to index in full.
         long dropped = this.getDroppedDocuments();
         if (dropped > 0) {
             log.error(Constants.E_LOG_SNAPSHOT_INDEXING_INCOMPLETE, this.consumerType, dropped);
             return false;
+        }
+
+        // 4. Promote to stable, delete source, or leave in place (rollback re-index)
+        if (this.stablePath != null && !localZip.equals(this.stablePath)) {
+            promoteToStable(localZip, this.stablePath);
+        } else if (this.stablePath == null) {
+            SnapshotServiceImpl.deleteSnapshot(localZip);
         }
 
         // 5. Partial update of consumer state: bump local_offset to the highest offset observed

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -333,6 +333,8 @@ public class Constants {
             "Skipped {} snapshot entries (missing payload: {}, unknown type: {}, unmapped type: {}, parse errors: {}).";
     public static final String E_LOG_SNAPSHOT_READ_FILE_FAILED =
             "Error reading snapshot file [{}]: {}";
+    public static final String E_LOG_SNAPSHOT_INDEXING_INCOMPLETE =
+            "Snapshot indexing for consumer [{}] dropped {} document(s); local_offset was not advanced so the next sync retries the snapshot.";
     public static final String D_LOG_SNAPSHOT_LOCAL_INIT_START =
             "Starting local snapshot initialization for [{}] from [{}]";
     public static final String E_LOG_SNAPSHOT_LOCAL_PROCESS_FAILED =
@@ -454,9 +456,15 @@ public class Constants {
     public static final String D_LOG_NO_DOCUMENT_FOUND_QUERY =
             "No document found in [{}] with query {}";
     public static final String E_LOG_SEARCH_BY_QUERY_FAILED = "Search by query failed in [{}]: {}";
-    public static final String W_LOG_BULK_INDEXING_FAILURES =
-            "Bulk indexing finished with failures: {}";
     public static final String E_LOG_BULK_INDEX_OPERATION_FAILED = "Bulk index operation failed: {}";
+    public static final String W_LOG_BULK_RETRY_SCHEDULED =
+            "Bulk indexing shed {} document(s) under load; retry {}/{} in {}ms.";
+    public static final String E_LOG_BULK_RETRIES_EXHAUSTED =
+            "Bulk indexing dropped {} document(s) after {} retries. Last failure: {}";
+    public static final String E_LOG_BULK_ITEMS_NOT_RETRYABLE =
+            "Bulk indexing dropped {} document(s) with non-retryable failures. Last failure: {}";
+    public static final String E_LOG_BULK_RETRY_SCHEDULE_FAILED =
+            "Bulk indexing dropped {} document(s): retry could not be scheduled: {}";
     public static final String E_LOG_SEMAPHORE_INTERRUPTED =
             "Interrupted while waiting for semaphore: {}";
     public static final String E_LOG_CLEAR_INDEX_NO_MAPPINGS =

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexBulkRetryTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexBulkRetryTests.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2024-2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.cti.catalog.index;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.wazuh.contentmanager.settings.PluginSettings;
+
+/**
+ * Reproduces, against a real OpenSearch cluster, the bulk indexing failure reported during the
+ * 5.0.0 Central Components DTT run and validates that the retry added to {@link ContentIndex}
+ * recovers the documents the cluster sheds.
+ *
+ * <p>The DTT failure was a parent circuit breaker trip on the node holding the single primary shard
+ * of {@code .wazuh-threatintel-vulnerabilities-a}. The trigger there was real heap pressure, which
+ * is not reproducible on demand; the breaker is instead driven deterministically here by accounting
+ * reserved bytes ({@code indices.breaker.total.use_real_memory: false}) and lowering {@code
+ * indices.breaker.total.limit} so that any bulk trips it. The resulting failure delivered to the
+ * client is the same {@code CircuitBreakingException}, exercising the same code path.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(
+        scope = OpenSearchIntegTestCase.Scope.TEST,
+        numDataNodes = 2,
+        supportsDedicatedMasters = false)
+public class ContentIndexBulkRetryTests extends OpenSearchIntegTestCase {
+
+    private static final Logger log = LogManager.getLogger(ContentIndexBulkRetryTests.class);
+
+    private static final String INDEX = "wazuh-threatintel-vulnerabilities-a";
+    private static final String PARENT_BREAKER_LIMIT = "indices.breaker.total.limit";
+
+    /** Documents per bulk, mirroring a slice of the CVE catalog the DTT run was loading. */
+    private static final int DOCUMENT_COUNT = 50;
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+                .put(super.nodeSettings(nodeOrdinal))
+                // Account reserved bytes instead of real heap, so the trip point is deterministic.
+                .put("indices.breaker.total.use_real_memory", false)
+                .build();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        PluginSettings.getInstance(Settings.builder().build());
+        // Several shards over two nodes guarantees at least one shard-level bulk leaves the
+        // coordinating node, the hop that reserves in_flight_requests against the parent breaker.
+        createIndex(
+                INDEX,
+                Settings.builder()
+                        .put("index.number_of_shards", 4)
+                        .put("index.number_of_replicas", 0)
+                        .build());
+        ensureGreen(INDEX);
+    }
+
+    /** Lowers or restores the parent circuit breaker limit on the live cluster. */
+    private void setParentBreakerLimit(String limit) {
+        boolean acked =
+                client()
+                        .admin()
+                        .cluster()
+                        .prepareUpdateSettings()
+                        .setPersistentSettings(Settings.builder().put(PARENT_BREAKER_LIMIT, limit))
+                        .get()
+                        .isAcknowledged();
+        assertTrue("breaker limit update was not acknowledged", acked);
+        log.info("[VALIDATION] parent circuit breaker limit set to [{}]", limit);
+    }
+
+    private static BulkRequest cveBulk(int count) {
+        BulkRequest request = new BulkRequest();
+        for (int i = 0; i < count; i++) {
+            request.add(
+                    new IndexRequest(INDEX)
+                            .id("CVE-2024-" + (10000 + i))
+                            .source(
+                                    "{\"name\":\"CVE-2024-"
+                                            + (10000 + i)
+                                            + "\",\"description\":\""
+                                            + "x".repeat(2048)
+                                            + "\"}",
+                                    XContentType.JSON));
+        }
+        return request;
+    }
+
+    private long indexedDocuments() {
+        client().admin().indices().prepareRefresh(INDEX).get();
+        return client().prepareSearch(INDEX).setSize(0).get().getHits().getTotalHits().value();
+    }
+
+    /**
+     * Confirms the cluster really does shed the bulk, and captures the failure exactly as the content
+     * manager receives it. This is the condition the DTT run hit.
+     */
+    public void testCircuitBreakerShedsBulkWrites() throws Exception {
+        this.setParentBreakerLimit("1kb");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> failure = new AtomicReference<>();
+        client()
+                .bulk(
+                        cveBulk(DOCUMENT_COUNT),
+                        ActionListener.wrap(
+                                response -> {
+                                    if (response.hasFailures()) {
+                                        failure.set(response.buildFailureMessage());
+                                    }
+                                    latch.countDown();
+                                },
+                                e -> {
+                                    failure.set(e.toString());
+                                    latch.countDown();
+                                }));
+        assertTrue("bulk did not complete", latch.await(30, TimeUnit.SECONDS));
+        this.setParentBreakerLimit("70%");
+
+        assertNotNull("expected the cluster to shed the bulk", failure.get());
+        log.info(
+                "[VALIDATION] observed shed failure (first line): {}",
+                failure.get().lines().findFirst().orElse(""));
+        log.info(
+                "[VALIDATION] observed shed failure (first item): {}",
+                failure.get().lines().skip(1).findFirst().orElse(""));
+        assertTrue(
+                "expected a CircuitBreakingException, got: " + failure.get(),
+                failure.get().contains("circuit_breaking_exception")
+                        || failure.get().contains("CircuitBreakingException"));
+
+        long indexed = this.indexedDocuments();
+        log.info(
+                "[VALIDATION] {} documents submitted, {} indexed, {} shed",
+                DOCUMENT_COUNT,
+                indexed,
+                DOCUMENT_COUNT - indexed);
+        assertTrue("expected part of the bulk to be shed", indexed < DOCUMENT_COUNT);
+    }
+
+    /**
+     * Baseline: the pre-fix fire-and-forget behaviour. The body below is the original {@code
+     * executeBulk} listener -- it logs the failure and moves on -- and shows the documents are lost
+     * for good.
+     */
+    public void testFireAndForgetLosesShedDocuments() throws Exception {
+        this.setParentBreakerLimit("1kb");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        client()
+                .bulk(
+                        cveBulk(DOCUMENT_COUNT),
+                        new ActionListener<>() {
+                            @Override
+                            public void onResponse(BulkResponse bulkResponse) {
+                                if (bulkResponse.hasFailures()) {
+                                    // This is what the plugin used to do: log and drop.
+                                    log.warn(
+                                            "[VALIDATION][pre-fix] Bulk indexing finished with failures: {}",
+                                            bulkResponse.buildFailureMessage().lines().findFirst().orElse(""));
+                                }
+                                latch.countDown();
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                log.error("[VALIDATION][pre-fix] Bulk index operation failed: {}", e.getMessage());
+                                latch.countDown();
+                            }
+                        });
+        assertTrue("bulk did not complete", latch.await(30, TimeUnit.SECONDS));
+
+        // Pressure clears, exactly as it did on node-9 once G1GC ran.
+        this.setParentBreakerLimit("70%");
+        Thread.sleep(2000);
+
+        long indexed = this.indexedDocuments();
+        log.info(
+                "[VALIDATION][pre-fix] {} documents submitted, {} indexed -- {} lost for good",
+                DOCUMENT_COUNT,
+                indexed,
+                DOCUMENT_COUNT - indexed);
+        assertTrue(
+                "pre-fix behaviour: shed documents are never re-submitted, so some must be missing",
+                indexed < DOCUMENT_COUNT);
+    }
+
+    /**
+     * The fix: {@link ContentIndex#executeBulk} re-submits what the cluster shed, so once the
+     * pressure clears every document lands and nothing is reported as dropped.
+     */
+    public void testExecuteBulkRecoversShedDocuments() throws Exception {
+        ContentIndex contentIndex = new ContentIndex(client(), INDEX);
+
+        this.setParentBreakerLimit("1kb");
+        contentIndex.executeBulk(cveBulk(DOCUMENT_COUNT));
+
+        // Let the first attempt be shed, then clear the pressure while the retry is pending.
+        Thread.sleep(500);
+        this.setParentBreakerLimit("70%");
+
+        contentIndex.waitForPendingUpdates();
+
+        long indexed = this.indexedDocuments();
+        log.info(
+                "[VALIDATION][post-fix] {} documents submitted, {} indexed, {} dropped",
+                DOCUMENT_COUNT,
+                indexed,
+                contentIndex.getDroppedDocuments());
+
+        assertEquals("every shed document must be recovered by the retry", DOCUMENT_COUNT, indexed);
+        assertEquals("nothing should be reported as dropped", 0L, contentIndex.getDroppedDocuments());
+    }
+
+    /**
+     * When the pressure never clears, the documents are still lost -- but they are now counted, which
+     * is what lets the snapshot loader refuse to advance the consumer offset over the gap.
+     */
+    public void testExecuteBulkCountsDocumentsDroppedWhenPressureNeverClears() throws Exception {
+        ContentIndex contentIndex = new ContentIndex(client(), INDEX);
+
+        this.setParentBreakerLimit("1kb");
+        contentIndex.executeBulk(cveBulk(DOCUMENT_COUNT));
+        contentIndex.waitForPendingUpdates();
+
+        long dropped = contentIndex.getDroppedDocuments();
+        this.setParentBreakerLimit("70%");
+
+        log.info(
+                "[VALIDATION][post-fix] pressure sustained: {} documents submitted, {} indexed, {} dropped",
+                DOCUMENT_COUNT,
+                this.indexedDocuments(),
+                dropped);
+
+        long indexed = this.indexedDocuments();
+        assertTrue("expected the cluster to shed part of the bulk", dropped > 0);
+        assertEquals(
+                "every document that did not land must be counted as dropped",
+                DOCUMENT_COUNT - indexed,
+                dropped);
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/index/ContentIndexTests.java
@@ -19,6 +19,8 @@ package com.wazuh.contentmanager.cti.catalog.index;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
@@ -31,9 +33,12 @@ import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.breaker.CircuitBreakingException;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.Client;
 import org.junit.After;
@@ -43,6 +48,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.wazuh.contentmanager.cti.catalog.model.Operation;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -53,6 +59,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -639,5 +647,148 @@ public class ContentIndexTests extends OpenSearchTestCase {
 
         verify(this.client, times(2)).get(any(GetRequest.class));
         verify(this.client).index(any(IndexRequest.class));
+    }
+
+    // ---------------------------------------------------------------------
+    // executeBulk: load shedding must be retried, never silently dropped.
+    // ---------------------------------------------------------------------
+
+    /** Makes the scheduler run the retry inline, so backoff does not slow the tests down. */
+    private void runScheduledTasksInline() {
+        when(this.client.threadPool().schedule(any(Runnable.class), any(TimeValue.class), anyString()))
+                .thenAnswer(
+                        invocation -> {
+                            invocation.getArgument(0, Runnable.class).run();
+                            return null;
+                        });
+    }
+
+    private static BulkResponse bulkResponseWith(BulkItemResponse... items) {
+        return new BulkResponse(items, 1L);
+    }
+
+    private static BulkItemResponse successItem(int id) {
+        return new BulkItemResponse(id, DocWriteRequest.OpType.INDEX, mock(IndexResponse.class));
+    }
+
+    private static BulkItemResponse shedItem(int id, String docId) {
+        return new BulkItemResponse(
+                id,
+                DocWriteRequest.OpType.INDEX,
+                new BulkItemResponse.Failure(
+                        INDEX_NAME,
+                        docId,
+                        new CircuitBreakingException(
+                                "Data too large", 100, 50, CircuitBreaker.Durability.TRANSIENT)));
+    }
+
+    private static BulkItemResponse rejectedItem(int id, String docId) {
+        return new BulkItemResponse(
+                id,
+                DocWriteRequest.OpType.INDEX,
+                new BulkItemResponse.Failure(
+                        INDEX_NAME,
+                        docId,
+                        new IllegalArgumentException("mapper error"),
+                        RestStatus.BAD_REQUEST));
+    }
+
+    private static BulkRequest bulkOf(String... ids) {
+        BulkRequest request = new BulkRequest();
+        for (String id : ids) {
+            request.add(new IndexRequest(INDEX_NAME).id(id).source("{}", XContentType.JSON));
+        }
+        return request;
+    }
+
+    /** Answers client.bulk() with the given responses in order, capturing each request. */
+    private List<BulkRequest> stubBulkResponses(BulkResponse... responses) {
+        List<BulkRequest> captured = new ArrayList<>();
+        AtomicInteger call = new AtomicInteger();
+        doAnswer(
+                        invocation -> {
+                            captured.add(invocation.getArgument(0, BulkRequest.class));
+                            int index = Math.min(call.getAndIncrement(), responses.length - 1);
+                            invocation.getArgument(1, ActionListener.class).onResponse(responses[index]);
+                            return null;
+                        })
+                .when(this.client)
+                .bulk(any(BulkRequest.class), any(ActionListener.class));
+        return captured;
+    }
+
+    /**
+     * A circuit breaker trip is the cluster shedding load, not a bad document: only the shed item is
+     * re-submitted, and nothing is reported as dropped once the retry lands.
+     */
+    @SuppressWarnings("unchecked")
+    public void testExecuteBulk_RetriesShedItemsAndKeepsThem() throws Exception {
+        this.runScheduledTasksInline();
+        List<BulkRequest> sent =
+                this.stubBulkResponses(
+                        bulkResponseWith(successItem(0), shedItem(1, "CVE-2024-7295")),
+                        bulkResponseWith(successItem(0)));
+
+        this.contentIndex.executeBulk(bulkOf("CVE-2024-0001", "CVE-2024-7295"));
+
+        Assert.assertEquals(2, sent.size());
+        // Only the shed document is retried, not the whole batch.
+        Assert.assertEquals(1, sent.get(1).numberOfActions());
+        Assert.assertEquals("CVE-2024-7295", sent.get(1).requests().get(0).id());
+        Assert.assertEquals(0L, this.contentIndex.getDroppedDocuments());
+    }
+
+    /** Once the retry budget is spent the documents are counted, so callers can refuse to commit. */
+    @SuppressWarnings("unchecked")
+    public void testExecuteBulk_CountsDroppedDocumentsWhenRetriesExhausted() throws Exception {
+        this.runScheduledTasksInline();
+        List<BulkRequest> sent = this.stubBulkResponses(bulkResponseWith(shedItem(0, "CVE-2024-7295")));
+
+        this.contentIndex.executeBulk(bulkOf("CVE-2024-7295"));
+
+        // Initial attempt plus MAX_BULK_RETRIES.
+        Assert.assertEquals(4, sent.size());
+        Assert.assertEquals(1L, this.contentIndex.getDroppedDocuments());
+    }
+
+    /** A rejected document is not load shedding: retrying cannot help, so it is dropped at once. */
+    @SuppressWarnings("unchecked")
+    public void testExecuteBulk_DoesNotRetryNonRetryableFailures() throws Exception {
+        this.runScheduledTasksInline();
+        List<BulkRequest> sent =
+                this.stubBulkResponses(bulkResponseWith(rejectedItem(0, "CVE-2024-7295")));
+
+        this.contentIndex.executeBulk(bulkOf("CVE-2024-7295"));
+
+        Assert.assertEquals(1, sent.size());
+        Assert.assertEquals(1L, this.contentIndex.getDroppedDocuments());
+    }
+
+    /**
+     * The concurrency permit must be released on every terminal path, otherwise {@code
+     * waitForPendingUpdates} deadlocks and the snapshot load never finishes.
+     */
+    @SuppressWarnings("unchecked")
+    public void testExecuteBulk_ReleasesPermitAfterRetriesExhausted() throws Exception {
+        this.runScheduledTasksInline();
+        this.stubBulkResponses(bulkResponseWith(shedItem(0, "CVE-2024-7295")));
+
+        this.contentIndex.executeBulk(bulkOf("CVE-2024-7295"));
+        this.contentIndex.waitForPendingUpdates();
+
+        Assert.assertEquals(1L, this.contentIndex.getDroppedDocuments());
+    }
+
+    /** The counter is per-load, so a fresh snapshot run starts from a clean tally. */
+    @SuppressWarnings("unchecked")
+    public void testResetDroppedDocuments() throws Exception {
+        this.runScheduledTasksInline();
+        this.stubBulkResponses(bulkResponseWith(rejectedItem(0, "CVE-2024-7295")));
+
+        this.contentIndex.executeBulk(bulkOf("CVE-2024-7295"));
+        Assert.assertEquals(1L, this.contentIndex.getDroppedDocuments());
+
+        this.contentIndex.resetDroppedDocuments();
+        Assert.assertEquals(0L, this.contentIndex.getDroppedDocuments());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
@@ -353,8 +353,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
 
     /**
      * The rule-fetch query must filter to {@code document.enabled: true} -- a disabled rule must
-     * never be evaluated in Log Test, matching the same gate {@code fetchEnabledRuleIds} applies
-     * when building a Security Analytics detector.
+     * never be evaluated in Log Test, matching the same gate {@code fetchEnabledRuleIds} applies when
+     * building a Security Analytics detector.
      */
     @SuppressWarnings("unchecked")
     public void testFetchRuleBodiesFiltersDisabledRules() throws Exception {

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -243,6 +243,49 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
     }
 
     /**
+     * When the content indices report dropped documents, the snapshot is only partially indexed. The
+     * consumer offset must stay where it is: incremental syncs resume from it, so advancing it over
+     * the gap would strand the missing documents permanently.
+     */
+    public void testInitialize_DoesNotAdvanceOffsetWhenDocumentsWereDropped() throws Exception {
+        // Mock
+        String url = "http://example.com/snapshot.zip";
+        long offset = 100L;
+        when(this.remoteConsumer.getSnapshotLink()).thenReturn(url);
+        when(this.remoteConsumer.getOffset()).thenReturn(offset);
+        when(this.remoteConsumer.getSnapshotOffset()).thenReturn(offset);
+
+        // A t0 consumer doc must exist, otherwise updateLocalOffset would bail out on its own and
+        // the test would pass without exercising the drop gate at all.
+        String existingConsumerJson =
+                "{\"name\":\"test-consumer\",\"context\":\"test-context\","
+                        + "\"type\":\"cti:catalog:consumer:ruleset\","
+                        + "\"resource\":\"https://cti.example/catalog/contexts/test-context/consumers/test-consumer\","
+                        + "\"is_public\":true,\"status\":\"running\",\"local_offset\":0,\"remote_offset\":100}";
+        org.opensearch.action.get.GetResponse t0Response =
+                mock(org.opensearch.action.get.GetResponse.class);
+        when(t0Response.isExists()).thenReturn(true);
+        when(t0Response.getSourceAsString()).thenReturn(existingConsumerJson);
+        when(this.consumersIndex.getConsumer("cti:catalog:consumer:ruleset")).thenReturn(t0Response);
+
+        // The cluster shed documents that never made it back, exactly as on DTT node-9.
+        when(this.contentIndexMock.getDroppedDocuments()).thenReturn(9332L);
+
+        Path zipPath =
+                this.createZipFileWithContent(
+                        "data.json",
+                        "{\"name\": \"12345678\", \"offset\": 1, \"payload\": {\"type\": \"kvdb\", \"document\": {\"id\": \"12345678\", \"title\": \"Test Kvdb\"}}}");
+        when(this.snapshotClient.downloadFile(url)).thenReturn(zipPath);
+
+        // Act
+        boolean result = this.snapshotService.initialize(this.remoteConsumer);
+
+        // Assert
+        Assert.assertFalse("a partial load must not report success", result);
+        verify(this.consumersIndex, never()).setConsumer(any(LocalConsumer.class));
+    }
+
+    /**
      * Tests that documents with type "policy" are indexed correctly.
      *
      * @throws URISyntaxException

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImplTests.java
@@ -1279,6 +1279,87 @@ public class SnapshotServiceImplTests extends OpenSearchTestCase {
         Assert.assertTrue("Source file should be preserved for retry", Files.exists(localZip));
     }
 
+    /**
+     * A remote load that dropped documents did not index in full, so its downloaded zip must not be
+     * promoted to stable: "stable" means a snapshot indexed in full at least once. Promoting a
+     * partial load would overwrite a previously-good stable with one that fails identically on every
+     * rollback, turning the safety net into a file the system has just proven it cannot load. The
+     * temp must be discarded and any existing stable left byte-for-byte untouched.
+     */
+    public void testRemoteInit_DroppedDocuments_DoesNotPromoteToStable() throws Exception {
+        Path snapshotsDir = this.tempDir.resolve("snapshots");
+        Files.createDirectories(snapshotsDir);
+        SnapshotServiceImpl service = createServiceWithStablePath(snapshotsDir, "ruleset.zip");
+
+        // A previously-good stable that must survive a partial load untouched.
+        Path existingStable = snapshotsDir.resolve("ruleset.stable.zip");
+        Path existingStableSrc =
+                this.createZipFileWithContent(
+                        "data.json",
+                        "{\"name\": \"old\", \"offset\": 1, \"payload\": {\"type\": \"kvdb\", \"document\": {\"id\": \"old\"}}}");
+        Files.copy(existingStableSrc, existingStable);
+        long stableSize = Files.size(existingStable);
+
+        String url = "http://example.com/snapshot.zip";
+        when(this.remoteConsumer.getSnapshotLink()).thenReturn(url);
+        when(this.remoteConsumer.getSnapshotOffset()).thenReturn(100L);
+        mockT0ConsumerDoc();
+
+        // The snapshot streams and indexes, but the cluster shed part of the bulk.
+        when(this.contentIndexMock.getDroppedDocuments()).thenReturn(37L);
+
+        Path zipPath =
+                this.createZipFileWithContent(
+                        "data.json",
+                        "{\"name\": \"1\", \"offset\": 1, \"payload\": {\"type\": \"kvdb\", \"document\": {\"id\": \"1\"}}}");
+        when(this.snapshotClient.downloadFile(url)).thenReturn(zipPath);
+
+        boolean result = service.initialize(this.remoteConsumer);
+
+        Assert.assertFalse("A partial load must not report success", result);
+        Assert.assertFalse(
+                "The downloaded temp must be discarded, not promoted", Files.exists(zipPath));
+        Assert.assertTrue("The previously-good stable must survive", Files.exists(existingStable));
+        Assert.assertEquals(
+                "The stable must be byte-for-byte untouched", stableSize, Files.size(existingStable));
+        verify(this.consumersIndex, never()).setConsumer(any(LocalConsumer.class));
+    }
+
+    /**
+     * A local packaged load that dropped documents must not be promoted to stable either. The
+     * packaged source is left in place so the next sync can retry it, and no stable is manufactured
+     * from an incomplete load.
+     */
+    public void testLocalInit_DroppedDocuments_DoesNotPromoteToStable() throws Exception {
+        Path snapshotsDir = this.tempDir.resolve("snapshots");
+        Files.createDirectories(snapshotsDir);
+        SnapshotServiceImpl service = createServiceWithStablePath(snapshotsDir, "ruleset.zip");
+        mockT0ConsumerDoc();
+
+        // The cluster shed part of the packaged load.
+        when(this.contentIndexMock.getDroppedDocuments()).thenReturn(37L);
+
+        Path localZip = snapshotsDir.resolve("ruleset.zip");
+        try (java.util.zip.ZipOutputStream zos =
+                new java.util.zip.ZipOutputStream(Files.newOutputStream(localZip))) {
+            java.util.zip.ZipEntry entry = new java.util.zip.ZipEntry("data.json");
+            zos.putNextEntry(entry);
+            zos.write(
+                    "{\"name\": \"1\", \"offset\": 50, \"payload\": {\"type\": \"kvdb\", \"document\": {\"id\": \"1\"}}}"
+                            .getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        boolean result = service.initialize(localZip, null);
+
+        Assert.assertFalse("A partial load must not report success", result);
+        Path stableFile = snapshotsDir.resolve("ruleset.stable.zip");
+        Assert.assertFalse(
+                "A partial packaged load must not manufacture a stable", Files.exists(stableFile));
+        Assert.assertTrue("The packaged source must stay for the next retry", Files.exists(localZip));
+        verify(this.consumersIndex, never()).setConsumer(any(LocalConsumer.class));
+    }
+
     public void testDeleteSnapshots_PreservesStableFiles() throws Exception {
         Path snapshotsDir = this.tempDir.resolve("snapshots");
         Files.createDirectories(snapshotsDir);


### PR DESCRIPTION
## Description

It has been detected that the content manager silently discards CTI documents whenever the indexer sheds bulk writes under heap pressure.

The indexer is configured to shed writes rather than exhaust the heap, so a rejected bulk is an expected transient outcome that the client is responsible for re-submitting. `ContentIndex.executeBulk` never did, it logged a warning and moved on, and `SnapshotServiceImpl` then advanced the CTI consumer offset past the gap, so later incremental syncs skipped the missing documents

This PR solves this by retrying only the shed items with exponential backoff on the thread pool, counting anything finally given up on, and refusing to advance the consumer offset when documents were dropped, so the next sync re-runs instead of silently skipping the gap

Closes https://github.com/wazuh/wazuh-indexer/issues/1851

## Proposed Changes

- `ContentIndex.java`: Add retry what the cluster sheds

- `SnapshotServiceImpl.java`: Stop moving on over a gap

- `Constants.java`: Add new constants

### Results and Evidence

Reproduced on a 2-node cluster

I was not able to reproduce the DTT trigger, since it was real heap pressure. So I changed to `use_real_memory: false` and `indices.breaker.total.limit: 1kb`

I got the same error:
``` console
DTT   [0]: index [.wazuh-threatintel-vulnerabilities-a], id [CVE-2024-7295], message [
        RemoteTransportException[[node-9][172.31.43.44:9300][indices:data/write/bulk[s]]];
        nested: CircuitBreakingException[[parent] Data too large, ... in_flight_requests=31491564/30mb]];]

REPRO [1]: index [wazuh-threatintel-vulnerabilities-a],  id [CVE-2024-10001], message [
        RemoteTransportException[[node_t1][127.0.0.1:36021][indices:data/write/bulk[s]]];
        nested: CircuitBreakingException[[parent] Data too large, ... in_flight_requests=44994/43.9kb]];]
```

**After the changes**

Test 1: documents are recovered
``` console
[VALIDATION] parent circuit breaker limit set to [1kb]
[WARN ][c.w.c.c.c.i.ContentIndex ] [node_t1] Bulk indexing shed 33 document(s) under load; retry 1/3 in 1000ms.
[VALIDATION] parent circuit breaker limit set to [70%]
[VALIDATION][post-fix] 50 documents submitted, 50 indexed, 0 dropped
```

33 shed, all 33 recovered by the first retry. **50 / 50 indexed, 0 dropped.**

Test 2: pressure never clears (fails to recover)
``` console
[WARN ][c.w.c.c.c.i.ContentIndex ] [node_t2] Bulk indexing shed 50 document(s) under load; retry 1/3 in 1000ms.
[WARN ][c.w.c.c.c.i.ContentIndex ] [node_t2] Bulk indexing shed 50 document(s) under load; retry 2/3 in 2000ms.
[WARN ][c.w.c.c.c.i.ContentIndex ] [node_t2] Bulk indexing shed 50 document(s) under load; retry 3/3 in 4000ms.
[ERROR][c.w.c.c.c.i.ContentIndex ] [node_t2] Bulk indexing dropped 50 document(s) after 3 retries.
  Last failure: RemoteTransportException[[node_t1][127.0.0.1:34305][indices:data/write/bulk[s]]];
  nested: CircuitBreakingException[[parent] Data too large, data for [indices:data/write/bulk[s]]
  would be [71826/70.1kb], which is larger than the limit of [1024/1kb],
  usages [request=0/0b, fielddata=0/0b, in_flight_requests=71826/70.1kb]];
[VALIDATION][post-fix] pressure sustained: 50 documents submitted, 0 indexed, 50 dropped
```

Reproduce with:

```bash
./gradlew :wazuh-indexer-content-manager:test --tests "*ContentIndexBulkRetryTests*" -Dtests.logger.level=INFO
```

### Artifacts Affected

- Content Manager

### Configuration Changes

NA

### Documentation Updates

NA

### Tests Introduced

-`ContentIndexBulkRetryTests`: live 2-node `OpenSearchIntegTestCase` cluster, real circuit breaker, real bulk indexing:

| Test | Scope |
|---|---|
| `testCircuitBreakerShedsBulkWrites` | The cluster really sheds; captures the failure as the content manager receives it |
| `testFireAndForgetLosesShedDocuments` | Pre-fix baseline — the original listener, replicated verbatim, loses documents |
| `testExecuteBulkRecoversShedDocuments` | The fix recovers every shed document once pressure clears |
| `testExecuteBulkCountsDocumentsDroppedWhenPressureNeverClears` | Retry budget exhausts; every unlanded document is counted |

- `ContentIndexTests`: Add new tests that shed items retried

-`SnapshotServiceImplTests`: New test `testInitialize_DoesNotAdvanceOffsetWhenDocumentsWereDropped` drives `initialize` with a content index reporting `9332` dropped documents and asserts the consumer offset is never written.

#### Two things reviewers should know

> [!NOTE]
> On a single node I was not able to reproduce the error



## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
