### PR TITLE
Add `needrestart` override documentation for Debian-based systems

### DIFF
--- a/docs/ref/configuration/index.md
+++ b/docs/ref/configuration/index.md
@@ -140,6 +140,34 @@ Verify the limit applied to the running node by checking `max_file_descriptors`:
 curl -k -u <INDEXER_USERNAME>:<INDEXER_PASSWORD> "https://<INDEXER_IP_ADDRESS>:9200/_nodes/stats/process?filter_path=**.max_file_descriptors&pretty"
 ```
 
+## Avoiding unnecessary service restarts (needrestart)
+
+On Debian and Ubuntu systems with `needrestart` installed, Wazuh Indexer may get restarted automatically every time `apt` installs or upgrades **any** package, even one unrelated to Wazuh Indexer. On Ubuntu 24.04 and 26.04 this happens silently, without asking for confirmation.
+
+This happens because some bundled Java native libraries (used for compression and networking) extract a shared object file into `/var/lib/wazuh-indexer/tmp/` and delete it right after loading it, keeping it mapped in memory but no longer present on disk. `needrestart` interprets processes with deleted mapped libraries as running outdated code and restarts them.
+
+To stop `needrestart` from restarting Wazuh Indexer on unrelated `apt` operations, add one of the following to `/etc/needrestart/conf.d/`:
+
+**Ignore only the affected temporary files** (recommended — `needrestart` still checks the service for other legitimate reasons to restart):
+
+```console
+echo 'push(@{$nrconf{blacklist_mappings}}, qr(^/var/lib/wazuh-indexer/tmp/));' > /etc/needrestart/conf.d/wazuh-indexer-tmp.conf
+```
+
+**Ignore the service entirely** (`needrestart` will never flag Wazuh Indexer for restart, including for legitimate reasons such as a libc update):
+
+```console
+echo '$nrconf{blacklist_rc} = [ qr(^wazuh-indexer) ];' > /etc/needrestart/conf.d/wazuh-indexer.conf
+```
+
+Verify the change:
+
+```console
+needrestart -v
+```
+
+`wazuh-indexer.service` should no longer appear in the list of services to restart.
+
 ## Related documentation
 
 - [Security settings](../security)

--- a/docs/ref/configuration/index.md
+++ b/docs/ref/configuration/index.md
@@ -140,7 +140,7 @@ Verify the limit applied to the running node by checking `max_file_descriptors`:
 curl -k -u <INDEXER_USERNAME>:<INDEXER_PASSWORD> "https://<INDEXER_IP_ADDRESS>:9200/_nodes/stats/process?filter_path=**.max_file_descriptors&pretty"
 ```
 
-## Avoiding unnecessary service restarts (needrestart)
+## Avoiding unnecessary service restarts (`needrestart`)
 
 On Debian and Ubuntu systems with `needrestart` installed, Wazuh Indexer may get restarted automatically every time `apt` installs or upgrades **any** package, even one unrelated to Wazuh Indexer. On Ubuntu 24.04 and 26.04 this happens silently, without asking for confirmation.
 
@@ -148,16 +148,20 @@ This happens because some bundled Java native libraries (used for compression an
 
 To stop `needrestart` from restarting Wazuh Indexer on unrelated `apt` operations, add one of the following to `/etc/needrestart/conf.d/`:
 
-**Ignore only the affected temporary files** (recommended — `needrestart` still checks the service for other legitimate reasons to restart):
+### Ignore only the affected temporary files (recommended)
+
+`needrestart` still checks the service for other legitimate reasons to restart:
 
 ```console
 echo 'push(@{$nrconf{blacklist_mappings}}, qr(^/var/lib/wazuh-indexer/tmp/));' > /etc/needrestart/conf.d/wazuh-indexer-tmp.conf
 ```
 
-**Ignore the service entirely** (`needrestart` will never flag Wazuh Indexer for restart, including for legitimate reasons such as a libc update):
+### Ignore the service entirely
+
+`needrestart` will never flag Wazuh Indexer for restart, including for legitimate reasons such as a libc update:
 
 ```console
-echo '$nrconf{blacklist_rc} = [ qr(^wazuh-indexer) ];' > /etc/needrestart/conf.d/wazuh-indexer.conf
+echo 'push(@{$nrconf{blacklist_rc}}, qr(^wazuh-indexer));' > /etc/needrestart/conf.d/wazuh-indexer.conf
 ```
 
 Verify the change:


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
-->

Closes wazuh/wazuh-indexer#1850

On Debian and Ubuntu systems with `needrestart` installed, Wazuh Indexer may get restarted automatically every time `apt` installs or upgrades **any** package, even one unrelated to Wazuh Indexer. On Ubuntu 24.04 and 26.04 this happens silently by default, without asking for confirmation.

This happens because some bundled Java native libraries (used for compression and networking) extract a shared object file into `/var/lib/wazuh-indexer/tmp/` and delete it right after loading it, keeping it mapped in memory but no longer present on disk. `needrestart` interprets processes with deleted mapped libraries as running outdated code and restarts them.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

Add instruction to the doc page `docs/ref/configuration/index.md` on how to configure `needrestart` in order to ignore this missing files.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

<img width="826" height="718" alt="image" src="https://github.com/user-attachments/assets/8635a30a-b45b-4895-9618-77462daa6258" />


### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

This is just a documentation change, but this instructions are only applicable to Debian-based distributions.

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
The configurations explained in this doc change are related to `needrestart` which is not related to Wazuh.


### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->
- `docs/ref/configuration/index.md`

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->
N/A

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Relevant evidence provided
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
