### PR TITLE
Unify manager.address and manager.port into manager.endpoint

### DIFF
--- a/plugins/setup/src/main/resources/templates/states/agent-config.json
+++ b/plugins/setup/src/main/resources/templates/states/agent-config.json
@@ -8,13 +8,13 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "mapping.total_fields.limit": 1000,
+        "max_docvalue_fields_search": 100,
         "number_of_replicas": "0",
         "number_of_shards": "1",
         "query.default_field": [
           "wazuh.agent.id"
         ],
-        "refresh_interval": "5s",
-        "max_docvalue_fields_search": 100
+        "refresh_interval": "5s"
       },
       "mapping.total_fields.limit": 1000
     },

--- a/plugins/setup/src/main/resources/templates/states/agent-config.json
+++ b/plugins/setup/src/main/resources/templates/states/agent-config.json
@@ -13,8 +13,10 @@
         "query.default_field": [
           "wazuh.agent.id"
         ],
-        "refresh_interval": "5s"
-      }
+        "refresh_interval": "5s",
+        "max_docvalue_fields_search": 100
+      },
+      "mapping.total_fields.limit": 1000
     },
     "mappings": {
       "date_detection": false,
@@ -133,7 +135,7 @@
                                 },
                                 "manager": {
                                   "properties": {
-                                    "address": {
+                                    "endpoint": {
                                       "ignore_above": 1024,
                                       "type": "keyword"
                                     },
@@ -141,9 +143,6 @@
                                       "type": "long"
                                     },
                                     "max_retries": {
-                                      "type": "long"
-                                    },
-                                    "port": {
                                       "type": "long"
                                     },
                                     "retry_interval": {

--- a/wcs/stateful/agent-config/docs/fields.csv
+++ b/wcs/stateful/agent-config/docs/fields.csv
@@ -34,10 +34,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.enrollment.server_certificate_path,keyword,custom,,,Agent module configuration: agent.agent.enrollment.server_certificate_path.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.enrollment.ssl_cipher,keyword,custom,,,Agent module configuration: agent.agent.enrollment.ssl_cipher.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.ip_update_interval,long,custom,,,Agent module configuration: agent.agent.ip_update_interval.
-9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.manager.address,keyword,custom,,,Agent module configuration: agent.agent.manager.address.
+9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.manager.endpoint,keyword,custom,,,Agent module configuration: agent.agent.manager.endpoint.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.manager.interface_index,long,custom,,,Agent module configuration: agent.agent.manager.interface_index.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.manager.max_retries,long,custom,,,Agent module configuration: agent.agent.manager.max_retries.
-9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.manager.port,long,custom,,,Agent module configuration: agent.agent.manager.port.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.manager.retry_interval,long,custom,,,Agent module configuration: agent.agent.manager.retry_interval.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.notify_time,long,custom,,,Agent module configuration: agent.agent.notify_time.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent.agent.remote_conf,keyword,custom,,,Agent module configuration: agent.agent.remote_conf.

--- a/wcs/stateful/agent-config/fields/custom/wazuh.yml
+++ b/wcs/stateful/agent-config/fields/custom/wazuh.yml
@@ -175,12 +175,12 @@
       level: custom
       description: >
         Agent module configuration: agent.agent.ip_update_interval.
-    - name: agent.configuration.content.agent.agent.manager.address
+    - name: agent.configuration.content.agent.agent.manager.endpoint
       type: keyword
       level: custom
       ignore_above: 1024
       description: >
-        Agent module configuration: agent.agent.manager.address.
+        Agent module configuration: agent.agent.manager.endpoint.
     - name: agent.configuration.content.agent.agent.manager.interface_index
       type: long
       level: custom
@@ -191,11 +191,6 @@
       level: custom
       description: >
         Agent module configuration: agent.agent.manager.max_retries.
-    - name: agent.configuration.content.agent.agent.manager.port
-      type: long
-      level: custom
-      description: >
-        Agent module configuration: agent.agent.manager.port.
     - name: agent.configuration.content.agent.agent.manager.retry_interval
       type: long
       level: custom

--- a/wcs/stateful/agent-config/fields/template-settings-legacy.json
+++ b/wcs/stateful/agent-config/fields/template-settings-legacy.json
@@ -1,5 +1,7 @@
 {
-  "index_patterns": ["wazuh-agent-config*"],
+  "index_patterns": [
+    "wazuh-agent-config*"
+  ],
   "order": 1,
   "settings": {
     "index": {
@@ -10,7 +12,9 @@
       "query.default_field": [
         "wazuh.agent.id"
       ],
-      "mapping.total_fields.limit": 1000
-    }
+      "mapping.total_fields.limit": 1000,
+      "max_docvalue_fields_search": 100
+    },
+    "mapping.total_fields.limit": 1000
   }
 }

--- a/wcs/stateful/agent-config/fields/template-settings.json
+++ b/wcs/stateful/agent-config/fields/template-settings.json
@@ -13,8 +13,10 @@
         "query.default_field": [
           "wazuh.agent.id"
         ],
-        "mapping.total_fields.limit": 1000
-      }
+        "mapping.total_fields.limit": 1000,
+        "max_docvalue_fields_search": 100
+      },
+      "mapping.total_fields.limit": 1000
     }
   }
 }


### PR DESCRIPTION
## Description

Unify `manager.address` and `manager.port` fields into a single field `manager.endpoint` for the WCS stateful agent-config module.

Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1490

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

<img width="1492" height="467" alt="image" src="https://github.com/user-attachments/assets/f577f7a5-baf0-4243-b827-69aa98a887c6" />
<img width="1492" height="467" alt="image" src="https://github.com/user-attachments/assets/075b64ba-7247-446b-8ecb-2a07cd18e7d4" />


### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
