### PR TITLE
Rename Engine's Unix socket file

### DIFF
--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -31,7 +31,7 @@ testClusters.integTest {
 
   // Environment variables.
   systemProperty "wazuh.version", "${wazuh_version}-beta3"
-  
+
   // Plugin settings.
   setting 'plugins.content_manager.catalog.update_on_start', 'true'
 }
@@ -433,7 +433,7 @@ The plugin communicates with the Wazuh Engine via a **Unix Domain Socket (UDS)**
 
 Located at: `engine/client/EngineSocketClient.java`
 
-- Connects to the socket at `/usr/share/wazuh-indexer/engine/sockets/engine-api.sock`.
+- Connects to the socket at `/usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock`.
 - Sends **HTTP-over-UDS** requests: builds a standard HTTP/1.1 request string (method, headers, JSON body) and writes it to the socket channel.
 - Each request opens a new `SocketChannel` (using `StandardProtocolFamily.UNIX`) that is closed after the response is read.
 - Parses the HTTP response, extracting the status code and JSON body.

--- a/docs/ref/modules/content-manager/architecture.md
+++ b/docs/ref/modules/content-manager/architecture.md
@@ -64,7 +64,7 @@ Manages the four content spaces (standard, draft, test, custom). Routes CUD oper
 
 ### Engine client
 
-Communicates with the Wazuh Engine via Unix domain socket at `/usr/share/wazuh-indexer/engine/sockets/engine-api.sock`. Used for logtest execution, content validation, and configuration reload.
+Communicates with the Wazuh Engine via Unix domain socket at `/usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock`. Used for logtest execution, content validation, and configuration reload.
 
 ## Data flows
 

--- a/docs/ref/modules/content-manager/index.md
+++ b/docs/ref/modules/content-manager/index.md
@@ -90,7 +90,7 @@ During promotion, the Content Manager:
 The Content Manager communicates with the Wazuh Engine through a Unix domain socket located at:
 
 ```
-/usr/share/wazuh-indexer/engine/sockets/engine-api.sock
+/usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock
 ```
 
 This socket is used for:

--- a/docs/ref/modules/content-manager/troubleshooting.md
+++ b/docs/ref/modules/content-manager/troubleshooting.md
@@ -11,7 +11,7 @@ The Wazuh Engine is not running or the Unix socket is not accessible.
 Resolution:
 1. Check the socket file exists:
    ```bash
-   ls -la /usr/share/wazuh-indexer/engine/sockets/engine-api.sock
+   ls -la /usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock
    ```
 
 2. Ensure the Wazuh Indexer process has permission to access the socket file.
@@ -97,7 +97,7 @@ Fields that are part of WCS (e.g., `event.action`, `source.ip`) never need the u
 
 The Unix socket used for Engine communication does not exist.
 
-**Expected path:** `/usr/share/wazuh-indexer/engine/sockets/engine-api.sock`
+**Expected path:** `/usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock`
 
 #### Resolution
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/engine/client/EngineSocketClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/engine/client/EngineSocketClient.java
@@ -51,7 +51,7 @@ import com.wazuh.contentmanager.utils.Constants;
 public class EngineSocketClient {
     private static final Logger logger = LogManager.getLogger(EngineSocketClient.class);
     private static final String DEFAULT_SOCKET_PATH =
-            "/usr/share/wazuh-indexer/engine/sockets/engine-api.sock";
+            "/usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock";
     private static final int BUFFER_SIZE = 8192;
     private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/engine/client/EngineSocketClientTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/engine/client/EngineSocketClientTests.java
@@ -57,7 +57,7 @@ public class EngineSocketClientTests extends OpenSearchTestCase {
         EngineSocketClient client = new EngineSocketClient();
 
         Assert.assertEquals(
-                "/usr/share/wazuh-indexer/engine/sockets/engine-api.sock", client.getSocketPath());
+                "/usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock", client.getSocketPath());
     }
 
     /** Test that the custom socket path constructor sets the path correctly. */


### PR DESCRIPTION
## Description

Rename Engine's Unix socket file to `engine-api-http.sock`.

## Proposed Changes

- Rename socket file name in `EngineSocketClient.java`.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

### Artifacts Affected

- Packages

### Configuration Changes

None

### Documentation Updates

Renamed engine socket file name.

### Tests Introduced

None. Existing tests update with the new file name.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
