### PR TITLE
Harden logtest endpoints againstDoS

### DIFF
--- a/docs/dev/plugins/content-manager-logtest.md
+++ b/docs/dev/plugins/content-manager-logtest.md
@@ -17,7 +17,7 @@ REST handlers no longer validate requests or contain any business logic — that
 
 **Path**: `rest/service/RestPostLogtestAction.java`
 
-The REST handler for `POST /_plugins/_content_manager/logtest`. It reads the raw request body into a `LogtestRequest` and calls `client.execute(LogtestAction.INSTANCE, logtestRequest, listener)`. It performs no validation and does not interact with indices or external services directly.
+The REST handler for `POST /_plugins/_content_manager/logtest`. Before dispatch it enforces the request-body size cap via `PayloadValidations.validateLogtestBodySize(...)` — a body larger than `plugins.content_manager.logtest.max_body_bytes` is rejected with **413** at the REST layer, before parsing (see [Request size limit and concurrency](#request-size-limit-and-concurrency)). Otherwise it reads the raw request body into a `LogtestRequest` and calls `client.execute(LogtestAction.INSTANCE, logtestRequest, listener)`. It performs no field-level validation and does not interact with indices or external services directly.
 
 ### TransportLogtestAction
 
@@ -36,7 +36,7 @@ The validation and dispatch layer for the combined endpoint. Responsibilities:
 
 **Path**: `rest/service/RestPostLogtestNormalizationAction.java`
 
-The REST handler for `POST /_plugins/_content_manager/logtest/normalization`. Reads the request body and calls `client.execute(LogtestNormalizationAction.INSTANCE, ...)`. No validation.
+The REST handler for `POST /_plugins/_content_manager/logtest/normalization`. Enforces the body-size cap (413) the same way as the combined handler, then reads the request body and calls `client.execute(LogtestNormalizationAction.INSTANCE, ...)`. No field-level validation.
 
 ### TransportLogtestNormalizationAction
 
@@ -54,7 +54,7 @@ Responsibilities:
 
 **Path**: `rest/service/RestPostLogtestDetectionAction.java`
 
-The REST handler for `POST /_plugins/_content_manager/logtest/detection`. Reads the request body and calls `client.execute(LogtestDetectionAction.INSTANCE, ...)`. No validation.
+The REST handler for `POST /_plugins/_content_manager/logtest/detection`. Enforces the body-size cap (413) the same way as the combined handler, then reads the request body and calls `client.execute(LogtestDetectionAction.INSTANCE, ...)`. No field-level validation.
 
 ### TransportLogtestDetectionAction
 
@@ -67,6 +67,15 @@ Responsibilities:
 3. Validates that `space` is not `"draft"`.
 4. Validates that `input` is a JSON object (not a string or array).
 5. Delegates to `LogtestService.executeDetection(integrationId, space, inputEvent)`.
+
+All three transport actions run this work on the dedicated `content_manager_logtest` thread pool rather than the transport thread (see [Request size limit and concurrency](#request-size-limit-and-concurrency)).
+
+### Request size limit and concurrency
+
+The logtest endpoints are deliberately reachable by low-privilege accounts. To keep that surface from being used to exhaust the indexer's heap, two independent controls bound the work each request can cause:
+
+- **Body-size cap (413).** Every logtest REST handler checks the raw request-body length against `plugins.content_manager.logtest.max_body_bytes` (default 1 MiB; dynamic; range 1 KiB–16 MiB) before parsing or dispatching, via the shared `PayloadValidations.validateLogtestBodySize(...)` helper. An oversized body is rejected with **413 `REQUEST_ENTITY_TOO_LARGE`** and the message `logtest payload exceeds the maximum allowed size of <N> bytes.`, and the offending account and size are logged at `WARN`. This removes the input-to-response amplification the endpoint would otherwise permit, since the input is bounded before any work happens.
+- **Bounded thread pool (429).** The three transport actions offload execution onto a dedicated `FixedExecutorBuilder` pool named `content_manager_logtest` (size `max(1, allocatedProcessors / 2)`, queue 100), registered in `ContentManagerPlugin.getExecutorBuilders(...)`. This keeps the blocking Engine-socket call off the transport threads, and when the bounded queue is full excess requests are shed with **429 `TOO_MANY_REQUESTS`** (`logtest is busy: too many concurrent requests. Please retry later.`) instead of accumulating on the heap. Worst-case in-flight payload is bounded to roughly `(pool size + queue) * max_body_bytes`.
 
 ### LogtestService
 

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -464,6 +464,7 @@ curl -sk -u admin:admin -X POST \
 
 - **200** — logtest executed (check inner status fields).
 - **400** — missing/invalid fields or integration not found.
+- **413** — request body exceeds `plugins.content_manager.logtest.max_body_bytes` (default 1 MiB); rejected before processing.
 - **500** — Engine socket communication error or internal error.
 
 ---
@@ -560,6 +561,7 @@ curl -sk -u admin:admin -X POST \
 
 - **200** — normalization executed successfully.
 - **400** — missing/invalid fields.
+- **413** — request body exceeds `plugins.content_manager.logtest.max_body_bytes` (default 1 MiB); rejected before processing.
 - **500** — Engine socket communication error or internal error.
 
 ---
@@ -679,6 +681,7 @@ curl -sk -u admin:admin -X POST \
 
 - **200** — detection executed (check `message.status`).
 - **400** — missing/invalid fields or integration not found.
+- **413** — request body exceeds `plugins.content_manager.logtest.max_body_bytes` (default 1 MiB); rejected before processing.
 - **500** — internal error.
 
 ---

--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -10,6 +10,7 @@ The Content Manager plugin is configured through settings in `opensearch.yml`. A
 - **`plugins.content_manager.max_items_per_bulk`** (Integer, default `999`, range 10–999) — maximum documents per bulk indexing request.
 - **`plugins.content_manager.max_concurrent_bulks`** (Integer, default `5`, range 1–5) — maximum concurrent bulk operations.
 - **`plugins.content_manager.max_bulk_bytes`** (Long, default `5242880` / 5 MB, range 1048576–104857600 / 1–100 MB) — maximum request body size, in bytes, for a single bulk indexing request.
+- **`plugins.content_manager.logtest.max_body_bytes`** (Long, default `1048576` / 1 MiB, range 1024–16777216 / 1 KiB–16 MiB, dynamic) — maximum size, in bytes, of a logtest request body (`POST /logtest`, `/logtest/normalization`, `/logtest/detection`). Requests whose body exceeds this are rejected with HTTP 413 at the REST layer, before parsing or dispatch, so an oversized event cannot be amplified into the response and exhaust the indexer's heap.
 - **`plugins.content_manager.client.timeout`** (Long, default `10`, range 10–50) — HTTP client timeout in seconds for CTI API requests.
 - **`plugins.content_manager.client.max_retries`** (Integer, default `3`, range 0–10) — number of times a CTI API request is retried after an HTTP 429 (Too Many Requests) response, before the 429 is returned to the caller.
 - **`plugins.content_manager.client.retry_backoff_base_seconds`** (Integer, default `30`, range 1–300) — base delay, in seconds, for the exponential backoff used between 429 retries when the response carries no usable `Retry-After` header (delay for retry `n` is `base * 2^n`).
@@ -218,7 +219,7 @@ Setting a limit to `0` blocks all new creation of that resource type.
 
 ### Notes
 
-- Changes to `opensearch.yml` require a restart of the Wazuh Indexer to take effect, except for dynamic settings, which can be updated at runtime via the OpenSearch API. Dynamic settings include `plugins.content_manager.telemetry.enabled` and all five resource creation limits (`max_integrations`, `max_decoders`, `max_rules`, `max_kvdbs`, `max_filters`).
+- Changes to `opensearch.yml` require a restart of the Wazuh Indexer to take effect, except for dynamic settings, which can be updated at runtime via the OpenSearch API. Dynamic settings include `plugins.content_manager.telemetry.enabled`, `plugins.content_manager.logtest.max_body_bytes`, and all five resource creation limits (`max_integrations`, `max_decoders`, `max_rules`, `max_kvdbs`, `max_filters`).
 - The catalog URL settings (`plugins.content_manager.catalog.ruleset`, `plugins.content_manager.catalog.iocs`, and `plugins.content_manager.catalog.vulnerabilities`) should only be changed if instructed by Wazuh support or documentation, and must point to valid absolute HTTP(S) CTI consumer endpoints.
 - The sync interval is enforced by the OpenSearch Job Scheduler. The actual sync timing may vary slightly depending on cluster load.
 - The update check service runs with a fixed interval of 1 day when enabled. The first ping is sent immediately after the job is registered (on node start or when the setting is dynamically enabled); subsequent pings follow the 1-day interval.

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -1075,6 +1075,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -1113,6 +1115,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -1167,6 +1171,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -2692,6 +2698,26 @@ components:
               value:
                 message: "Registration is disabled because the credentials index is not configured as a system index. Add it to plugins.security.system_indices.indices in opensearch.yml and restart."
                 status: 412
+
+    PayloadTooLarge:
+      description: |
+        Payload Too Large - The logtest request body exceeds the maximum allowed
+        size and is rejected at the REST layer before it is parsed or dispatched.
+
+        The limit is controlled by the `plugins.content_manager.logtest.max_body_bytes`
+        setting (default 1 MiB). A log line is at most a few kilobytes; this bound
+        prevents an oversized event from being amplified into the response and
+        exhausting the indexer's heap.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RestResponse"
+          examples:
+            event_too_large:
+              summary: logtest body over the size limit
+              value:
+                message: "logtest payload exceeds the maximum allowed size of 1048576 bytes."
+                status: 413
 
     InternalServerError:
       description: |

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -39,6 +39,7 @@ import org.opensearch.common.inject.AbstractModule;
 import org.opensearch.common.inject.Module;
 import org.opensearch.common.settings.*;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
@@ -60,6 +61,8 @@ import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.secure_sm.AccessController;
+import org.opensearch.threadpool.ExecutorBuilder;
+import org.opensearch.threadpool.FixedExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
@@ -278,6 +281,11 @@ public class ContentManagerPlugin extends Plugin
                 .getClusterSettings()
                 .addSettingsUpdateConsumer(
                         PluginSettings.WAZUH_UID, v -> PluginSettings.getInstance().setWazuhUid(v));
+        clusterService
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(
+                        PluginSettings.LOGTEST_MAX_BODY_BYTES,
+                        v -> PluginSettings.getInstance().setLogtestMaxBodyBytes(v));
 
         return List.of(
                 this.subscriptionService,
@@ -977,6 +985,7 @@ public class ContentManagerPlugin extends Plugin
                 PluginSettings.MAX_CONCURRENT_BULKS,
                 PluginSettings.MAX_ITEMS_PER_BULK,
                 PluginSettings.MAX_BULK_BYTES,
+                PluginSettings.LOGTEST_MAX_BODY_BYTES,
                 PluginSettings.CATALOG_SYNC_INTERVAL,
                 PluginSettings.UPDATE_ON_START,
                 PluginSettings.UPDATE_ON_SCHEDULE,
@@ -999,6 +1008,21 @@ public class ContentManagerPlugin extends Plugin
                 PluginSettings.SETUP_WAIT_BACKOFF_BASE_SECONDS,
                 PluginSettings.CLIENT_MAX_RETRIES,
                 PluginSettings.CLIENT_RETRY_BACKOFF_BASE_SECONDS);
+    }
+
+    @Override
+    public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
+        // Dedicated, bounded pool for logtest execution. Sized to half the allocated processors (at
+        // least one) with a small bounded queue: excess concurrency is rejected with 429 rather than
+        // piling blocking engine-socket calls onto the transport threads and converting into heap.
+        int size = Math.max(1, OpenSearchExecutors.allocatedProcessors(settings) / 2);
+        return List.of(
+                new FixedExecutorBuilder(
+                        settings,
+                        PluginSettings.LOGTEST_THREAD_POOL,
+                        size,
+                        100,
+                        "plugins.content_manager.thread_pool.logtest"));
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestAction.java
@@ -33,6 +33,7 @@ import java.util.List;
 import com.wazuh.contentmanager.action.LogtestAction;
 import com.wazuh.contentmanager.action.LogtestRequest;
 import com.wazuh.contentmanager.action.LogtestResponse;
+import com.wazuh.contentmanager.rest.utils.PayloadValidations;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
 import static org.opensearch.rest.RestRequest.Method.POST;
@@ -74,6 +75,17 @@ public class RestPostLogtestAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         log.debug("{} {}", request.method(), PluginSettings.LOGTEST_URI);
 
+        // Reject oversized bodies at the REST layer, before parsing or dispatch, so the endpoint's
+        // input-to-response amplification can never be turned into heap pressure.
+        LogtestResponse tooLarge =
+                PayloadValidations.validateLogtestBodySize(
+                        request,
+                        PluginSettings.getInstance().getLogtestMaxBodyBytes(),
+                        client.threadPool().getThreadContext());
+        if (tooLarge != null) {
+            return channel -> channel.sendResponse(buildResponse(tooLarge));
+        }
+
         String body = request.content().utf8ToString();
         LogtestRequest logtestRequest = new LogtestRequest(body);
 
@@ -85,10 +97,14 @@ public class RestPostLogtestAction extends BaseRestHandler {
         return new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(LogtestResponse response) throws Exception {
-                return new BytesRestResponse(
-                        response.getStatus(),
-                        response.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
+                return RestPostLogtestAction.buildResponse(response);
             }
         };
+    }
+
+    private static BytesRestResponse buildResponse(LogtestResponse response) throws Exception {
+        return new BytesRestResponse(
+                response.getStatus(),
+                response.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestDetectionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestDetectionAction.java
@@ -33,6 +33,7 @@ import java.util.List;
 import com.wazuh.contentmanager.action.LogtestDetectionAction;
 import com.wazuh.contentmanager.action.LogtestDetectionRequest;
 import com.wazuh.contentmanager.action.LogtestResponse;
+import com.wazuh.contentmanager.rest.utils.PayloadValidations;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
 import static org.opensearch.rest.RestRequest.Method.POST;
@@ -74,6 +75,17 @@ public class RestPostLogtestDetectionAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         log.debug("{} {}", request.method(), PluginSettings.LOGTEST_DETECTION_URI);
 
+        // Reject oversized bodies at the REST layer, before parsing or dispatch, so the endpoint's
+        // input-to-response amplification can never be turned into heap pressure.
+        LogtestResponse tooLarge =
+                PayloadValidations.validateLogtestBodySize(
+                        request,
+                        PluginSettings.getInstance().getLogtestMaxBodyBytes(),
+                        client.threadPool().getThreadContext());
+        if (tooLarge != null) {
+            return channel -> channel.sendResponse(buildResponse(tooLarge));
+        }
+
         String body = request.content().utf8ToString();
         LogtestDetectionRequest detectionRequest = new LogtestDetectionRequest(body);
 
@@ -86,10 +98,14 @@ public class RestPostLogtestDetectionAction extends BaseRestHandler {
         return new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(LogtestResponse response) throws Exception {
-                return new BytesRestResponse(
-                        response.getStatus(),
-                        response.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
+                return RestPostLogtestDetectionAction.buildResponse(response);
             }
         };
+    }
+
+    private static BytesRestResponse buildResponse(LogtestResponse response) throws Exception {
+        return new BytesRestResponse(
+                response.getStatus(),
+                response.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestNormalizationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostLogtestNormalizationAction.java
@@ -33,6 +33,7 @@ import java.util.List;
 import com.wazuh.contentmanager.action.LogtestNormalizationAction;
 import com.wazuh.contentmanager.action.LogtestNormalizationRequest;
 import com.wazuh.contentmanager.action.LogtestResponse;
+import com.wazuh.contentmanager.rest.utils.PayloadValidations;
 import com.wazuh.contentmanager.settings.PluginSettings;
 
 import static org.opensearch.rest.RestRequest.Method.POST;
@@ -74,6 +75,17 @@ public class RestPostLogtestNormalizationAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         log.debug("{} {}", request.method(), PluginSettings.LOGTEST_NORMALIZATION_URI);
 
+        // Reject oversized bodies at the REST layer, before parsing or dispatch, so the endpoint's
+        // input-to-response amplification can never be turned into heap pressure.
+        LogtestResponse tooLarge =
+                PayloadValidations.validateLogtestBodySize(
+                        request,
+                        PluginSettings.getInstance().getLogtestMaxBodyBytes(),
+                        client.threadPool().getThreadContext());
+        if (tooLarge != null) {
+            return channel -> channel.sendResponse(buildResponse(tooLarge));
+        }
+
         String body = request.content().utf8ToString();
         LogtestNormalizationRequest normalizationRequest = new LogtestNormalizationRequest(body);
 
@@ -88,10 +100,14 @@ public class RestPostLogtestNormalizationAction extends BaseRestHandler {
         return new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(LogtestResponse response) throws Exception {
-                return new BytesRestResponse(
-                        response.getStatus(),
-                        response.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
+                return RestPostLogtestNormalizationAction.buildResponse(response);
             }
         };
+    }
+
+    private static BytesRestResponse buildResponse(LogtestResponse response) throws Exception {
+        return new BytesRestResponse(
+                response.getStatus(),
+                response.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/utils/PayloadValidations.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/utils/PayloadValidations.java
@@ -18,10 +18,13 @@ package com.wazuh.contentmanager.rest.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
@@ -40,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.wazuh.contentmanager.action.LogtestResponse;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
@@ -48,10 +52,53 @@ import com.wazuh.contentmanager.utils.Constants;
 /** Utility class providing common validation methods for REST handlers. */
 public class PayloadValidations {
 
+    private static final Logger log = LogManager.getLogger(PayloadValidations.class);
+
     private static final Pattern ID_PATTERN = Pattern.compile("^[a-zA-Z0-9-_]+$");
+
+    /**
+     * Transient thread-context key under which the OpenSearch security plugin stores the
+     * authenticated user. Read reflectively (via {@code toString()}) so the plugin does not take a
+     * hard compile dependency on the optional security plugin.
+     */
+    private static final String SECURITY_USER_TRANSIENT = "_opendistro_security_user";
 
     /** Public constructor to allow instantiation. */
     public PayloadValidations() {}
+
+    /**
+     * Enforces the configured maximum logtest request-body size, before the body is parsed or
+     * dispatched to the transport layer. The raw byte length of the request content is checked (the
+     * envelope around the {@code event} is negligible, so this bounds the event too). When the limit
+     * is exceeded the offending call is logged with the responsible account so operators can
+     * attribute abuse, and a {@code 413 REQUEST_ENTITY_TOO_LARGE} response is returned.
+     *
+     * @param request the incoming REST request.
+     * @param maxBytes the maximum allowed body size in bytes.
+     * @param threadContext the current thread context, used to resolve the authenticated user for the
+     *     abuse log (may be null).
+     * @return a {@link LogtestResponse} carrying the 413 error when the body is too large, or {@code
+     *     null} when the body is within the limit.
+     */
+    public static LogtestResponse validateLogtestBodySize(
+            RestRequest request, long maxBytes, ThreadContext threadContext) {
+        int length = request.content().length();
+        if (length > maxBytes) {
+            Object userObj =
+                    threadContext == null ? null : threadContext.getTransient(SECURITY_USER_TRANSIENT);
+            String user = userObj == null ? "unknown" : userObj.toString();
+            log.warn(
+                    "Rejected oversized logtest request: {} bytes exceeds limit of {} bytes, path [{}], user [{}].",
+                    length,
+                    maxBytes,
+                    request.path(),
+                    user);
+            return new LogtestResponse(
+                    String.format(Locale.ROOT, Constants.E_413_LOGTEST_EVENT_TOO_LARGE, maxBytes),
+                    RestStatus.REQUEST_ENTITY_TOO_LARGE);
+        }
+        return null;
+    }
 
     /**
      * Validates that a document exists and is in the draft space.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -48,6 +48,13 @@ public class PluginSettings {
     public static final String SPACE_URI = PLUGINS_BASE_URI + "/space";
     public static final String VERSION_CHECK_URI = PLUGINS_BASE_URI + "/version/check";
 
+    /**
+     * Name of the dedicated, bounded thread pool that executes logtest requests. Offloading logtest
+     * off the transport thread and onto a fixed pool with a bounded queue prevents request
+     * concurrency from being converted directly into heap pressure (overflow is rejected with 429).
+     */
+    public static final String LOGTEST_THREAD_POOL = "content_manager_logtest";
+
     /** Settings default values */
     private static final int DEFAULT_MAX_ITEMS_PER_BULK = 999;
 
@@ -67,6 +74,7 @@ public class PluginSettings {
     private static final int MINIMUM_MAX_FILTERS = 0;
 
     private static final long DEFAULT_MAX_BULK_BYTES = 5L * 1024 * 1024;
+    private static final long DEFAULT_LOGTEST_MAX_BODY_BYTES = 1L * 1024 * 1024;
     private static final int DEFAULT_MAX_CONCURRENT_BULKS = 5;
     private static final int DEFAULT_CLIENT_TIMEOUT = 10;
     private static final int DEFAULT_CATALOG_SYNC_INTERVAL = 60;
@@ -139,6 +147,24 @@ public class PluginSettings {
                     100L * 1024 * 1024,
                     Setting.Property.NodeScope,
                     Setting.Property.Filtered);
+
+    /**
+     * Maximum size, in bytes, of a logtest request body ({@code POST
+     * /_plugins/_content_manager/logtest} and its {@code /normalization} and {@code /detection}
+     * siblings). A log line is at most a few kilobytes; the endpoint amplifies its input into the
+     * response (~2 bytes out per byte in) and, being available to read-only accounts, is otherwise a
+     * cheap way to exhaust the indexer's heap. Requests whose raw body exceeds this limit are
+     * rejected with {@code 413 REQUEST_ENTITY_TOO_LARGE} at the REST layer, before parsing or
+     * dispatch, so the amplification never happens. Default 1 MiB; bounded 1 KiB–16 MiB.
+     */
+    public static final Setting<Long> LOGTEST_MAX_BODY_BYTES =
+            Setting.longSetting(
+                    "plugins.content_manager.logtest.max_body_bytes",
+                    DEFAULT_LOGTEST_MAX_BODY_BYTES,
+                    1L * 1024,
+                    16L * 1024 * 1024,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
     /**
      * The maximum number of co-existing bulk operations during the initialization from a snapshot.
@@ -399,6 +425,7 @@ public class PluginSettings {
     private final String ctiBaseUrl;
     private final int maximumItemsPerBulk;
     private final long maximumBulkBytes;
+    private volatile long logtestMaxBodyBytes;
     private final int maximumConcurrentBulks;
     private final long clientTimeout;
     private final int catalogSyncInterval;
@@ -435,6 +462,7 @@ public class PluginSettings {
         this.ctiBaseUrl = CTI_API_URL.get(settings);
         this.maximumItemsPerBulk = MAX_ITEMS_PER_BULK.get(settings);
         this.maximumBulkBytes = MAX_BULK_BYTES.get(settings);
+        this.logtestMaxBodyBytes = LOGTEST_MAX_BODY_BYTES.get(settings);
         this.maximumConcurrentBulks = MAX_CONCURRENT_BULKS.get(settings);
         this.clientTimeout = CLIENT_TIMEOUT.get(settings);
         this.catalogSyncInterval = CATALOG_SYNC_INTERVAL.get(settings);
@@ -645,6 +673,25 @@ public class PluginSettings {
      */
     public long getMaxBulkBytes() {
         return this.maximumBulkBytes;
+    }
+
+    /**
+     * Retrieves the maximum allowed size, in bytes, of a logtest request body.
+     *
+     * @return the maximum logtest request body size in bytes.
+     */
+    public long getLogtestMaxBodyBytes() {
+        return this.logtestMaxBodyBytes;
+    }
+
+    /**
+     * Updates the maximum allowed logtest request body size. Invoked by the cluster-settings update
+     * consumer when {@code plugins.content_manager.logtest.max_body_bytes} changes.
+     *
+     * @param logtestMaxBodyBytes the new maximum size in bytes.
+     */
+    public void setLogtestMaxBodyBytes(long logtestMaxBodyBytes) {
+        this.logtestMaxBodyBytes = logtestMaxBodyBytes;
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestAction.java
@@ -24,8 +24,10 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.List;
@@ -38,6 +40,7 @@ import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.rest.utils.PayloadValidations;
+import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
 public class TransportLogtestAction
@@ -45,20 +48,36 @@ public class TransportLogtestAction
 
     private final LogtestService logtestService;
     private final PayloadValidations payloadValidations;
+    private final ThreadPool threadPool;
 
     @Inject
     public TransportLogtestAction(
             TransportService transportService,
             ActionFilters actionFilters,
+            ThreadPool threadPool,
             LogtestService logtestService) {
         super(LogtestAction.NAME, transportService, actionFilters, LogtestRequest::new);
         this.logtestService = logtestService;
         this.payloadValidations = new PayloadValidations();
+        this.threadPool = threadPool;
     }
 
     @Override
     protected void doExecute(
             Task task, LogtestRequest request, ActionListener<LogtestResponse> listener) {
+        // Run on the dedicated bounded pool so blocking engine work never occupies a transport
+        // thread and excess concurrency is shed as 429 rather than accumulating on the heap.
+        try {
+            this.threadPool
+                    .executor(PluginSettings.LOGTEST_THREAD_POOL)
+                    .execute(() -> process(request, listener));
+        } catch (OpenSearchRejectedExecutionException e) {
+            listener.onResponse(
+                    new LogtestResponse(Constants.E_429_LOGTEST_BUSY, RestStatus.TOO_MANY_REQUESTS));
+        }
+    }
+
+    private void process(LogtestRequest request, ActionListener<LogtestResponse> listener) {
         try {
             // 1. Parse JSON
             ObjectMapper mapper = new ObjectMapper();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionAction.java
@@ -23,8 +23,10 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.List;
@@ -37,6 +39,7 @@ import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.rest.utils.PayloadValidations;
+import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
 public class TransportLogtestDetectionAction
@@ -44,21 +47,37 @@ public class TransportLogtestDetectionAction
 
     private final LogtestService logtestService;
     private final PayloadValidations payloadValidations;
+    private final ThreadPool threadPool;
 
     @Inject
     public TransportLogtestDetectionAction(
             TransportService transportService,
             ActionFilters actionFilters,
+            ThreadPool threadPool,
             LogtestService logtestService) {
         super(
                 LogtestDetectionAction.NAME, transportService, actionFilters, LogtestDetectionRequest::new);
         this.logtestService = logtestService;
         this.payloadValidations = new PayloadValidations();
+        this.threadPool = threadPool;
     }
 
     @Override
     protected void doExecute(
             Task task, LogtestDetectionRequest request, ActionListener<LogtestResponse> listener) {
+        // Run on the dedicated bounded pool so blocking engine work never occupies a transport
+        // thread and excess concurrency is shed as 429 rather than accumulating on the heap.
+        try {
+            this.threadPool
+                    .executor(PluginSettings.LOGTEST_THREAD_POOL)
+                    .execute(() -> process(request, listener));
+        } catch (OpenSearchRejectedExecutionException e) {
+            listener.onResponse(
+                    new LogtestResponse(Constants.E_429_LOGTEST_BUSY, RestStatus.TOO_MANY_REQUESTS));
+        }
+    }
+
+    private void process(LogtestDetectionRequest request, ActionListener<LogtestResponse> listener) {
         try {
             // 1. Parse JSON
             ObjectMapper mapper = new ObjectMapper();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestNormalizationAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportLogtestNormalizationAction.java
@@ -24,8 +24,10 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.util.List;
@@ -38,6 +40,7 @@ import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
 import com.wazuh.contentmanager.rest.model.RestResponse;
 import com.wazuh.contentmanager.rest.utils.PayloadValidations;
+import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
 
 public class TransportLogtestNormalizationAction
@@ -45,11 +48,13 @@ public class TransportLogtestNormalizationAction
 
     private final LogtestService logtestService;
     private final PayloadValidations payloadValidations;
+    private final ThreadPool threadPool;
 
     @Inject
     public TransportLogtestNormalizationAction(
             TransportService transportService,
             ActionFilters actionFilters,
+            ThreadPool threadPool,
             LogtestService logtestService) {
         super(
                 LogtestNormalizationAction.NAME,
@@ -58,11 +63,26 @@ public class TransportLogtestNormalizationAction
                 LogtestNormalizationRequest::new);
         this.logtestService = logtestService;
         this.payloadValidations = new PayloadValidations();
+        this.threadPool = threadPool;
     }
 
     @Override
     protected void doExecute(
             Task task, LogtestNormalizationRequest request, ActionListener<LogtestResponse> listener) {
+        // Run on the dedicated bounded pool so blocking engine work never occupies a transport
+        // thread and excess concurrency is shed as 429 rather than accumulating on the heap.
+        try {
+            this.threadPool
+                    .executor(PluginSettings.LOGTEST_THREAD_POOL)
+                    .execute(() -> process(request, listener));
+        } catch (OpenSearchRejectedExecutionException e) {
+            listener.onResponse(
+                    new LogtestResponse(Constants.E_429_LOGTEST_BUSY, RestStatus.TOO_MANY_REQUESTS));
+        }
+    }
+
+    private void process(
+            LogtestNormalizationRequest request, ActionListener<LogtestResponse> listener) {
         try {
             // 1. Parse JSON
             ObjectMapper mapper = new ObjectMapper();

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -72,6 +72,10 @@ public class Constants {
             "This request would create more than the allowed kvdbs [%d].";
     public static final String E_400_TOO_MANY_FILTERS =
             "This request would create more than the allowed filters [%d].";
+    public static final String E_413_LOGTEST_EVENT_TOO_LARGE =
+            "logtest payload exceeds the maximum allowed size of %d bytes.";
+    public static final String E_429_LOGTEST_BUSY =
+            "logtest is busy: too many concurrent requests. Please retry later.";
     public static final String E_400_UUID_SHOULD_NOT_BE_PROVIDED =
             "ID should not be provided in the payload.";
     public static final String E_400_ENGINE_VALIDATION_FAILED = "Engine validation failed.";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
@@ -353,8 +353,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
 
     /**
      * The rule-fetch query must filter to {@code document.enabled: true} -- a disabled rule must
-     * never be evaluated in Log Test, matching the same gate {@code fetchEnabledRuleIds} applies
-     * when building a Security Analytics detector.
+     * never be evaluated in Log Test, matching the same gate {@code fetchEnabledRuleIds} applies when
+     * building a Security Analytics detector.
      */
     @SuppressWarnings("unchecked")
     public void testFetchRuleBodiesFiltersDisabledRules() throws Exception {

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/utils/PayloadValidationsTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/utils/PayloadValidationsTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.rest.utils;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.junit.Assert;
+
+import com.wazuh.contentmanager.action.LogtestResponse;
+
+public class PayloadValidationsTests extends OpenSearchTestCase {
+
+    private RestRequest requestWithBody(int bytes) {
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+                .withContent(new BytesArray(new byte[bytes]), null)
+                .withPath("/_plugins/_content_manager/logtest")
+                .build();
+    }
+
+    public void testValidateLogtestBodySize_underLimitReturnsNull() {
+        ThreadContext ctx = new ThreadContext(Settings.EMPTY);
+        LogtestResponse result =
+                PayloadValidations.validateLogtestBodySize(requestWithBody(512), 1024, ctx);
+        Assert.assertNull(result);
+    }
+
+    public void testValidateLogtestBodySize_atLimitReturnsNull() {
+        ThreadContext ctx = new ThreadContext(Settings.EMPTY);
+        LogtestResponse result =
+                PayloadValidations.validateLogtestBodySize(requestWithBody(1024), 1024, ctx);
+        Assert.assertNull(result);
+    }
+
+    public void testValidateLogtestBodySize_overLimitReturns413() {
+        ThreadContext ctx = new ThreadContext(Settings.EMPTY);
+        LogtestResponse result =
+                PayloadValidations.validateLogtestBodySize(requestWithBody(2048), 1024, ctx);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(RestStatus.REQUEST_ENTITY_TOO_LARGE, result.getStatus());
+    }
+
+    public void testValidateLogtestBodySize_nullThreadContextDoesNotThrow() {
+        LogtestResponse result =
+                PayloadValidations.validateLogtestBodySize(requestWithBody(2048), 1024, null);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(RestStatus.REQUEST_ENTITY_TOO_LARGE, result.getStatus());
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestActionTests.java
@@ -19,10 +19,13 @@ package com.wazuh.contentmanager.transport;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.concurrency.OpenSearchRejectedExecutionException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,6 +40,7 @@ import static org.mockito.Mockito.*;
 
 public class TransportLogtestActionTests extends OpenSearchTestCase {
     private LogtestService logtestService;
+    private ThreadPool threadPool;
     private TransportLogtestAction action;
 
     @Before
@@ -44,9 +48,35 @@ public class TransportLogtestActionTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.logtestService = mock(LogtestService.class);
+        this.threadPool = mock(ThreadPool.class);
+        // Execute submitted work synchronously so the existing assertions still observe the result.
+        when(this.threadPool.executor(anyString()))
+                .thenReturn(OpenSearchExecutors.newDirectExecutorService());
         this.action =
                 new TransportLogtestAction(
-                        mock(TransportService.class), mock(ActionFilters.class), this.logtestService);
+                        mock(TransportService.class),
+                        mock(ActionFilters.class),
+                        this.threadPool,
+                        this.logtestService);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testDoExecute_PoolRejectionReturns429() {
+        when(this.threadPool.executor(anyString()))
+                .thenThrow(new OpenSearchRejectedExecutionException("queue full"));
+
+        LogtestRequest request = new LogtestRequest("{\"space\":\"test\"}");
+        ActionListener<LogtestResponse> listener = mock(ActionListener.class);
+        this.action.doExecute(mock(Task.class), request, listener);
+
+        verify(listener)
+                .onResponse(
+                        argThat(
+                                response -> {
+                                    Assert.assertEquals(RestStatus.TOO_MANY_REQUESTS, response.getStatus());
+                                    return true;
+                                }));
+        verifyNoInteractions(this.logtestService);
     }
 
     @SuppressWarnings("unchecked")

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestDetectionActionTests.java
@@ -19,10 +19,12 @@ package com.wazuh.contentmanager.transport;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,6 +40,7 @@ import static org.mockito.Mockito.*;
 
 public class TransportLogtestDetectionActionTests extends OpenSearchTestCase {
     private LogtestService logtestService;
+    private ThreadPool threadPool;
     private TransportLogtestDetectionAction action;
 
     @Before
@@ -45,9 +48,16 @@ public class TransportLogtestDetectionActionTests extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.logtestService = mock(LogtestService.class);
+        this.threadPool = mock(ThreadPool.class);
+        // Execute submitted work synchronously so the existing assertions still observe the result.
+        when(this.threadPool.executor(anyString()))
+                .thenReturn(OpenSearchExecutors.newDirectExecutorService());
         this.action =
                 new TransportLogtestDetectionAction(
-                        mock(TransportService.class), mock(ActionFilters.class), this.logtestService);
+                        mock(TransportService.class),
+                        mock(ActionFilters.class),
+                        this.threadPool,
+                        this.logtestService);
     }
 
     @SuppressWarnings("unchecked")

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestNormalizationActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportLogtestNormalizationActionTests.java
@@ -19,10 +19,12 @@ package com.wazuh.contentmanager.transport;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,6 +38,7 @@ import static org.mockito.Mockito.*;
 
 public class TransportLogtestNormalizationActionTests extends OpenSearchTestCase {
     private LogtestService logtestService;
+    private ThreadPool threadPool;
     private TransportLogtestNormalizationAction action;
 
     @Before
@@ -43,9 +46,16 @@ public class TransportLogtestNormalizationActionTests extends OpenSearchTestCase
     public void setUp() throws Exception {
         super.setUp();
         this.logtestService = mock(LogtestService.class);
+        this.threadPool = mock(ThreadPool.class);
+        // Execute submitted work synchronously so the existing assertions still observe the result.
+        when(this.threadPool.executor(anyString()))
+                .thenReturn(OpenSearchExecutors.newDirectExecutorService());
         this.action =
                 new TransportLogtestNormalizationAction(
-                        mock(TransportService.class), mock(ActionFilters.class), this.logtestService);
+                        mock(TransportService.class),
+                        mock(ActionFilters.class),
+                        this.threadPool,
+                        this.logtestService);
     }
 
     public void testDoExecute_Success() {


### PR DESCRIPTION
## Description

Logtest endpoint accepted up to 16 MB per call, amplified its input into the response, ran a blocking engine call inline on the transport thread, and had no queue or rate limit. 
As a result the lowest-privilege account in the product was able to produce a resource-exhaustion DoS

Root cause problem, two independent, multiplying levers: unbounded input size & unbounded concurrency
This PR closes both


## Proposed Changes

1. Add a size cap at the REST layer (413)
2. Create a new bounded thread pool (429) for logtest
3. Add logging when an error is produced

## Results and Evidence

| # | What was tested | Expected | Result |
|---|---|---|---|
| 1 | Oversized body (10 MB) on all 3 routes | 413, rejected before processing | ✅ 413, 93-byte response |
| 2 | Legitimate small event (178 B) | 200, reaches engine | ✅ 200 |
| 3 | Size boundary (exact 1 MiB) | ≤ limit 200, > limit 413 | ✅ cuts over at > 1048576 |
| 4 | 30× concurrent 10 MB flood + live traffic | attacker shed, no breaker trips, legit unaffected | ✅ 30×413, breaker delta 0, 0 legit failures |
| 5 | Error logging | WARN names the account | ✅ logged with user + size |

<details><summary>Tests </summary>
<p>

- Tests 1: Oversized body is rejected with 413 on all three routes 10 MB body

``` http
POST /_plugins/_content_manager/logtest               → HTTP 413
POST /_plugins/_content_manager/logtest/normalization → HTTP 413
POST /_plugins/_content_manager/logtest/detection     → HTTP 413

Response:
{"message":"logtest payload exceeds the maximum allowed size of 1048576 bytes.","status":413}
```

- Test 2: small events still works

```http
POST /_plugins/_content_manager/logtest
{
"integration": "943ff754-b4d5-5b56-8401-29900a823081",
"space": "standard",
"queue": 1,
"location": "/var/log/auth.log",
"event": "May 20 12:00:00 host sshd[1234]: Accepted publickey for user from 10.0.0.5 port 55000 ssh2",
"metadata": {},
"trace_level": "NONE"
}
{
...
  },
  "status": 200
}
```

- Tests 3: Size boundary is exact

| body size (bytes) | HTTP | note |
|---|---|---|
| 1 048 575 | 200 | below limit |
| 1 048 576 | 200 | equal to limit (check is `length > max`) |
| 1 048 577 | 413 | above limit → rejected |


- Test 4: Concurrency no longer trips the circuit breaker 

| Metric | This PR | Issue (pre-fix) |
|---|---|---|
| Attacker oversized calls | 30 × **413** | 200 + ~20 MB body each |
| Legitimate `_count` during flood | **1251 OK, 0 failed** | 429s observed |
| Parent circuit-breaker trips (before → after) | **0 → 0 (delta 0)** | delta 44 |

The attacker traffic is shed at the REST layer before it reaches the heap, and legitimate traffic is completely unaffected.

- Test 5: Rejections are attributable

``` console
[WARN][c.w.c.r.u.PayloadValidations] Rejected oversized logtest request: 10485840 bytes exceeds limit of 1048576 bytes, path [/_plugins/_content_manager/logtest], user [User [name=wazuh-readonly, backend_roles=[], requestedTenant=null]].
```

</p>
</details> 


## Artifacts Affected

- Content manager

## Configuration Changes

- New dynamic node setting `plugins.content_manager.logtest.max_body_bytes` 
- New thread pool `content_manager_logtest`

## Documentation Updates

- Added in b5d52ce6306b1c44a9244b4dbc7e2fa66501fa58, including OpenApi

## Tests Introduced

- `PayloadValidationsTests`: 413 above limit, null at/under limit, at-boundary, null-thread-context.
- `TransportLogtestActionTests`: added the 429 pool-rejection case; existing cases adapted to the
  injected `ThreadPool` (direct executor).
- `TransportLogtest{Normalization,Detection}ActionTests`: adapted to the injected `ThreadPool`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...