### PR TITLE
Retry sending resources to SAP after failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,7 @@
 - [BUG] Fix issues in workflows [(#1449)](https://github.com/wazuh/wazuh-indexer/issues/1449)
 - Failed to save/update ManagedIndexMetaData [(#1828)](https://github.com/wazuh/wazuh-indexer/issues/1828)
 - [BUG] `wazuh-threatintel-enrichments-a` is never created, so the CTI writer auto-creates a dynamically mapped index under the alias name and the home overview's Threat catalog fails [(#1476)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1476)
-- [BUG] SAP sync not retrying after failure [(#1487)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1487)
+- [BUG] Retry sending resources to SAP after failure [(#1487)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1487)
 
 ## Prior versions
 - []()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@
 - [BUG] Fix issues in workflows [(#1449)](https://github.com/wazuh/wazuh-indexer/issues/1449)
 - Failed to save/update ManagedIndexMetaData [(#1828)](https://github.com/wazuh/wazuh-indexer/issues/1828)
 - [BUG] `wazuh-threatintel-enrichments-a` is never created, so the CTI writer auto-creates a dynamically mapped index under the alias name and the home overview's Threat catalog fails [(#1476)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1476)
+- [BUG] SAP sync not retrying after failure [(#1487)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1487)
 
 ## Prior versions
 - []()

--- a/docs/ref/modules/content-manager/architecture.md
+++ b/docs/ref/modules/content-manager/architecture.md
@@ -255,7 +255,8 @@ The `.wazuh-cti-consumers` index stores one document per consumer type:
     "is_public": true,
     "status": "ready",
     "local_offset": 3932,
-    "remote_offset": 3932
+    "remote_offset": 3932,
+    "pending_sync_phases": []
   }
 }
 ```
@@ -269,3 +270,5 @@ The `status` field reflects the consumer's synchronization lifecycle:
 | `failed` | The previous sync cycle was interrupted by an unexpected exception. |
 
 The status is set to `running` at the very start of a sync cycle and transitions to `ready` after all post-sync work finishes — including hash recalculation, Security Analytics Plugin synchronization, and Engine IoC notification — or to `failed` if an unexpected exception interrupts the cycle. The job scheduler logs the failure and retries on the next scheduled run regardless of the consumer's status.
+
+For the ruleset consumer, `pending_sync_phases` lists which of `integrations`, `rules`, and `detectors` failed to sync to Security Analytics on the last pass and are retried on the next scheduled sync, even without new CTI content; an empty array means all sub-phases are in sync.

--- a/docs/ref/modules/content-manager/index.md
+++ b/docs/ref/modules/content-manager/index.md
@@ -105,7 +105,7 @@ The Content Manager uses the following system indices:
 
 | Index                                | Description                                                                                          |
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `.wazuh-cti-consumers`                | Synchronization state for each CTI consumer type (`type`, `resource`, `is_public`, offsets, status)   |
+| `.wazuh-cti-consumers`                | Synchronization state for each CTI consumer type (`type`, `resource`, `is_public`, offsets, status, pending sync phases) |
 | `.wazuh-internal-state`               | Persisted CTI access token (hidden, single document)                                                  |
 | `wazuh-threatintel-rules`             | Detection rules (both CTI-synced and user-generated, across all spaces)                               |
 | `wazuh-threatintel-decoders`          | Log decoders                                                                                           |

--- a/docs/ref/modules/content-manager/troubleshooting.md
+++ b/docs/ref/modules/content-manager/troubleshooting.md
@@ -148,7 +148,8 @@ Example output:
           "is_public": true,
           "status": "ready",
           "local_offset": 3932,
-          "remote_offset": 3932
+          "remote_offset": 3932,
+          "pending_sync_phases": []
         }
       }
     ]
@@ -162,6 +163,7 @@ Example output:
 - `local_offset == remote_offset`: Content is up-to-date.
 - `local_offset < remote_offset`: Content needs updating.
 - `local_offset == 0`: Content has never been synced (snapshot required).
+- `pending_sync_phases`: for the ruleset consumer, lists which of `integrations`, `rules`, and `detectors` failed to sync to Security Analytics and are retried on the next scheduled sync; empty means all sub-phases are in sync.
 
 ### Check sync job
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumer.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumer.java
@@ -26,6 +26,8 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Data Transfer Object representing the local state of a CTI Catalog Consumer.
@@ -82,6 +84,9 @@ public class LocalConsumer extends AbstractConsumer implements ToXContent {
 
     @JsonProperty("is_public")
     private boolean isPublic;
+
+    @JsonProperty("pending_sync_phases")
+    private List<String> pendingSyncPhases = Collections.emptyList();
 
     /** Default constructor. */
     public LocalConsumer() {
@@ -171,6 +176,41 @@ public class LocalConsumer extends AbstractConsumer implements ToXContent {
     }
 
     /**
+     * Constructs a LocalConsumer with full state details including explicit status and pending SAP
+     * sync phases.
+     *
+     * @param context The context identifier.
+     * @param name The consumer name.
+     * @param type The consumer type identifier.
+     * @param resource The full CTI consumer URL.
+     * @param isPublic Whether the consumer is public.
+     * @param status The current synchronization status.
+     * @param localOffset The current offset processed locally.
+     * @param remoteOffset The last known offset available remotely.
+     * @param pendingSyncPhases Names of SAP sync sub-phases still owed a retry.
+     */
+    public LocalConsumer(
+            String context,
+            String name,
+            String type,
+            String resource,
+            boolean isPublic,
+            Status status,
+            long localOffset,
+            long remoteOffset,
+            List<String> pendingSyncPhases) {
+        this.context = context;
+        this.name = name;
+        this.type = type;
+        this.resource = resource;
+        this.isPublic = isPublic;
+        this.status = status;
+        this.localOffset = localOffset;
+        this.remoteOffset = remoteOffset;
+        this.pendingSyncPhases = pendingSyncPhases != null ? pendingSyncPhases : Collections.emptyList();
+    }
+
+    /**
      * Gets the current synchronization status of the consumer.
      *
      * @return The {@link Status} indicating whether the consumer is ready, running, or failed.
@@ -210,6 +250,16 @@ public class LocalConsumer extends AbstractConsumer implements ToXContent {
     /** Returns true if the consumer is public. */
     public boolean isPublic() {
         return this.isPublic;
+    }
+
+    /**
+     * Gets the names of SAP sync sub-phases still owed a retry.
+     *
+     * @return The pending phase names (e.g. "integrations", "rules", "detectors"), or an empty list
+     *     if none are pending.
+     */
+    public List<String> getPendingSyncPhases() {
+        return this.pendingSyncPhases;
     }
 
     @Override
@@ -268,6 +318,7 @@ public class LocalConsumer extends AbstractConsumer implements ToXContent {
                 .field("status", this.status != null ? this.status.toString() : Status.READY.toString())
                 .field("local_offset", this.localOffset)
                 .field("remote_offset", this.remoteOffset)
+                .field("pending_sync_phases", this.pendingSyncPhases)
                 .endObject();
 
         return builder;

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumer.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumer.java
@@ -207,7 +207,8 @@ public class LocalConsumer extends AbstractConsumer implements ToXContent {
         this.status = status;
         this.localOffset = localOffset;
         this.remoteOffset = remoteOffset;
-        this.pendingSyncPhases = pendingSyncPhases != null ? pendingSyncPhases : Collections.emptyList();
+        this.pendingSyncPhases =
+                pendingSyncPhases != null ? pendingSyncPhases : Collections.emptyList();
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -253,11 +253,71 @@ public abstract class AbstractConsumerService {
                             current.isPublic(),
                             status,
                             current.getLocalOffset(),
-                            current.getRemoteOffset());
+                            current.getRemoteOffset(),
+                            current.getPendingSyncPhases());
             this.consumersIndex.setConsumer(updated);
             log.debug(Constants.D_LOG_CONSUMER_STATUS_SET, consumerType, status);
         } catch (Exception e) {
             log.warn(Constants.W_LOG_CONSUMER_STATUS_FAILED, consumerType, status, e.getMessage());
+        }
+    }
+
+    /**
+     * Reads the names of SAP sync sub-phases still owed a retry from the {@code
+     * .wazuh-cti-consumers} document, so a caller can re-attempt them on a pass that otherwise has
+     * nothing new to sync. Read failures and an absent document are treated as "nothing pending"
+     * rather than propagated, so a transient read error never permanently wedges a retry.
+     *
+     * @return The pending phase names, or an empty list if none are pending or the document is
+     *     absent/unreadable.
+     */
+    protected List<String> readPendingSyncPhases() {
+        String consumerType = this.getConsumerType();
+        try {
+            GetResponse response = this.consumersIndex.getConsumer(consumerType);
+            if (response == null || !response.isExists()) {
+                return Collections.emptyList();
+            }
+            LocalConsumer current = MAPPER.readValue(response.getSourceAsString(), LocalConsumer.class);
+            List<String> phases = current.getPendingSyncPhases();
+            return phases != null ? phases : Collections.emptyList();
+        } catch (Exception e) {
+            log.debug(Constants.D_LOG_CONSUMER_PENDING_PHASES_READ_FAILED, consumerType, e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Persists the names of SAP sync sub-phases still owed a retry to the {@code
+     * .wazuh-cti-consumers} document. This is a partial update: it preserves all identity fields,
+     * status and offsets, mutating only {@code pending_sync_phases}. When the consumer document does
+     * not yet exist, the call is a no-op since identity fields would not be derivable.
+     *
+     * @param phases The pending phase names to persist; an empty list clears all pending phases.
+     */
+    protected void setPendingSyncPhases(List<String> phases) {
+        String consumerType = this.getConsumerType();
+        try {
+            GetResponse response = this.consumersIndex.getConsumer(consumerType);
+            if (response == null || !response.isExists()) {
+                log.debug(Constants.D_LOG_CONSUMER_PENDING_PHASES_DOC_ABSENT, consumerType, phases);
+                return;
+            }
+            LocalConsumer current = MAPPER.readValue(response.getSourceAsString(), LocalConsumer.class);
+            LocalConsumer updated =
+                    new LocalConsumer(
+                            current.getContext(),
+                            current.getName(),
+                            current.getType(),
+                            current.getResource(),
+                            current.isPublic(),
+                            current.getStatus(),
+                            current.getLocalOffset(),
+                            current.getRemoteOffset(),
+                            phases);
+            this.consumersIndex.setConsumer(updated);
+        } catch (Exception e) {
+            log.warn(Constants.W_LOG_CONSUMER_PENDING_PHASES_FAILED, consumerType, e.getMessage());
         }
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -263,10 +263,10 @@ public abstract class AbstractConsumerService {
     }
 
     /**
-     * Reads the names of SAP sync sub-phases still owed a retry from the {@code
-     * .wazuh-cti-consumers} document, so a caller can re-attempt them on a pass that otherwise has
-     * nothing new to sync. Read failures and an absent document are treated as "nothing pending"
-     * rather than propagated, so a transient read error never permanently wedges a retry.
+     * Reads the names of SAP sync sub-phases still owed a retry from the {@code .wazuh-cti-consumers}
+     * document, so a caller can re-attempt them on a pass that otherwise has nothing new to sync.
+     * Read failures and an absent document are treated as "nothing pending" rather than propagated,
+     * so a transient read error never permanently wedges a retry.
      *
      * @return The pending phase names, or an empty list if none are pending or the document is
      *     absent/unreadable.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
@@ -56,6 +56,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
 
     private static final Logger log = LogManager.getLogger(ConsumerRulesetService.class);
     private static final String[] DOCUMENT_ONLY_SOURCE = new String[] {Constants.KEY_DOCUMENT};
+    private static final String PHASE_DETECTORS = "detectors";
     private final ObjectMapper mapper;
 
     private final SecurityAnalyticsService securityAnalyticsService;
@@ -165,6 +166,18 @@ public class ConsumerRulesetService extends AbstractConsumerService {
     public void onSyncComplete(boolean isUpdated) {
         this.initializeSpaces();
 
+        List<String> pendingPhases = this.readPendingSyncPhases();
+        boolean createDetectors = PluginSettings.getInstance().getCreateDetectors();
+
+        boolean shouldSyncIntegrations = isUpdated || pendingPhases.contains(Constants.KEY_INTEGRATIONS);
+        boolean shouldSyncRules = isUpdated || pendingPhases.contains(Constants.KEY_RULES);
+        boolean shouldSyncDetectors =
+                createDetectors && (isUpdated || pendingPhases.contains(PHASE_DETECTORS));
+
+        if (!shouldSyncIntegrations && !shouldSyncRules && !shouldSyncDetectors) {
+            return;
+        }
+
         if (isUpdated) {
             this.refreshIndices(
                     Constants.INDEX_RULES,
@@ -186,36 +199,64 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             } catch (IOException e) {
                 log.error(Constants.E_LOG_USER_OVERRIDES_REGISTRY_READ_FAILED, e.getMessage());
             }
+        }
 
-            // Sync Integrations
-            Map<String, JsonNode> integrationDocs = Collections.emptyMap();
+        List<String> stillPending = new ArrayList<>();
+
+        // Sync Integrations
+        Map<String, JsonNode> integrationDocs = Collections.emptyMap();
+        if (shouldSyncIntegrations) {
             try {
-                integrationDocs = this.syncIntegrations();
+                IntegrationsSyncResult result = this.syncIntegrations();
+                integrationDocs = result.docs();
+                if (!result.success()) {
+                    stillPending.add(Constants.KEY_INTEGRATIONS);
+                }
             } catch (Exception e) {
                 log.error(Constants.E_LOG_SAP_SYNC_FAILED, Constants.KEY_INTEGRATIONS, e.getMessage(), e);
+                stillPending.add(Constants.KEY_INTEGRATIONS);
             }
+        } else if (shouldSyncDetectors) {
+            // Detectors need the integration documents even though integrations itself isn't due
+            // for a retry this pass.
+            integrationDocs = this.readIntegrationDocs();
+        }
 
-            // Sync Rules
+        // Sync Rules
+        if (shouldSyncRules) {
             try {
-                this.syncRules();
+                if (!this.syncRules()) {
+                    stillPending.add(Constants.KEY_RULES);
+                }
             } catch (Exception e) {
                 log.error(Constants.E_LOG_SAP_SYNC_FAILED, Constants.KEY_RULES, e.getMessage(), e);
+                stillPending.add(Constants.KEY_RULES);
             }
+        }
 
-            // Sync Detectors (reuses integration docs already fetched above)
-            if (PluginSettings.getInstance().getCreateDetectors()) {
-                try {
-                    this.syncDetectors(integrationDocs);
-                } catch (Exception e) {
-                    log.error(Constants.E_LOG_SAP_SYNC_FAILED, "detectors", e.getMessage(), e);
+        // Sync Detectors (reuses integration docs already fetched above)
+        if (shouldSyncDetectors) {
+            try {
+                if (!this.syncDetectors(integrationDocs)) {
+                    stillPending.add(PHASE_DETECTORS);
                 }
+            } catch (Exception e) {
+                log.error(Constants.E_LOG_SAP_SYNC_FAILED, PHASE_DETECTORS, e.getMessage(), e);
+                stillPending.add(PHASE_DETECTORS);
             }
+        }
 
-            if (this.shadowSwapPerformed) {
-                this.deleteStaleResources();
-                this.shadowSwapPerformed = false;
-            }
+        this.setPendingSyncPhases(stillPending);
+        if (!stillPending.isEmpty()) {
+            log.error(Constants.E_LOG_SAP_SYNC_DEGRADED, this.getConsumerType(), stillPending);
+        }
 
+        if (this.shadowSwapPerformed) {
+            this.deleteStaleResources();
+            this.shadowSwapPerformed = false;
+        }
+
+        if (isUpdated) {
             // Reload STANDARD space, as it was updated.
             try {
                 this.<Set<String>>awaitResult(
@@ -267,13 +308,24 @@ public class ConsumerRulesetService extends AbstractConsumerService {
     }
 
     /**
-     * Synchronizes Integrations from the internal index to the Security Analytics Plugin. Uses
-     * parallel execution with a CountDownLatch to ensure all async requests complete.
+     * Result of {@link #syncIntegrations()}.
      *
-     * @return the extracted document nodes keyed by document ID, for reuse by {@link
+     * @param docs the extracted document nodes keyed by document ID, for reuse by {@link
      *     #syncDetectors(Map)}.
+     * @param success {@code true} if every integration was sent successfully (or there was nothing
+     *     to sync); {@code false} if the source index is missing or at least one item failed.
      */
-    private Map<String, JsonNode> syncIntegrations() {
+    private record IntegrationsSyncResult(Map<String, JsonNode> docs, boolean success) {}
+
+    /**
+     * Reads the Integrations from the internal index, without sending anything to Security
+     * Analytics. Used both by {@link #syncIntegrations()} and, on its own, by {@link
+     * #onSyncComplete(boolean)} when detectors need the integration documents but integrations
+     * itself is not due for a retry this pass.
+     *
+     * @return the extracted document nodes keyed by document ID.
+     */
+    private Map<String, JsonNode> readIntegrationDocs() {
         Map<String, JsonNode> docs = new LinkedHashMap<>();
 
         if (this.indexIsMissing(Constants.INDEX_INTEGRATIONS)) {
@@ -299,11 +351,28 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                             docs.put(id, doc);
                         }
                     });
+        } catch (Exception e) {
+            log.error(Constants.E_LOG_SAP_SYNC_UNEXPECTED, "integrations", e.getMessage());
+        }
+        return docs;
+    }
 
-            if (docs.isEmpty()) {
-                return docs;
-            }
+    /**
+     * Synchronizes Integrations from the internal index to the Security Analytics Plugin. Uses
+     * parallel execution with a CountDownLatch to ensure all async requests complete.
+     *
+     * @return the extracted document nodes and whether every one of them was sent successfully.
+     */
+    private IntegrationsSyncResult syncIntegrations() {
+        Map<String, JsonNode> docs = this.readIntegrationDocs();
+        if (docs.isEmpty()) {
+            // Empty means either "nothing to sync" (success) or "index missing", which
+            // readIntegrationDocs() already logged; distinguish them without a second log line.
+            return new IntegrationsSyncResult(docs, !this.indexIsMissing(Constants.INDEX_INTEGRATIONS));
+        }
 
+        boolean success = true;
+        try {
             CountDownLatch latch = new CountDownLatch(docs.size());
             AtomicInteger sent = new AtomicInteger();
             List<String> failed = Collections.synchronizedList(new ArrayList<>());
@@ -328,36 +397,39 @@ public class ConsumerRulesetService extends AbstractConsumerService {
 
             if (!latch.await(60, TimeUnit.SECONDS)) {
                 log.warn(Constants.W_LOG_SAP_SYNC_TIMEOUT, "integrations");
+                success = false;
             }
             if (sent.get() > 0) {
                 log.info(
-                        Constants.I_LOG_SAP_SUMMARY,
-                        sent.get(),
-                        integrations.size(),
-                        "integrations",
-                        Space.STANDARD);
+                        Constants.I_LOG_SAP_SUMMARY, sent.get(), docs.size(), "integrations", Space.STANDARD);
             }
             if (!failed.isEmpty()) {
-                log.warn(
+                log.error(
                         Constants.W_LOG_SAP_PARTIAL, failed.size(), "integrations", Space.STANDARD, failed);
+                success = false;
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error(Constants.E_LOG_SAP_SYNC_INTERRUPTED, "integrations", e.getMessage());
+            success = false;
         } catch (Exception e) {
             log.error(Constants.E_LOG_SAP_SYNC_UNEXPECTED, "integrations", e.getMessage());
+            success = false;
         }
-        return docs;
+        return new IntegrationsSyncResult(docs, success);
     }
 
     /**
      * Synchronizes Rules from the internal index to the Security Analytics Plugin. Supports both
      * Standard and Custom rules.
+     *
+     * @return {@code true} if every rule was sent successfully (or there was nothing to sync);
+     *     {@code false} if the source index is missing or at least one item failed.
      */
-    private void syncRules() {
+    private boolean syncRules() {
         if (this.indexIsMissing(Constants.INDEX_RULES)) {
             log.error(Constants.E_LOG_SAP_INDEX_MISSING, "Rules", "rules");
-            return;
+            return false;
         }
 
         try {
@@ -368,7 +440,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                                             Constants.INDEX_RULES, Space.STANDARD, DOCUMENT_ONLY_SOURCE, l));
             if (rules.isEmpty()) {
                 log.debug(Constants.D_LOG_SAP_NOTHING_TO_SYNC, "rules");
-                return;
+                return true;
             }
 
             Map<String, JsonNode> docs = new LinkedHashMap<>();
@@ -381,7 +453,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                     });
 
             if (docs.isEmpty()) {
-                return;
+                return true;
             }
 
             CountDownLatch latch = new CountDownLatch(docs.size());
@@ -406,20 +478,26 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                                         }));
                     });
 
+            boolean success = true;
             if (!latch.await(60, TimeUnit.SECONDS)) {
                 log.warn(Constants.W_LOG_SAP_SYNC_TIMEOUT, "rules");
+                success = false;
             }
             if (sent.get() > 0) {
-                log.info(Constants.I_LOG_SAP_SUMMARY, sent.get(), rules.size(), "rules", Space.STANDARD);
+                log.info(Constants.I_LOG_SAP_SUMMARY, sent.get(), docs.size(), "rules", Space.STANDARD);
             }
             if (!failed.isEmpty()) {
-                log.warn(Constants.W_LOG_SAP_PARTIAL, failed.size(), "rules", Space.STANDARD, failed);
+                log.error(Constants.W_LOG_SAP_PARTIAL, failed.size(), "rules", Space.STANDARD, failed);
+                success = false;
             }
+            return success;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error(Constants.E_LOG_SAP_SYNC_INTERRUPTED, "rules", e.getMessage());
+            return false;
         } catch (Exception e) {
             log.error(Constants.E_LOG_SAP_SYNC_UNEXPECTED, "rules", e.getMessage());
+            return false;
         }
     }
 
@@ -429,11 +507,13 @@ public class ConsumerRulesetService extends AbstractConsumerService {
      * created in parallel.
      *
      * @param integrationDocs the integration document nodes already extracted by {@link
-     *     #syncIntegrations()}, keyed by document ID.
+     *     #syncIntegrations()} (or {@link #readIntegrationDocs()}), keyed by document ID.
+     * @return {@code true} if every detector was sent successfully (or there was nothing to sync);
+     *     {@code false} if required source indices are missing or at least one item failed.
      */
-    private void syncDetectors(Map<String, JsonNode> integrationDocs) throws IOException {
+    private boolean syncDetectors(Map<String, JsonNode> integrationDocs) {
         if (!(this.securityAnalyticsService instanceof SecurityAnalyticsServiceImpl sapService)) {
-            return;
+            return true;
         }
         // One read for every detector: the user's decisions live in a single registry document.
         Map<String, Boolean> detectorOverrides = new HashMap<>();
@@ -464,7 +544,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                 });
 
         if (docs.isEmpty()) {
-            return;
+            return true;
         }
 
         // detectors reference the wazuh-events-v5-* data streams as source indices, and Security
@@ -474,7 +554,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             log.error(
                     "Skipping detectors sync. Required source indices not found: {}",
                     String.join(", ", missingIndices));
-            return;
+            return false;
         }
 
         log.debug(Constants.D_LOG_SAP_DETECTORS_SYNCING, docs.size(), 1, docs.size() - 1);
@@ -509,15 +589,16 @@ public class ConsumerRulesetService extends AbstractConsumerService {
         try {
             if (!firstLatch.await(30, TimeUnit.SECONDS)) {
                 log.warn(Constants.W_LOG_SAP_SYNC_TIMEOUT, "detectors");
-                return;
+                return false;
             }
         } catch (InterruptedException e) {
             log.error(Constants.E_LOG_DETECTOR_WAIT_INTERRUPTED, e);
             Thread.currentThread().interrupt();
-            return;
+            return false;
         }
 
         // Process remaining detectors in parallel
+        boolean timedOut = false;
         if (docs.size() > 1) {
             CountDownLatch parallelLatch = new CountDownLatch(docs.size() - 1);
             for (int i = 1; i < docs.size(); i++) {
@@ -547,10 +628,12 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             try {
                 if (!parallelLatch.await(60, TimeUnit.SECONDS)) {
                     log.warn(Constants.W_LOG_SAP_SYNC_TIMEOUT, "detectors");
+                    timedOut = true;
                 }
             } catch (InterruptedException e) {
                 log.error(Constants.E_LOG_DETECTOR_WAIT_INTERRUPTED, e);
                 Thread.currentThread().interrupt();
+                timedOut = true;
             }
         }
 
@@ -560,8 +643,9 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             log.info(Constants.I_LOG_SAP_SUMMARY, sent.get(), docs.size(), "detectors", Space.STANDARD);
         }
         if (!failed.isEmpty()) {
-            log.warn(Constants.W_LOG_SAP_PARTIAL, failed.size(), "detectors", Space.STANDARD, failed);
+            log.error(Constants.W_LOG_SAP_PARTIAL, failed.size(), "detectors", Space.STANDARD, failed);
         }
+        return !timedOut && failed.isEmpty();
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetService.java
@@ -56,7 +56,15 @@ public class ConsumerRulesetService extends AbstractConsumerService {
 
     private static final Logger log = LogManager.getLogger(ConsumerRulesetService.class);
     private static final String[] DOCUMENT_ONLY_SOURCE = new String[] {Constants.KEY_DOCUMENT};
+
+    // Names of the SAP sync sub-phases that can independently fail and be retried on a later pass.
+    // These are a persisted contract: they are stored in the pending_sync_phases field of the
+    // .wazuh-cti-consumers document, so they are kept separate from the identically-spelled
+    // Constants.KEY_* resource keys, which name REST payload fields and may evolve on their own.
+    private static final String PHASE_INTEGRATIONS = "integrations";
+    private static final String PHASE_RULES = "rules";
     private static final String PHASE_DETECTORS = "detectors";
+
     private final ObjectMapper mapper;
 
     private final SecurityAnalyticsService securityAnalyticsService;
@@ -169,12 +177,19 @@ public class ConsumerRulesetService extends AbstractConsumerService {
         List<String> pendingPhases = this.readPendingSyncPhases();
         boolean createDetectors = PluginSettings.getInstance().getCreateDetectors();
 
-        boolean shouldSyncIntegrations = isUpdated || pendingPhases.contains(Constants.KEY_INTEGRATIONS);
-        boolean shouldSyncRules = isUpdated || pendingPhases.contains(Constants.KEY_RULES);
+        boolean shouldSyncIntegrations = isUpdated || pendingPhases.contains(PHASE_INTEGRATIONS);
+        boolean shouldSyncRules = isUpdated || pendingPhases.contains(PHASE_RULES);
         boolean shouldSyncDetectors =
                 createDetectors && (isUpdated || pendingPhases.contains(PHASE_DETECTORS));
 
         if (!shouldSyncIntegrations && !shouldSyncRules && !shouldSyncDetectors) {
+            // Reaching this point with "detectors" still pending means detector creation is disabled,
+            // so the phase can never be retried: drop it rather than re-reading it on every pass
+            // forever. Every other path rebuilds the pending list from scratch below.
+            if (pendingPhases.contains(PHASE_DETECTORS)) {
+                this.setPendingSyncPhases(
+                        pendingPhases.stream().filter(phase -> !PHASE_DETECTORS.equals(phase)).toList());
+            }
             return;
         }
 
@@ -203,50 +218,67 @@ public class ConsumerRulesetService extends AbstractConsumerService {
 
         List<String> stillPending = new ArrayList<>();
 
-        // Sync Integrations
+        // Integrations and detectors are both built from the integration documents, so read them
+        // once for whichever of the two phases is due this pass.
         Map<String, JsonNode> integrationDocs = Collections.emptyMap();
+        boolean integrationDocsRead = false;
+        if (shouldSyncIntegrations || shouldSyncDetectors) {
+            IntegrationDocsResult read = this.readIntegrationDocs();
+            integrationDocs = read.docs();
+            integrationDocsRead = read.ok();
+        }
+
+        // Sync Integrations
         if (shouldSyncIntegrations) {
             try {
-                IntegrationsSyncResult result = this.syncIntegrations();
-                integrationDocs = result.docs();
-                if (!result.success()) {
-                    stillPending.add(Constants.KEY_INTEGRATIONS);
+                if (!integrationDocsRead || !this.pushIntegrations(integrationDocs)) {
+                    stillPending.add(PHASE_INTEGRATIONS);
                 }
             } catch (Exception e) {
-                log.error(Constants.E_LOG_SAP_SYNC_FAILED, Constants.KEY_INTEGRATIONS, e.getMessage(), e);
-                stillPending.add(Constants.KEY_INTEGRATIONS);
+                log.error(Constants.E_LOG_SAP_SYNC_FAILED, PHASE_INTEGRATIONS, e.getMessage(), e);
+                stillPending.add(PHASE_INTEGRATIONS);
             }
-        } else if (shouldSyncDetectors) {
-            // Detectors need the integration documents even though integrations itself isn't due
-            // for a retry this pass.
-            integrationDocs = this.readIntegrationDocs();
         }
 
         // Sync Rules
         if (shouldSyncRules) {
             try {
                 if (!this.syncRules()) {
-                    stillPending.add(Constants.KEY_RULES);
+                    stillPending.add(PHASE_RULES);
                 }
             } catch (Exception e) {
-                log.error(Constants.E_LOG_SAP_SYNC_FAILED, Constants.KEY_RULES, e.getMessage(), e);
-                stillPending.add(Constants.KEY_RULES);
+                log.error(Constants.E_LOG_SAP_SYNC_FAILED, PHASE_RULES, e.getMessage(), e);
+                stillPending.add(PHASE_RULES);
             }
         }
 
-        // Sync Detectors (reuses integration docs already fetched above)
+        // Sync Detectors (reuses the integration docs already read above)
         if (shouldSyncDetectors) {
-            try {
-                if (!this.syncDetectors(integrationDocs)) {
+            if (!integrationDocsRead) {
+                // syncDetectors() cannot tell an empty map apart from "no detectors to create", so
+                // it would report success and this phase would be cleared without having created
+                // anything. readIntegrationDocs() already logged why the read failed.
+                log.debug(Constants.D_LOG_SAP_DETECTORS_NO_INTEGRATIONS);
+                stillPending.add(PHASE_DETECTORS);
+            } else {
+                try {
+                    if (!this.syncDetectors(integrationDocs)) {
+                        stillPending.add(PHASE_DETECTORS);
+                    }
+                } catch (Exception e) {
+                    log.error(Constants.E_LOG_SAP_SYNC_FAILED, PHASE_DETECTORS, e.getMessage(), e);
                     stillPending.add(PHASE_DETECTORS);
                 }
-            } catch (Exception e) {
-                log.error(Constants.E_LOG_SAP_SYNC_FAILED, PHASE_DETECTORS, e.getMessage(), e);
-                stillPending.add(PHASE_DETECTORS);
             }
         }
 
-        this.setPendingSyncPhases(stillPending);
+        // Only write when the set of pending phases actually changed. Persisting it costs a cluster
+        // health check plus an immediate-refresh index request, and both the healthy case (nothing
+        // pending before or after) and a permanently degraded one (the same phases failing every
+        // pass) would otherwise pay that on every scheduled sync.
+        if (!stillPending.equals(pendingPhases)) {
+            this.setPendingSyncPhases(stillPending);
+        }
         if (!stillPending.isEmpty()) {
             log.error(Constants.E_LOG_SAP_SYNC_DEGRADED, this.getConsumerType(), stillPending);
         }
@@ -308,29 +340,30 @@ public class ConsumerRulesetService extends AbstractConsumerService {
     }
 
     /**
-     * Result of {@link #syncIntegrations()}.
+     * Result of {@link #readIntegrationDocs()}.
      *
-     * @param docs the extracted document nodes keyed by document ID, for reuse by {@link
-     *     #syncDetectors(Map)}.
-     * @param success {@code true} if every integration was sent successfully (or there was nothing
-     *     to sync); {@code false} if the source index is missing or at least one item failed.
+     * @param docs the extracted document nodes keyed by document ID, for use by {@link
+     *     #pushIntegrations(Map)} and {@link #syncDetectors(Map)}.
+     * @param ok {@code true} if the read completed, including when it legitimately found nothing to
+     *     sync; {@code false} if the source index is missing or the read itself failed. Callers must
+     *     not treat an empty {@code docs} as "nothing to sync" without checking this flag, or a
+     *     failed read would mark the phase as done without anything having been sent.
      */
-    private record IntegrationsSyncResult(Map<String, JsonNode> docs, boolean success) {}
+    private record IntegrationDocsResult(Map<String, JsonNode> docs, boolean ok) {}
 
     /**
-     * Reads the Integrations from the internal index, without sending anything to Security
-     * Analytics. Used both by {@link #syncIntegrations()} and, on its own, by {@link
-     * #onSyncComplete(boolean)} when detectors need the integration documents but integrations
-     * itself is not due for a retry this pass.
+     * Reads the Integrations from the internal index, without sending anything to Security Analytics.
+     * Both the integrations phase and the detectors phase are built from these documents, so {@link
+     * #onSyncComplete(boolean)} reads them once per pass.
      *
-     * @return the extracted document nodes keyed by document ID.
+     * @return the extracted document nodes and whether the read completed.
      */
-    private Map<String, JsonNode> readIntegrationDocs() {
+    private IntegrationDocsResult readIntegrationDocs() {
         Map<String, JsonNode> docs = new LinkedHashMap<>();
 
         if (this.indexIsMissing(Constants.INDEX_INTEGRATIONS)) {
             log.error(Constants.E_LOG_SAP_INDEX_MISSING, "Integrations", "integrations");
-            return docs;
+            return new IntegrationDocsResult(docs, false);
         }
 
         try {
@@ -341,7 +374,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                                             Constants.INDEX_INTEGRATIONS, Space.STANDARD, DOCUMENT_ONLY_SOURCE, l));
             if (integrations.isEmpty()) {
                 log.debug(Constants.D_LOG_SAP_NOTHING_TO_SYNC, "integrations");
-                return docs;
+                return new IntegrationDocsResult(docs, true);
             }
 
             integrations.forEach(
@@ -353,22 +386,24 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                     });
         } catch (Exception e) {
             log.error(Constants.E_LOG_SAP_SYNC_UNEXPECTED, "integrations", e.getMessage());
+            return new IntegrationDocsResult(docs, false);
         }
-        return docs;
+        return new IntegrationDocsResult(docs, true);
     }
 
     /**
-     * Synchronizes Integrations from the internal index to the Security Analytics Plugin. Uses
-     * parallel execution with a CountDownLatch to ensure all async requests complete.
+     * Sends already-read Integrations to the Security Analytics Plugin. Uses parallel execution with
+     * a CountDownLatch to ensure all async requests complete.
      *
-     * @return the extracted document nodes and whether every one of them was sent successfully.
+     * @param docs the integration document nodes to send, keyed by document ID, as read by {@link
+     *     #readIntegrationDocs()}.
+     * @return {@code true} if every integration was sent successfully, or there was nothing to send;
+     *     {@code false} if at least one item failed, the wait timed out or the thread was
+     *     interrupted.
      */
-    private IntegrationsSyncResult syncIntegrations() {
-        Map<String, JsonNode> docs = this.readIntegrationDocs();
+    private boolean pushIntegrations(Map<String, JsonNode> docs) {
         if (docs.isEmpty()) {
-            // Empty means either "nothing to sync" (success) or "index missing", which
-            // readIntegrationDocs() already logged; distinguish them without a second log line.
-            return new IntegrationsSyncResult(docs, !this.indexIsMissing(Constants.INDEX_INTEGRATIONS));
+            return true;
         }
 
         boolean success = true;
@@ -405,7 +440,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             }
             if (!failed.isEmpty()) {
                 log.error(
-                        Constants.W_LOG_SAP_PARTIAL, failed.size(), "integrations", Space.STANDARD, failed);
+                        Constants.E_LOG_SAP_PARTIAL, failed.size(), "integrations", Space.STANDARD, failed);
                 success = false;
             }
         } catch (InterruptedException e) {
@@ -416,15 +451,15 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             log.error(Constants.E_LOG_SAP_SYNC_UNEXPECTED, "integrations", e.getMessage());
             success = false;
         }
-        return new IntegrationsSyncResult(docs, success);
+        return success;
     }
 
     /**
      * Synchronizes Rules from the internal index to the Security Analytics Plugin. Supports both
      * Standard and Custom rules.
      *
-     * @return {@code true} if every rule was sent successfully (or there was nothing to sync);
-     *     {@code false} if the source index is missing or at least one item failed.
+     * @return {@code true} if every rule was sent successfully (or there was nothing to sync); {@code
+     *     false} if the source index is missing or at least one item failed.
      */
     private boolean syncRules() {
         if (this.indexIsMissing(Constants.INDEX_RULES)) {
@@ -487,7 +522,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
                 log.info(Constants.I_LOG_SAP_SUMMARY, sent.get(), docs.size(), "rules", Space.STANDARD);
             }
             if (!failed.isEmpty()) {
-                log.error(Constants.W_LOG_SAP_PARTIAL, failed.size(), "rules", Space.STANDARD, failed);
+                log.error(Constants.E_LOG_SAP_PARTIAL, failed.size(), "rules", Space.STANDARD, failed);
                 success = false;
             }
             return success;
@@ -507,7 +542,9 @@ public class ConsumerRulesetService extends AbstractConsumerService {
      * created in parallel.
      *
      * @param integrationDocs the integration document nodes already extracted by {@link
-     *     #syncIntegrations()} (or {@link #readIntegrationDocs()}), keyed by document ID.
+     *     #readIntegrationDocs()}, keyed by document ID. Callers must only pass the documents of a
+     *     read that completed: an empty map is reported as success ("no detectors to create"), so a
+     *     failed read would silently look like a successful sync.
      * @return {@code true} if every detector was sent successfully (or there was nothing to sync);
      *     {@code false} if required source indices are missing or at least one item failed.
      */
@@ -643,7 +680,7 @@ public class ConsumerRulesetService extends AbstractConsumerService {
             log.info(Constants.I_LOG_SAP_SUMMARY, sent.get(), docs.size(), "detectors", Space.STANDARD);
         }
         if (!failed.isEmpty()) {
-            log.error(Constants.W_LOG_SAP_PARTIAL, failed.size(), "detectors", Space.STANDARD, failed);
+            log.error(Constants.E_LOG_SAP_PARTIAL, failed.size(), "detectors", Space.STANDARD, failed);
         }
         return !timedOut && failed.isEmpty();
     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SnapshotServiceImpl.java
@@ -448,9 +448,10 @@ public class SnapshotServiceImpl implements SnapshotService {
 
     /**
      * Reads the existing consumer document and persists it back with only {@code local_offset}
-     * mutated. All other fields (identity, {@code is_public}, {@code status}, {@code remote_offset})
-     * are preserved. Returns {@code false} and logs a warning if no document exists — the t0 write in
-     * {@link AbstractConsumerService} is expected to create it before this method runs.
+     * mutated. All other fields (identity, {@code is_public}, {@code status}, {@code remote_offset},
+     * {@code pending_sync_phases}) are preserved. Returns {@code false} and logs a warning if no
+     * document exists — the t0 write in {@link AbstractConsumerService} is expected to create it
+     * before this method runs.
      */
     private boolean updateLocalOffset(long newLocalOffset) {
         try {
@@ -470,7 +471,8 @@ public class SnapshotServiceImpl implements SnapshotService {
                             current.isPublic(),
                             current.getStatus() != null ? current.getStatus() : LocalConsumer.Status.RUNNING,
                             newLocalOffset,
-                            current.getRemoteOffset());
+                            current.getRemoteOffset(),
+                            current.getPendingSyncPhases());
             this.consumersIndex.setConsumer(updatedConsumer);
             return true;
         } catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/UpdateServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/UpdateServiceImpl.java
@@ -116,6 +116,7 @@ public class UpdateServiceImpl extends AbstractService implements UpdateService 
             String effectiveType = this.firstNonBlank(current.getType(), this.consumerType);
             String effectiveResource = this.firstNonBlank(current.getResource(), this.consumerUri);
             boolean effectiveIsPublic = current.isPublic();
+            List<String> effectivePendingSyncPhases = current.getPendingSyncPhases();
 
             long currentFromOffset = fromOffset;
             long lastAppliedOffset = fromOffset;
@@ -179,7 +180,8 @@ public class UpdateServiceImpl extends AbstractService implements UpdateService 
                                 effectiveName,
                                 effectiveType,
                                 effectiveResource,
-                                effectiveIsPublic);
+                                effectiveIsPublic,
+                                effectivePendingSyncPhases);
                         throw e;
                     }
                 }
@@ -197,7 +199,8 @@ public class UpdateServiceImpl extends AbstractService implements UpdateService 
                                 effectiveName,
                                 effectiveType,
                                 effectiveResource,
-                                effectiveIsPublic);
+                                effectiveIsPublic,
+                                effectivePendingSyncPhases);
                         throw e;
                     }
                 }
@@ -214,7 +217,8 @@ public class UpdateServiceImpl extends AbstractService implements UpdateService 
                                 effectiveIsPublic,
                                 LocalConsumer.Status.RUNNING,
                                 lastAppliedOffset,
-                                toOffset),
+                                toOffset,
+                                effectivePendingSyncPhases),
                         true);
 
                 batchCount++;
@@ -361,7 +365,8 @@ public class UpdateServiceImpl extends AbstractService implements UpdateService 
             String effectiveName,
             String effectiveType,
             String effectiveResource,
-            boolean effectiveIsPublic) {
+            boolean effectiveIsPublic,
+            List<String> effectivePendingSyncPhases) {
         if (lastAppliedOffset > fromOffset) {
             try {
                 this.consumersIndex.setConsumer(
@@ -373,7 +378,8 @@ public class UpdateServiceImpl extends AbstractService implements UpdateService 
                                 effectiveIsPublic,
                                 LocalConsumer.Status.RUNNING,
                                 lastAppliedOffset,
-                                toOffset),
+                                toOffset,
+                                effectivePendingSyncPhases),
                         true);
             } catch (Exception ce) {
                 log.error(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -159,6 +159,12 @@ public class Constants {
     public static final String D_LOG_CONSUMER_STATUS_SET = "Consumer [{}] status set to [{}]";
     public static final String W_LOG_CONSUMER_STATUS_FAILED =
             "Failed to set consumer [{}] status to [{}]: {}";
+    public static final String D_LOG_CONSUMER_PENDING_PHASES_DOC_ABSENT =
+            "Consumer [{}] doc not present; skipping pending sync phases update to {}";
+    public static final String D_LOG_CONSUMER_PENDING_PHASES_READ_FAILED =
+            "Could not read pending sync phases for [{}]: {}";
+    public static final String W_LOG_CONSUMER_PENDING_PHASES_FAILED =
+            "Failed to persist pending sync phases for [{}]: {}";
     public static final String D_LOG_CONSUMER_RESOURCE_READ_FAILED =
             "Could not read existing consumer resource for [{}]: {}";
     public static final String D_LOG_CONSUMER_T0_WRITTEN =
@@ -338,6 +344,9 @@ public class Constants {
             "Interrupted while waiting for detector sync to complete.";
     public static final String W_LOG_HIT_MISSING_DOCUMENT =
             "Hit [{}] missing 'document' field, skipping";
+    public static final String E_LOG_SAP_SYNC_DEGRADED =
+            "Security Analytics content sync degraded for consumer [{}]: phase(s) {} still pending; "
+                    + "will retry on the next scheduled sync pass.";
 
     // Log messages - snapshot / update / IOC (SnapshotServiceImpl, UpdateServiceImpl,
     // ConsumerIocService)

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -142,7 +142,7 @@ public class Constants {
             "Sending delete request for {} to Security Analytics (document.id={}{}).";
     public static final String I_LOG_SAP_SUMMARY =
             "Sent {} of {} {} to Security Analytics for space [{}].";
-    public static final String W_LOG_SAP_PARTIAL =
+    public static final String E_LOG_SAP_PARTIAL =
             "{} {} could not be sent to Security Analytics for space [{}]: {}";
     public static final String I_LOG_ACCESS_TOKEN_REMOVED =
             "Access token removed successfully. Environment is now unregistered.";
@@ -340,6 +340,8 @@ public class Constants {
             "Unexpected error sending {} to the Security Analytics plugin: {}";
     public static final String D_LOG_SAP_DETECTORS_SYNCING =
             "Syncing {} detectors ({} sequentially, {} in parallel)";
+    public static final String D_LOG_SAP_DETECTORS_NO_INTEGRATIONS =
+            "Integration documents could not be read; keeping the detectors phase pending.";
     public static final String E_LOG_DETECTOR_WAIT_INTERRUPTED =
             "Interrupted while waiting for detector sync to complete.";
     public static final String W_LOG_HIT_MISSING_DOCUMENT =

--- a/plugins/content-manager/src/main/resources/mappings/consumers-mapping.json
+++ b/plugins/content-manager/src/main/resources/mappings/consumers-mapping.json
@@ -23,6 +23,9 @@
     },
     "remote_offset": {
       "type": "long"
+    },
+    "pending_sync_phases": {
+      "type": "keyword"
     }
   }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumerTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumerTests.java
@@ -175,7 +175,9 @@ public class LocalConsumerTests extends OpenSearchTestCase {
         Assert.assertEquals(List.of("detectors"), consumer.getPendingSyncPhases());
     }
 
-    /** Tests that documents without a pending_sync_phases field (legacy) deserialize to an empty list. */
+    /**
+     * Tests that documents without a pending_sync_phases field (legacy) deserialize to an empty list.
+     */
     public void testLegacyDocumentWithoutPendingSyncPhasesDefaultsEmpty() throws Exception {
         String json =
                 "{\"name\":\"name\",\"context\":\"ctx\","

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumerTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/model/LocalConsumerTests.java
@@ -22,6 +22,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 import org.junit.Assert;
 
+import java.util.List;
+
 /** Unit tests for the {@link LocalConsumer} class. */
 public class LocalConsumerTests extends OpenSearchTestCase {
 
@@ -121,5 +123,68 @@ public class LocalConsumerTests extends OpenSearchTestCase {
                         + "\"local_offset\":0,\"remote_offset\":0}";
         LocalConsumer consumer = this.mapper.readValue(json, LocalConsumer.class);
         Assert.assertEquals(LocalConsumer.Status.FAILED, consumer.getStatus());
+    }
+
+    /** Tests that pendingSyncPhases defaults to an empty list on the offsets/status constructor. */
+    public void testPendingSyncPhasesDefaultsEmpty() {
+        LocalConsumer consumer =
+                new LocalConsumer(
+                        "ctx",
+                        "name",
+                        "cti:catalog:consumer:ruleset",
+                        "https://cti/rules",
+                        true,
+                        LocalConsumer.Status.RUNNING,
+                        10L,
+                        20L);
+        Assert.assertTrue(consumer.getPendingSyncPhases().isEmpty());
+    }
+
+    /** Tests that toXContent serializes the pending_sync_phases field. */
+    public void testToXContentIncludesPendingSyncPhases() throws Exception {
+        LocalConsumer consumer =
+                new LocalConsumer(
+                        "ctx",
+                        "name",
+                        "cti:catalog:consumer:ruleset",
+                        "https://cti/rules",
+                        true,
+                        LocalConsumer.Status.RUNNING,
+                        5L,
+                        10L,
+                        List.of("integrations", "detectors"));
+        XContentBuilder builder = consumer.toXContent();
+        String json = builder.toString();
+
+        Assert.assertTrue(
+                "pending_sync_phases field must be present in serialized output",
+                json.contains("\"pending_sync_phases\""));
+        Assert.assertTrue(json.contains("\"integrations\""));
+        Assert.assertTrue(json.contains("\"detectors\""));
+    }
+
+    /** Tests that the pending_sync_phases field round-trips through JSON deserialization. */
+    public void testPendingSyncPhasesDeserializesFromJson() throws Exception {
+        String json =
+                "{\"name\":\"name\",\"context\":\"ctx\",\"status\":\"ready\","
+                        + "\"type\":\"cti:catalog:consumer:ruleset\","
+                        + "\"resource\":\"https://cti/rules\",\"is_public\":true,"
+                        + "\"local_offset\":0,\"remote_offset\":0,"
+                        + "\"pending_sync_phases\":[\"detectors\"]}";
+        LocalConsumer consumer = this.mapper.readValue(json, LocalConsumer.class);
+        Assert.assertEquals(List.of("detectors"), consumer.getPendingSyncPhases());
+    }
+
+    /** Tests that documents without a pending_sync_phases field (legacy) deserialize to an empty list. */
+    public void testLegacyDocumentWithoutPendingSyncPhasesDefaultsEmpty() throws Exception {
+        String json =
+                "{\"name\":\"name\",\"context\":\"ctx\","
+                        + "\"type\":\"cti:catalog:consumer:iocs\","
+                        + "\"resource\":\"https://cti/iocs\",\"is_public\":true,"
+                        + "\"local_offset\":5,\"remote_offset\":10}";
+        LocalConsumer consumer = this.mapper.readValue(json, LocalConsumer.class);
+        Assert.assertTrue(
+                "pending_sync_phases should default to empty for legacy documents",
+                consumer.getPendingSyncPhases().isEmpty());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
@@ -107,7 +107,9 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         // it the same way so isUpdated=true tests don't block either.
         doAnswer(
                         invocation -> {
-                            invocation.<ActionListener<Set<String>>>getArgument(1).onResponse(Collections.emptySet());
+                            invocation
+                                    .<ActionListener<Set<String>>>getArgument(1)
+                                    .onResponse(Collections.emptySet());
                             return null;
                         })
                 .when(this.spaceService)
@@ -140,8 +142,9 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     /**
      * Stubs {@code client.admin().indices().resolveIndex(...)} so {@code indexIsMissing(name)}
      * returns {@code true} only for names accepted by {@code missing}. Same
-     * AdminClient/IndicesAdminClient wiring as {@link #testMissingSourceIndices_dataStreamResolved_returnsOnlyMissingOnes},
-     * generalized to answer for any index name instead of a fixed pair.
+     * AdminClient/IndicesAdminClient wiring as {@link
+     * #testMissingSourceIndices_dataStreamResolved_returnsOnlyMissingOnes}, generalized to answer for
+     * any index name instead of a fixed pair.
      */
     @SuppressWarnings("unchecked")
     private void mockIndexResolution(Predicate<String> missing) throws Exception {
@@ -166,7 +169,8 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
                             ResolveIndexAction.Response response = mock(ResolveIndexAction.Response.class);
                             boolean isMissing = missing.test(indexName);
                             when(response.getIndices())
-                                    .thenReturn(isMissing ? Collections.emptyList() : Collections.singletonList(null));
+                                    .thenReturn(
+                                            isMissing ? Collections.emptyList() : Collections.singletonList(null));
                             when(response.getAliases()).thenReturn(Collections.emptyList());
                             when(response.getDataStreams()).thenReturn(Collections.emptyList());
                             ActionFuture<ResolveIndexAction.Response> future = mock(ActionFuture.class);
@@ -179,7 +183,8 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     private void mockResourcesBySpace(String indexName, Map<String, Map<String, Object>> result) {
         doAnswer(
                         invocation -> {
-                            invocation.<ActionListener<Map<String, Map<String, Object>>>>getArgument(3)
+                            invocation
+                                    .<ActionListener<Map<String, Map<String, Object>>>>getArgument(3)
                                     .onResponse(result);
                             return null;
                         })
@@ -187,7 +192,10 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
                 .getResourcesBySpace(eq(indexName), eq(Space.STANDARD), any(), any());
     }
 
-    /** Stubs {@code consumersIndex.getConsumer(...)} to return a ruleset doc with the given pending phases. */
+    /**
+     * Stubs {@code consumersIndex.getConsumer(...)} to return a ruleset doc with the given pending
+     * phases.
+     */
     private void mockExistingConsumerDoc(List<String> pendingPhases) throws Exception {
         GetResponse response = mock(GetResponse.class);
         when(response.isExists()).thenReturn(true);
@@ -575,10 +583,10 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     }
 
     /**
-     * missingSourceIndices() aborting the detector push sets "detectors" as pending and never
-     * reaches upsertDetectorAsync, without affecting integrations/rules. Requires a
-     * SecurityAnalyticsServiceImpl mock (not the plain interface) since syncDetectors() only runs
-     * its real logic for that concrete type.
+     * missingSourceIndices() aborting the detector push sets "detectors" as pending and never reaches
+     * upsertDetectorAsync, without affecting integrations/rules. Requires a
+     * SecurityAnalyticsServiceImpl mock (not the plain interface) since syncDetectors() only runs its
+     * real logic for that concrete type.
      */
     @SuppressWarnings("unchecked")
     public void testOnSyncComplete_missingSourceIndices_setsDetectorsPending() throws Exception {
@@ -631,8 +639,8 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     /**
      * The core regression test: with isUpdated=false and only "detectors" persisted as pending, the
      * next pass still retries detectors — reading (but not re-pushing) integrations, and never
-     * touching rules at all. This is the fix for the permanent-loss bug: today's code skips the
-     * whole SAP block whenever isUpdated is false, regardless of what failed last time.
+     * touching rules at all. This is the fix for the permanent-loss bug: today's code skips the whole
+     * SAP block whenever isUpdated is false, regardless of what failed last time.
      */
     @SuppressWarnings("unchecked")
     public void testOnSyncComplete_notUpdatedButDetectorsPending_onlyRetriesDetectors()
@@ -747,8 +755,8 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
     }
 
     /**
-     * With nothing new to sync (isUpdated=false) and nothing pending, onSyncComplete is a true
-     * no-op beyond initializeSpaces(): no index reads, no SAP calls, no consumer doc write.
+     * With nothing new to sync (isUpdated=false) and nothing pending, onSyncComplete is a true no-op
+     * beyond initializeSpaces(): no index reads, no SAP calls, no consumer doc write.
      */
     public void testOnSyncComplete_notUpdatedAndNothingPending_isNoOp() throws Exception {
         this.mockExistingConsumerDoc(Collections.emptyList());
@@ -827,5 +835,102 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         LocalConsumer lastWrite = captor.getValue();
         Assert.assertEquals(LocalConsumer.Status.READY, lastWrite.getStatus());
         Assert.assertEquals(List.of("detectors"), lastWrite.getPendingSyncPhases());
+    }
+
+    /**
+     * A failed integrations read must not clear a pending "detectors" phase. syncDetectors() reports
+     * an empty document map as success ("nothing to create"), so mistaking the failed read for an
+     * empty result would drop the retry for good — the very bug the pending-phase list exists to
+     * prevent.
+     */
+    @SuppressWarnings("unchecked")
+    public void testOnSyncComplete_integrationsReadFailure_keepsDetectorsPending() throws Exception {
+        this.mockExistingConsumerDoc(List.of("detectors"));
+        this.mockIndexResolution(name -> false);
+
+        SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
+        ConsumerRulesetService svc =
+                new ConsumerRulesetService(
+                        this.client, this.consumersIndex, this.environment, this.spaceService, sapServiceImpl);
+
+        // The integrations index resolves, but reading it fails, so no document reaches detectors.
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<Map<String, Map<String, Object>>>>getArgument(3)
+                                    .onFailure(new RuntimeException("read failed"));
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getResourcesBySpace(eq(Constants.INDEX_INTEGRATIONS), eq(Space.STANDARD), any(), any());
+
+        svc.onSyncComplete(false);
+
+        verify(sapServiceImpl, never()).upsertDetectorAsync(any(), anyBoolean(), any(), any());
+        // "detectors" must survive as pending. It was already the persisted state and the retry did
+        // not change it, so the correct outcome is no consumer write at all -- in particular not the
+        // write clearing the phase that treating the failed read as "nothing to sync" would produce.
+        verify(this.consumersIndex, never()).setConsumer(any());
+    }
+
+    /**
+     * A "detectors" phase left pending from when detector creation was still enabled is dropped once
+     * the setting is off: it can never be retried, so keeping it would cost a consumer document read
+     * on every sync pass forever.
+     */
+    public void testOnSyncComplete_detectorsDisabled_dropsUnreachableDetectorsPhase()
+            throws Exception {
+        this.mockExistingConsumerDoc(List.of("detectors"));
+
+        PluginSettings.resetForTesting();
+        try {
+            PluginSettings.getInstance(
+                    Settings.builder().put(PluginSettings.CREATE_DETECTORS.getKey(), false).build());
+
+            this.synchronizer.onSyncComplete(false);
+
+            ArgumentCaptor<LocalConsumer> captor = ArgumentCaptor.forClass(LocalConsumer.class);
+            verify(this.consumersIndex).setConsumer(captor.capture());
+            Assert.assertTrue(captor.getValue().getPendingSyncPhases().isEmpty());
+            verify(this.spaceService, never()).getResourcesBySpace(any(), any(), any(), any());
+            verifyNoInteractions(this.securityAnalyticsService);
+        } finally {
+            PluginSettings.resetForTesting();
+            PluginSettings.getInstance(Settings.EMPTY);
+        }
+    }
+
+    /**
+     * A phase that fails again on retry leaves the persisted list exactly as it was, so the consumer
+     * document is not rewritten: a permanently degraded consumer would otherwise pay a cluster health
+     * check and an immediate-refresh index request on every scheduled pass.
+     */
+    @SuppressWarnings("unchecked")
+    public void testOnSyncComplete_pendingPhasesUnchanged_skipsConsumerWrite() throws Exception {
+        this.mockExistingConsumerDoc(List.of("detectors"));
+        // The detector's source index stays missing, so detectors fails exactly as it did last pass.
+        this.mockIndexResolution("wazuh-events-v5-test"::equals);
+
+        SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
+        ConsumerRulesetService svc =
+                new ConsumerRulesetService(
+                        this.client, this.consumersIndex, this.environment, this.spaceService, sapServiceImpl);
+
+        Map<String, Map<String, Object>> integrations = new LinkedHashMap<>();
+        integrations.put(
+                "int-1",
+                Map.of(
+                        "document",
+                        Map.of(
+                                "id", "int-1",
+                                "metadata", Map.of("title", "Test"),
+                                "detector", Map.of("source", List.of("wazuh-events-v5-test")))));
+        this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, integrations);
+        when(sapServiceImpl.buildDetectorRequest(any(), eq(true)))
+                .thenReturn(mock(WIndexDetectorRequest.class));
+
+        svc.onSyncComplete(false);
+
+        verify(this.consumersIndex, never()).setConsumer(any());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
@@ -851,7 +851,12 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
         ConsumerRulesetService svc =
                 new ConsumerRulesetService(
-                        this.client, this.consumersIndex, this.environment, this.spaceService, sapServiceImpl);
+                        this.client,
+                        this.consumersIndex,
+                        this.environment,
+                        this.spaceService,
+                        sapServiceImpl,
+                        this.userOverridesService);
 
         // The integrations index resolves, but reading it fails, so no document reaches detectors.
         doAnswer(
@@ -866,7 +871,7 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
 
         svc.onSyncComplete(false);
 
-        verify(sapServiceImpl, never()).upsertDetectorAsync(any(), anyBoolean(), any(), any());
+        verify(sapServiceImpl, never()).upsertDetectorAsync(any(), anyBoolean(), any(), any(), any());
         // "detectors" must survive as pending. It was already the persisted state and the retry did
         // not change it, so the correct outcome is no consumer write at all -- in particular not the
         // write clearing the phase that treating the failed read as "nothing to sync" would produce.
@@ -914,7 +919,12 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
         ConsumerRulesetService svc =
                 new ConsumerRulesetService(
-                        this.client, this.consumersIndex, this.environment, this.spaceService, sapServiceImpl);
+                        this.client,
+                        this.consumersIndex,
+                        this.environment,
+                        this.spaceService,
+                        sapServiceImpl,
+                        this.userOverridesService);
 
         Map<String, Map<String, Object>> integrations = new LinkedHashMap<>();
         integrations.put(
@@ -926,7 +936,7 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
                                 "metadata", Map.of("title", "Test"),
                                 "detector", Map.of("source", List.of("wazuh-events-v5-test")))));
         this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, integrations);
-        when(sapServiceImpl.buildDetectorRequest(any(), eq(true)))
+        when(sapServiceImpl.buildDetectorRequest(any(), eq(true), any()))
                 .thenReturn(mock(WIndexDetectorRequest.class));
 
         svc.onSyncComplete(false);

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerRulesetServiceTests.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequestBuilder;
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.common.action.ActionFuture;
@@ -36,18 +38,26 @@ import org.junit.Assert;
 import org.junit.Before;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import com.wazuh.contentmanager.cti.catalog.index.ConsumersIndex;
 import com.wazuh.contentmanager.cti.catalog.model.LocalConsumer;
+import com.wazuh.contentmanager.cti.catalog.model.Space;
+import com.wazuh.contentmanager.cti.catalog.model.UserOverrides;
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
+import com.wazuh.securityanalytics.action.WIndexDetectorRequest;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -82,6 +92,123 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
                         this.spaceService,
                         this.securityAnalyticsService,
                         this.userOverridesService);
+
+        // initializeSpaces() runs unconditionally at the top of onSyncComplete(); stub it so tests
+        // that don't care about it don't block on awaitResult()'s 60s timeout.
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Void>>getArgument(0).onResponse(null);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .initializeDefaultSpaces(any());
+
+        // calculateAndUpdate() runs at the end of onSyncComplete() whenever isUpdated is true; stub
+        // it the same way so isUpdated=true tests don't block either.
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Set<String>>>getArgument(1).onResponse(Collections.emptySet());
+                            return null;
+                        })
+                .when(this.spaceService)
+                .calculateAndUpdate(any(), any());
+
+        // syncDetectors() reads the user overrides registry before building any detector request;
+        // stub it to "no overrides" so tests that don't care about it don't block on awaitResult()'s
+        // 60s timeout.
+        doAnswer(
+                        invocation -> {
+                            invocation
+                                    .<ActionListener<UserOverrides>>getArgument(1)
+                                    .onResponse(new UserOverrides(null, null, null));
+                            return null;
+                        })
+                .when(this.userOverridesService)
+                .read(any(), any());
+
+        // onSyncComplete() re-applies the user overrides whenever isUpdated is true; stub it the
+        // same way so isUpdated=true tests don't block either.
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Void>>getArgument(1).onResponse(null);
+                            return null;
+                        })
+                .when(this.userOverridesService)
+                .apply(any(), any());
+    }
+
+    /**
+     * Stubs {@code client.admin().indices().resolveIndex(...)} so {@code indexIsMissing(name)}
+     * returns {@code true} only for names accepted by {@code missing}. Same
+     * AdminClient/IndicesAdminClient wiring as {@link #testMissingSourceIndices_dataStreamResolved_returnsOnlyMissingOnes},
+     * generalized to answer for any index name instead of a fixed pair.
+     */
+    @SuppressWarnings("unchecked")
+    private void mockIndexResolution(Predicate<String> missing) throws Exception {
+        AdminClient adminClient = mock(AdminClient.class);
+        IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
+        when(this.client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+
+        // syncConsumerServices() checks prepareExists(...).get().isExists() before creating each
+        // content index; only reached via the full synchronize() path, not onSyncComplete() directly.
+        IndicesExistsRequestBuilder existsBuilder = mock(IndicesExistsRequestBuilder.class);
+        IndicesExistsResponse existsResponse = mock(IndicesExistsResponse.class);
+        when(existsResponse.isExists()).thenReturn(true);
+        when(existsBuilder.get()).thenReturn(existsResponse);
+        when(indicesAdminClient.prepareExists(any(String[].class))).thenReturn(existsBuilder);
+
+        when(indicesAdminClient.resolveIndex(any(ResolveIndexAction.Request.class)))
+                .thenAnswer(
+                        invocation -> {
+                            ResolveIndexAction.Request request = invocation.getArgument(0);
+                            String indexName = request.indices()[0];
+                            ResolveIndexAction.Response response = mock(ResolveIndexAction.Response.class);
+                            boolean isMissing = missing.test(indexName);
+                            when(response.getIndices())
+                                    .thenReturn(isMissing ? Collections.emptyList() : Collections.singletonList(null));
+                            when(response.getAliases()).thenReturn(Collections.emptyList());
+                            when(response.getDataStreams()).thenReturn(Collections.emptyList());
+                            ActionFuture<ResolveIndexAction.Response> future = mock(ActionFuture.class);
+                            when(future.actionGet()).thenReturn(response);
+                            return future;
+                        });
+    }
+
+    /** Stubs {@code spaceService.getResourcesBySpace(indexName, STANDARD, ..., listener)}. */
+    private void mockResourcesBySpace(String indexName, Map<String, Map<String, Object>> result) {
+        doAnswer(
+                        invocation -> {
+                            invocation.<ActionListener<Map<String, Map<String, Object>>>>getArgument(3)
+                                    .onResponse(result);
+                            return null;
+                        })
+                .when(this.spaceService)
+                .getResourcesBySpace(eq(indexName), eq(Space.STANDARD), any(), any());
+    }
+
+    /** Stubs {@code consumersIndex.getConsumer(...)} to return a ruleset doc with the given pending phases. */
+    private void mockExistingConsumerDoc(List<String> pendingPhases) throws Exception {
+        GetResponse response = mock(GetResponse.class);
+        when(response.isExists()).thenReturn(true);
+        StringBuilder phasesJson = new StringBuilder("[");
+        for (int i = 0; i < pendingPhases.size(); i++) {
+            if (i > 0) {
+                phasesJson.append(",");
+            }
+            phasesJson.append("\"").append(pendingPhases.get(i)).append("\"");
+        }
+        phasesJson.append("]");
+        when(response.getSourceAsString())
+                .thenReturn(
+                        "{\"name\":\"name\",\"context\":\"ctx\",\"status\":\"ready\","
+                                + "\"type\":\"cti:catalog:consumer:ruleset\","
+                                + "\"resource\":\"\",\"is_public\":true,"
+                                + "\"local_offset\":0,\"remote_offset\":0,"
+                                + "\"pending_sync_phases\":"
+                                + phasesJson
+                                + "}");
+        when(this.consumersIndex.getConsumer(any())).thenReturn(response);
     }
 
     @After
@@ -373,5 +500,332 @@ public class ConsumerRulesetServiceTests extends OpenSearchTestCase {
         verify(this.consumersIndex, org.mockito.Mockito.atLeastOnce()).setConsumer(captor.capture());
         LocalConsumer lastWrite = captor.getValue();
         Assert.assertEquals(LocalConsumer.Status.FAILED, lastWrite.getStatus());
+    }
+
+    /**
+     * A partial failure isolated to integrations sets only "integrations" as pending, leaving rules
+     * and detectors untouched. securityAnalyticsService stays a plain interface mock here, so
+     * syncDetectors() takes its "not a SecurityAnalyticsServiceImpl" early-return path and never
+     * interferes with the assertion.
+     */
+    @SuppressWarnings("unchecked")
+    public void testOnSyncComplete_integrationsPartialFailure_setsOnlyIntegrationsPending()
+            throws Exception {
+        this.mockExistingConsumerDoc(Collections.emptyList());
+        this.mockIndexResolution(name -> false);
+
+        Map<String, Map<String, Object>> integrations = new LinkedHashMap<>();
+        integrations.put("int-good", Map.of("document", Map.of("name", "good")));
+        integrations.put("int-bad", Map.of("document", Map.of("name", "bad")));
+        this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, integrations);
+        this.mockResourcesBySpace(Constants.INDEX_RULES, Collections.emptyMap());
+
+        doAnswer(
+                        invocation -> {
+                            JsonNode doc = invocation.getArgument(0);
+                            ActionListener<?> listener = invocation.getArgument(3);
+                            if ("bad".equals(doc.get("name").asText())) {
+                                listener.onFailure(new RuntimeException("boom"));
+                            } else {
+                                listener.onResponse(null);
+                            }
+                            return null;
+                        })
+                .when(this.securityAnalyticsService)
+                .upsertIntegration(any(), eq(Space.STANDARD), any(), any());
+
+        this.synchronizer.onSyncComplete(true);
+
+        ArgumentCaptor<LocalConsumer> captor = ArgumentCaptor.forClass(LocalConsumer.class);
+        verify(this.consumersIndex).setConsumer(captor.capture());
+        Assert.assertEquals(List.of("integrations"), captor.getValue().getPendingSyncPhases());
+    }
+
+    /** Symmetric to the integrations case: a rules-only failure sets only "rules" as pending. */
+    @SuppressWarnings("unchecked")
+    public void testOnSyncComplete_rulesPartialFailure_setsOnlyRulesPending() throws Exception {
+        this.mockExistingConsumerDoc(Collections.emptyList());
+        this.mockIndexResolution(name -> false);
+
+        this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, Collections.emptyMap());
+        Map<String, Map<String, Object>> rules = new LinkedHashMap<>();
+        rules.put("rule-good", Map.of("document", Map.of("name", "good")));
+        rules.put("rule-bad", Map.of("document", Map.of("name", "bad")));
+        this.mockResourcesBySpace(Constants.INDEX_RULES, rules);
+
+        doAnswer(
+                        invocation -> {
+                            JsonNode doc = invocation.getArgument(0);
+                            ActionListener<?> listener = invocation.getArgument(3);
+                            if ("bad".equals(doc.get("name").asText())) {
+                                listener.onFailure(new RuntimeException("boom"));
+                            } else {
+                                listener.onResponse(null);
+                            }
+                            return null;
+                        })
+                .when(this.securityAnalyticsService)
+                .upsertRule(any(), eq(Space.STANDARD), any(), any());
+
+        this.synchronizer.onSyncComplete(true);
+
+        ArgumentCaptor<LocalConsumer> captor = ArgumentCaptor.forClass(LocalConsumer.class);
+        verify(this.consumersIndex).setConsumer(captor.capture());
+        Assert.assertEquals(List.of("rules"), captor.getValue().getPendingSyncPhases());
+    }
+
+    /**
+     * missingSourceIndices() aborting the detector push sets "detectors" as pending and never
+     * reaches upsertDetectorAsync, without affecting integrations/rules. Requires a
+     * SecurityAnalyticsServiceImpl mock (not the plain interface) since syncDetectors() only runs
+     * its real logic for that concrete type.
+     */
+    @SuppressWarnings("unchecked")
+    public void testOnSyncComplete_missingSourceIndices_setsDetectorsPending() throws Exception {
+        this.mockExistingConsumerDoc(Collections.emptyList());
+        // Only the detector's source index is missing; every other resolveIndex() check succeeds.
+        this.mockIndexResolution("wazuh-events-v5-test"::equals);
+
+        SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
+        ConsumerRulesetService svc =
+                new ConsumerRulesetService(
+                        this.client,
+                        this.consumersIndex,
+                        this.environment,
+                        this.spaceService,
+                        sapServiceImpl,
+                        this.userOverridesService);
+
+        Map<String, Map<String, Object>> integrations = new LinkedHashMap<>();
+        integrations.put(
+                "int-1",
+                Map.of(
+                        "document",
+                        Map.of(
+                                "id", "int-1",
+                                "metadata", Map.of("title", "Test"),
+                                "detector", Map.of("source", List.of("wazuh-events-v5-test")))));
+        this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, integrations);
+        this.mockResourcesBySpace(Constants.INDEX_RULES, Collections.emptyMap());
+
+        doAnswer(
+                        invocation -> {
+                            ActionListener<?> listener = invocation.getArgument(3);
+                            listener.onResponse(null);
+                            return null;
+                        })
+                .when(sapServiceImpl)
+                .upsertIntegration(any(), eq(Space.STANDARD), any(), any());
+        when(sapServiceImpl.buildDetectorRequest(any(), eq(true), any()))
+                .thenReturn(mock(WIndexDetectorRequest.class));
+
+        svc.onSyncComplete(true);
+
+        verify(sapServiceImpl, never()).upsertDetectorAsync(any(), anyBoolean(), any(), any(), any());
+
+        ArgumentCaptor<LocalConsumer> captor = ArgumentCaptor.forClass(LocalConsumer.class);
+        verify(this.consumersIndex).setConsumer(captor.capture());
+        Assert.assertEquals(List.of("detectors"), captor.getValue().getPendingSyncPhases());
+    }
+
+    /**
+     * The core regression test: with isUpdated=false and only "detectors" persisted as pending, the
+     * next pass still retries detectors — reading (but not re-pushing) integrations, and never
+     * touching rules at all. This is the fix for the permanent-loss bug: today's code skips the
+     * whole SAP block whenever isUpdated is false, regardless of what failed last time.
+     */
+    @SuppressWarnings("unchecked")
+    public void testOnSyncComplete_notUpdatedButDetectorsPending_onlyRetriesDetectors()
+            throws Exception {
+        this.mockExistingConsumerDoc(List.of("detectors"));
+        this.mockIndexResolution(name -> false);
+
+        SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
+        ConsumerRulesetService svc =
+                new ConsumerRulesetService(
+                        this.client,
+                        this.consumersIndex,
+                        this.environment,
+                        this.spaceService,
+                        sapServiceImpl,
+                        this.userOverridesService);
+
+        Map<String, Map<String, Object>> integrations = new LinkedHashMap<>();
+        integrations.put(
+                "int-1",
+                Map.of(
+                        "document",
+                        Map.of(
+                                "id", "int-1",
+                                "metadata", Map.of("title", "Test"),
+                                "detector", Map.of("source", List.of("wazuh-events-v5-test")))));
+        this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, integrations);
+
+        when(sapServiceImpl.buildDetectorRequest(any(), eq(true), any()))
+                .thenReturn(mock(WIndexDetectorRequest.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<?> listener = invocation.getArgument(4);
+                            listener.onResponse(null);
+                            return null;
+                        })
+                .when(sapServiceImpl)
+                .upsertDetectorAsync(any(), anyBoolean(), any(), any(), any());
+
+        svc.onSyncComplete(false);
+
+        // Integration data was read (detectors need it to build their request) but never pushed.
+        verify(this.spaceService)
+                .getResourcesBySpace(eq(Constants.INDEX_INTEGRATIONS), eq(Space.STANDARD), any(), any());
+        verify(sapServiceImpl, never()).upsertIntegration(any(), any(), any(), any());
+        // Rules was never pending and isUpdated is false, so it's not touched at all.
+        verify(this.spaceService, never())
+                .getResourcesBySpace(eq(Constants.INDEX_RULES), eq(Space.STANDARD), any(), any());
+        verify(sapServiceImpl, never()).upsertRule(any(), any(), any(), any());
+        verify(sapServiceImpl).upsertDetectorAsync(any(), anyBoolean(), any(), any(), any());
+
+        ArgumentCaptor<LocalConsumer> captor = ArgumentCaptor.forClass(LocalConsumer.class);
+        verify(this.consumersIndex).setConsumer(captor.capture());
+        Assert.assertTrue(captor.getValue().getPendingSyncPhases().isEmpty());
+    }
+
+    /**
+     * When every previously-pending phase succeeds on retry, the persisted list is cleared back to
+     * empty.
+     */
+    @SuppressWarnings("unchecked")
+    public void testOnSyncComplete_fullSuccess_clearsPendingPhases() throws Exception {
+        this.mockExistingConsumerDoc(List.of("integrations", "rules", "detectors"));
+        this.mockIndexResolution(name -> false);
+
+        SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
+        ConsumerRulesetService svc =
+                new ConsumerRulesetService(
+                        this.client,
+                        this.consumersIndex,
+                        this.environment,
+                        this.spaceService,
+                        sapServiceImpl,
+                        this.userOverridesService);
+
+        Map<String, Map<String, Object>> integrations = new LinkedHashMap<>();
+        integrations.put(
+                "int-1",
+                Map.of(
+                        "document",
+                        Map.of(
+                                "id", "int-1",
+                                "metadata", Map.of("title", "Test"),
+                                "detector", Map.of("source", List.of("wazuh-events-v5-test")))));
+        this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, integrations);
+        this.mockResourcesBySpace(Constants.INDEX_RULES, Collections.emptyMap());
+
+        doAnswer(
+                        invocation -> {
+                            ActionListener<?> listener = invocation.getArgument(3);
+                            listener.onResponse(null);
+                            return null;
+                        })
+                .when(sapServiceImpl)
+                .upsertIntegration(any(), eq(Space.STANDARD), any(), any());
+        when(sapServiceImpl.buildDetectorRequest(any(), eq(true), any()))
+                .thenReturn(mock(WIndexDetectorRequest.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<?> listener = invocation.getArgument(4);
+                            listener.onResponse(null);
+                            return null;
+                        })
+                .when(sapServiceImpl)
+                .upsertDetectorAsync(any(), anyBoolean(), any(), any(), any());
+
+        svc.onSyncComplete(false);
+
+        ArgumentCaptor<LocalConsumer> captor = ArgumentCaptor.forClass(LocalConsumer.class);
+        verify(this.consumersIndex).setConsumer(captor.capture());
+        Assert.assertTrue(captor.getValue().getPendingSyncPhases().isEmpty());
+    }
+
+    /**
+     * With nothing new to sync (isUpdated=false) and nothing pending, onSyncComplete is a true
+     * no-op beyond initializeSpaces(): no index reads, no SAP calls, no consumer doc write.
+     */
+    public void testOnSyncComplete_notUpdatedAndNothingPending_isNoOp() throws Exception {
+        this.mockExistingConsumerDoc(Collections.emptyList());
+
+        this.synchronizer.onSyncComplete(false);
+
+        verify(this.consumersIndex, never()).setConsumer(any());
+        verify(this.spaceService, never()).getResourcesBySpace(any(), any(), any(), any());
+        verifyNoInteractions(this.securityAnalyticsService);
+    }
+
+    /**
+     * synchronize() calls setConsumerStatus(READY) right after onSyncComplete() on every pass; that
+     * status write must preserve pending_sync_phases, not reset it. Drives synchronize() end to end
+     * (not onSyncComplete() directly) so the trailing status write is actually exercised.
+     */
+    @SuppressWarnings("unchecked")
+    public void testSynchronize_pendingPhaseSurvivesTrailingStatusWrite() throws Exception {
+        this.mockExistingConsumerDoc(List.of("detectors"));
+        this.mockIndexResolution(name -> false);
+
+        SecurityAnalyticsServiceImpl sapServiceImpl = mock(SecurityAnalyticsServiceImpl.class);
+        ConsumerRulesetService svc =
+                new ConsumerRulesetService(
+                        this.client,
+                        this.consumersIndex,
+                        this.environment,
+                        this.spaceService,
+                        sapServiceImpl,
+                        this.userOverridesService);
+
+        // No catalog configured and the offset is already caught up, so syncConsumerServices()
+        // reports isUpdated=false — the retry must come entirely from the persisted pending phase.
+        ConsumerService consumerService = mock(ConsumerService.class);
+        LocalConsumer localConsumer =
+                new LocalConsumer(
+                        "ctx",
+                        "name",
+                        "cti:catalog:consumer:ruleset",
+                        "",
+                        true,
+                        LocalConsumer.Status.READY,
+                        100L,
+                        100L,
+                        List.of("detectors"));
+        when(consumerService.getLocalConsumer()).thenReturn(localConsumer);
+        svc.setConsumerService(consumerService);
+
+        // Detectors fail again on this retry, so onSyncComplete() ends the pass with "detectors"
+        // still pending.
+        Map<String, Map<String, Object>> integrations = new LinkedHashMap<>();
+        integrations.put(
+                "int-1",
+                Map.of(
+                        "document",
+                        Map.of(
+                                "id", "int-1",
+                                "metadata", Map.of("title", "Test"),
+                                "detector", Map.of("source", List.of("wazuh-events-v5-test")))));
+        this.mockResourcesBySpace(Constants.INDEX_INTEGRATIONS, integrations);
+        when(sapServiceImpl.buildDetectorRequest(any(), eq(true), any()))
+                .thenReturn(mock(WIndexDetectorRequest.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener<?> listener = invocation.getArgument(4);
+                            listener.onFailure(new RuntimeException("still broken"));
+                            return null;
+                        })
+                .when(sapServiceImpl)
+                .upsertDetectorAsync(any(), anyBoolean(), any(), any(), any());
+
+        svc.synchronize();
+
+        ArgumentCaptor<LocalConsumer> captor = ArgumentCaptor.forClass(LocalConsumer.class);
+        verify(this.consumersIndex, org.mockito.Mockito.atLeastOnce()).setConsumer(captor.capture());
+        LocalConsumer lastWrite = captor.getValue();
+        Assert.assertEquals(LocalConsumer.Status.READY, lastWrite.getStatus());
+        Assert.assertEquals(List.of("detectors"), lastWrite.getPendingSyncPhases());
     }
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
-->

The Security Analytics content sync (Integrations, Rules, Detectors) previously ran only when the catalog had new remote content to apply, so a transient Security Analytics failure on one sub-phase was never retried until unrelated catalog content changed — potentially never.

Closes #1487 

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

This adds a small persisted state, pending_sync_phases, to the .wazuh-cti-consumers document that tracks which of the three sub-phases (integrations, rules, detectors) still owe a retry:

- Each sub-phase reports success or failure independently. A phase that fails is recorded as pending; a phase that succeeds is cleared.
- On every sync pass, a phase runs if either the catalog has new content or it was left pending from a previous pass — so a failure gets retried on the very next scheduled sync, not on the next unrelated content update.
- Integrations and Detectors share the same underlying read of the integrations index; that read is done once per pass and its outcome (not just its result being empty) determines whether Detectors can be evaluated, so a read failure keeps Detectors pending rather than mistaking "nothing read" for "nothing to sync."
- A detectors phase left pending while detector creation is disabled via settings is dropped instead of being retried forever, since it can never succeed in that configuration.
- The consumer document is only rewritten when the set of pending phases actually changes, so a healthy pass or a phase that keeps failing the same way doesn't pay a write on every sync.

Example document:

```
{
  "_index" : ".wazuh-cti-consumers",
  "_id" : "cti:catalog:consumer:ruleset",
  "_version" : 14,
  "_seq_no" : 225,
  "_primary_term" : 22,
  "found" : true,
  "_source" : {
    "name" : "public-ruleset-5",
    "context" : "beta5-t1-ruleset-5",
    "type" : "cti:catalog:consumer:ruleset",
    "resource" : "...",
    "is_public" : true,
    "status" : "ready",
    "local_offset" : 1003,
    "remote_offset" : 1003,
    "pending_sync_phases" : [      <--- new
      "integrations",
      "rules",
      "detectors"
    ]
  }
}

```
### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

First run with detectors failure
<img width="1761" height="94" alt="Captura desde 2026-08-31 16-58-52" src="https://github.com/user-attachments/assets/cca17c43-b9ae-4a6a-bf0f-c7ae833a9d3f" />

Next run the detectors are sent successfully
<img width="1181" height="29" alt="Captura desde 2026-08-31 16-59-06" src="https://github.com/user-attachments/assets/f91a427e-56ff-4134-83c1-3d87e32b29b2" />

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

- Executables: `wazuh-indexer-content-manager` plugin (Java changes)
- Default configuration files: `consumers-mapping.json` (new `pending_sync_phases` keyword field)

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
N/A

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

- docs/ref/modules/content-manager/architecture.md
- docs/ref/modules/content-manager/troubleshooting.md
- docs/ref/modules/content-manager/index.md

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

### `LocalConsumerTests.java` — 4 new tests

Covers the `LocalConsumer` model and the new `pendingSyncPhases` field:

| Test | What it verifies |
|---|---|
| `testPendingSyncPhasesDefaultsEmpty` | The constructor without that parameter initializes it to empty, not `null`. |
| `testToXContentIncludesPendingSyncPhases` | Serializes correctly to JSON. |
| `testPendingSyncPhasesDeserializesFromJson` | Deserialization round-trip. |
| `testLegacyDocumentWithoutPendingSyncPhasesDefaultsEmpty` | A legacy document without the field (pre-migration) deserializes to an empty list instead of failing. |

### `ConsumerRulesetServiceTests.java` — 10 new tests

All exercise `onSyncComplete`/`synchronize` on `ConsumerRulesetService`:

| Test | What it verifies |
|---|---|
| `testOnSyncComplete_integrationsPartialFailure_setsOnlyIntegrationsPending` | An isolated integrations failure marks only that phase pending, without touching rules/detectors. |
| `testOnSyncComplete_rulesPartialFailure_setsOnlyRulesPending` | Symmetric case for rules. |
| `testOnSyncComplete_missingSourceIndices_setsDetectorsPending` | Missing source indices for detectors leaves that phase pending, without invoking `upsertDetectorAsync`. |
| `testOnSyncComplete_notUpdatedButDetectorsPending_onlyRetriesDetectors` | The core regression case: with `isUpdated=false` but `detectors` pending, only that phase is retried (integrations is read but not re-sent, rules is never touched). |
| `testOnSyncComplete_fullSuccess_clearsPendingPhases` | If all three pending phases succeed on retry, the persisted list is cleared. |
| `testOnSyncComplete_notUpdatedAndNothingPending_isNoOp` | With no new content and nothing pending, there are no reads or writes — a true no-op. |
| `testSynchronize_pendingPhaseSurvivesTrailingStatusWrite` | The trailing `status=READY` write at the end of `synchronize()` does not clobber `pending_sync_phases`. |
| `testOnSyncComplete_integrationsReadFailure_keepsDetectorsPending` | A failed integrations read must not be mistaken for "nothing to sync": `detectors` stays pending, and there's no write (nothing changed). |
| `testOnSyncComplete_detectorsDisabled_dropsUnreachableDetectorsPhase` | With `create_detectors=false`, a pending `detectors` phase is dropped instead of being retried forever. |
| `testOnSyncComplete_pendingPhasesUnchanged_skipsConsumerWrite` | If the set of pending phases doesn't change between passes, the consumer document is not rewritten. |

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
