### PR TITLE
Privacy default per provider mapped as object under dynamic strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@
 - [BUG] Fix issues in workflows [(#1449)](https://github.com/wazuh/wazuh-indexer/issues/1449)
 - Failed to save/update ManagedIndexMetaData [(#1828)](https://github.com/wazuh/wazuh-indexer/issues/1828)
 - [BUG] `wazuh-threatintel-enrichments-a` is never created, so the CTI writer auto-creates a dynamically mapped index under the alias name and the home overview's Threat catalog fails [(#1476)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1476)
+- [BUG] `privacy_default_per_provider` mapped as object under `dynamic:strict` rejects new provider overrides [(#1498)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1498)
 
 ## Prior versions
 - []()

--- a/docs/dev/plugins/setup.md
+++ b/docs/dev/plugins/setup.md
@@ -669,7 +669,7 @@ Sessions are read and written by each user directly against the data stream, und
 The index holds several kinds of documents under one mapping, avoiding a separate index for what would otherwise be a handful of settings fields.
 
 - One document per configured AI provider, id an arbitrary UUID: `name`, `type`, `base_url`, `model`, `api_key`, `is_default`, `updated_at`. `listProviders()` caps the result at `AiAssistantSettingsAdminIndex.MAX_PROVIDERS` = 500.
-- A single reserved-id document (id `"wazuh-ai-assistant-settings"`) holding the assistant-wide settings and the field anonymization policy, under `field_policy`
+- A single reserved-id document (id `"wazuh-ai-assistant-settings"`) holding the assistant-wide settings and the field anonymization policy, under `field_policy`. Its `privacy_default_per_provider` is keyed by provider document id, so it is mapped as `flat_object`: the keys are UUIDs minted at runtime and a plain `object` would reject every one of them under this index's `dynamic: strict` mapping.
 - A single reserved-id document (`"credentials"`), owned entirely by Content Manager. The administrative AI assistant API never reads or returns this document.
 
 Example documents:
@@ -681,7 +681,7 @@ Example documents:
 // Settings + field policy document (reserved id "wazuh-ai-assistant-settings")
 {
   "privacy_default_on": false,
-  "privacy_default_per_provider": {},
+  "privacy_default_per_provider": { "3f6b5f7e-6f2d-4a4f-9c1e-2f6d0a1b2c3d": true },
   "user_can_override": true,
   "field_policy": [
     { "field": "wazuh.agent.name", "action": "anonymize", "kind": "HOST" },

--- a/plugins/content-manager/src/main/resources/mappings/internal-state-mapping.json
+++ b/plugins/content-manager/src/main/resources/mappings/internal-state-mapping.json
@@ -62,7 +62,7 @@
           "type": "boolean"
         },
         "privacy_default_per_provider": {
-          "type": "object"
+          "type": "flat_object"
         },
         "type": {
           "ignore_above": 1024,

--- a/plugins/setup/src/test/java/com/wazuh/setup/AiAssistantSettingsAdminIT.java
+++ b/plugins/setup/src/test/java/com/wazuh/setup/AiAssistantSettingsAdminIT.java
@@ -108,7 +108,7 @@ public class AiAssistantSettingsAdminIT extends OpenSearchRestTestCase {
                         + "\"mappings\":{\"dynamic\":\"strict\",\"properties\":{"
                         + "\"access_token\":{\"type\":\"keyword\",\"index\":false},"
                         + "\"privacy_default_on\":{\"type\":\"boolean\"},"
-                        + "\"privacy_default_per_provider\":{\"type\":\"object\"},"
+                        + "\"privacy_default_per_provider\":{\"type\":\"flat_object\"},"
                         + "\"user_can_override\":{\"type\":\"boolean\"},"
                         + "\"field_policy\":{\"properties\":{"
                         + "\"field\":{\"type\":\"keyword\"},"
@@ -162,6 +162,38 @@ public class AiAssistantSettingsAdminIT extends OpenSearchRestTestCase {
         JsonNode settingsDoc = getDocById(SETTINGS_DOCUMENT_ID);
         org.junit.Assert.assertTrue(
                 "Settings document should exist under the reserved id", settingsDoc != null);
+    }
+
+    /**
+     * Verifies that a {@code privacy_default_per_provider} map keyed by runtime-generated provider
+     * ids is accepted and round-trips. The keys are UUIDs minted by the client, so under this
+     * index's {@code dynamic: strict} mapping the field has to be a {@code flat_object}: as a plain
+     * {@code object} every new key was rejected with a {@code strict_dynamic_mapping_exception}.
+     *
+     * @throws IOException if there is an issue with the HTTP request
+     * @throws ParseException if there is an issue parsing the response
+     */
+    public void testPutSettingsAcceptsUnknownProviderIdKeys() throws IOException, ParseException {
+        String firstProviderId = java.util.UUID.randomUUID().toString();
+        String secondProviderId = java.util.UUID.randomUUID().toString();
+
+        Request put = new Request("PUT", SETTINGS_URI);
+        put.setJsonEntity(
+                "{\"privacy_default_on\":false,\"user_can_override\":true,"
+                        + "\"privacy_default_per_provider\":{\""
+                        + firstProviderId
+                        + "\":true,\""
+                        + secondProviderId
+                        + "\":false}}");
+        Response putResponse = client().performRequest(put);
+        assertEquals(200, putResponse.getStatusLine().getStatusCode());
+
+        Response getResponse = client().performRequest(new Request("GET", SETTINGS_URI));
+        String body = EntityUtils.toString(getResponse.getEntity(), StandardCharsets.UTF_8);
+
+        logger.info("Get settings response: {}", body);
+        assertThat(body, containsString(firstProviderId));
+        assertThat(body, containsString(secondProviderId));
     }
 
     /**

--- a/wcs/internal-state/docs/fields.csv
+++ b/wcs/internal-state/docs/fields.csv
@@ -6,7 +6,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,base,model,keyword,custom,,claude-opus-4-6,Model to request from the provider.
 9.1.0,true,base,name,keyword,custom,,test-ai,Name given to the provider configuration.
 9.1.0,true,base,privacy_default_on,boolean,custom,,False,Whether privacy mode is enabled by default for new conversations.
-9.1.0,true,base,privacy_default_per_provider,object,custom,,"{""test-ai"": true}",Per-provider override of the default privacy mode.
+9.1.0,true,base,privacy_default_per_provider,flat_object,custom,,"{""3f6b5f7e-6f2d-4a4f-9c1e-2f6d0a1b2c3d"": true}",Per-provider override of the default privacy mode.
 9.1.0,true,base,type,keyword,custom,,anthropic,Provider implementation to use.
 9.1.0,true,base,updated_at,date,custom,,2026-08-03T09:54:52.193Z,"When this document was last written, stamped by the indexer."
 9.1.0,true,base,user_can_override,boolean,custom,,True,Whether users may override the default privacy setting for their own conversations.

--- a/wcs/internal-state/docs/wcs_flat.yml
+++ b/wcs/internal-state/docs/wcs_flat.yml
@@ -118,15 +118,17 @@ privacy_default_on:
   type: boolean
 privacy_default_per_provider:
   dashed_name: privacy-default-per-provider
-  description: Per-provider override of the default privacy mode, keyed by provider
-    name. Only present on the settings document.
-  example: '{"test-ai": true}'
+  description: 'Per-provider override of the default privacy mode, keyed by provider
+    document id. Only present on the settings document. Mapped as flat_object: the
+    keys are runtime-generated provider ids, so they cannot be declared up front under
+    this index''s strict mapping.'
+  example: '{"3f6b5f7e-6f2d-4a4f-9c1e-2f6d0a1b2c3d": true}'
   flat_name: privacy_default_per_provider
   level: custom
   name: privacy_default_per_provider
   normalize: []
   short: Per-provider override of the default privacy mode.
-  type: object
+  type: flat_object
 type:
   dashed_name: type
   description: Provider implementation to use. Only present on provider documents.

--- a/wcs/internal-state/fields/custom/base.yml
+++ b/wcs/internal-state/fields/custom/base.yml
@@ -81,13 +81,15 @@
         present on the settings document.
       example: false
     - name: privacy_default_per_provider
-      type: object
+      type: flat_object
       level: custom
       short: Per-provider override of the default privacy mode.
       description: >
         Per-provider override of the default privacy mode, keyed by provider
-        name. Only present on the settings document.
-      example: '{"test-ai": true}'
+        document id. Only present on the settings document. Mapped as
+        flat_object: the keys are runtime-generated provider ids, so they cannot
+        be declared up front under this index's strict mapping.
+      example: '{"3f6b5f7e-6f2d-4a4f-9c1e-2f6d0a1b2c3d": true}'
     - name: user_can_override
       type: boolean
       level: custom


### PR DESCRIPTION
## Description

`.wazuh-internal-state` is `dynamic: strict`, but `privacy_default_per_provider` was mapped as a plain `object`. Its keys are provider document ids minted at runtime with `crypto.randomUUID()`, so saving any per-provider privacy override failed:

```
strict_dynamic_mapping_exception: mapping set to strict, dynamic introduction
of [<provider-uuid>] within [privacy_default_per_provider] is not allowed
```

Closes #1498

## Proposed Changes

Remap the field to `flat_object` in the `wcs/internal-state` module and regenerate through the WCS pipeline. `flat_object` accepts arbitrary unbounded keys without declaring each as a sub-field, so it satisfies the strict mapping while keeping the `Record<providerId, boolean>` wire format — the setup plugin's API is unchanged and `openapi.yml` needed no edit.

Also corrected the field description: the map is keyed by provider **document id**, not provider name.

### Results and Evidence

Verified on an AIO VM (manager + dashboard + indexer, indexer `5.0.0`), after rebuilding `content-manager` + `setup` and letting `CredentialsIndex` recreate the index.

Before:

```
$ PUT /_plugins/_setup/ai_assistant/settings
  {"privacy_default_per_provider":{"6328793c-e3e4-4211-bdd9-6c4a76d254d7":true}}
{"error":{"type":"strict_dynamic_mapping_exception","reason":"mapping set to strict,
dynamic introduction of [6328793c-e3e4-4211-bdd9-6c4a76d254d7] within
[privacy_default_per_provider] is not allowed"},"status":400}
```

After — mapping is `{"privacy_default_per_provider":{"type":"flat_object"}}`:

```
POST .../providers  {"id":"ebbc5c68-…", …}   → 200 Provider saved.
POST .../providers  {"id":"d98db284-…", …}   → 200 Provider saved.
PUT  .../settings   {"privacy_default_per_provider":{"ebbc5c68-…":true,"d98db284-…":false}}
                                             → 200 Settings updated.
GET  .../settings   → {"privacy_default_per_provider":{"ebbc5c68-…":true,"d98db284-…":false},
                       "field_policy":[…],"privacy_default_on":true,"user_can_override":true}
PUT  .../settings   {"privacy_default_per_provider":{"8b309155-…":true}}  (third unseen key)
                                             → 200 Settings updated.
```

Booleans round-trip unquoted through `flat_object`.

### Artifacts Affected

- `wazuh-indexer-content-manager` — ships the regenerated `internal-state-mapping.json`
- `wazuh-indexer-setup` — test-only change

### Configuration Changes

None. The API wire format is unchanged.

One migration note: `CredentialsIndex.createIndexAsync` only creates the index when absent, and OpenSearch cannot change a field's type in place — a deployment that already has `.wazuh-internal-state` keeps the broken `object` mapping until the index is deleted or reindexed. Harmless for unreleased 5.0.

### Documentation Updates

- `docs/dev/plugins/setup.md` — documents why the field must be `flat_object`
- `wcs/internal-state/docs/{fields.csv,wcs_flat.yml}` — regenerated

### Tests Introduced

`AiAssistantSettingsAdminIT.testPutSettingsAcceptsUnknownProviderIdKeys` — PUTs a `privacy_default_per_provider` map keyed by two fresh UUIDs and asserts both survive the GET round-trip. Confirmed to be a real regression test: with the IT's index mapping reverted to `object` it fails with the original `strict_dynamic_mapping_exception`. All 9 tests in the IT pass with the fix.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied