### PR TITLE
Explicitly send Accept-Encoding: gzip, br on all CTI/GIP requests

### DIFF
--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -189,9 +189,10 @@ The update check flow is split into two classes:
   - Headers sent:
     - `wazuh-uid`: cluster UUID
     - `wazuh-tag`: `v<version>`
+    - `Accept-Encoding`: `gzip, br`
   - Fire-and-forget behavior: callback logs success/failure without blocking scheduler threads.
 
-### CTI HTTP client User-Agent
+### CTI HTTP client User-Agent and Accept-Encoding
 
 All HTTP clients that communicate with CTI services include a custom `User-Agent` header set as a **default header on the HTTP client builder**:
 
@@ -200,6 +201,8 @@ User-Agent: Wazuh Indexer <version>
 ```
 
 The version is read from `VERSION.json` at plugin startup and stored in `PluginSettings`. The user-agent string is built by `PluginSettings.getUserAgent()` using the `Constants.USER_AGENT_PREFIX` constant. If the version is unavailable, the fallback value `unknown` is used.
+
+They also send `Accept-Encoding: gzip, br` so CTI responses are transferred compressed. Unlike `User-Agent`, this header is added **per request** (via each request builder) rather than as a client default header: HttpClient5's built-in content-compression handling silently overwrites an `Accept-Encoding` default header with its own value, so setting it on the request itself is required for it to reach the wire unchanged.
 
 Affected clients:
 - **Console `ApiClient`** (`cti/console/client/ApiClient.java`) — async HTTP client for CTI Console authentication and plans.

--- a/docs/dev/plugins/content-manager.md
+++ b/docs/dev/plugins/content-manager.md
@@ -189,7 +189,7 @@ The update check flow is split into two classes:
   - Headers sent:
     - `wazuh-uid`: cluster UUID
     - `wazuh-tag`: `v<version>`
-    - `Accept-Encoding`: `gzip, br`
+    - `Accept-Encoding`: `gzip`
   - Fire-and-forget behavior: callback logs success/failure without blocking scheduler threads.
 
 ### CTI HTTP client User-Agent and Accept-Encoding
@@ -202,7 +202,7 @@ User-Agent: Wazuh Indexer <version>
 
 The version is read from `VERSION.json` at plugin startup and stored in `PluginSettings`. The user-agent string is built by `PluginSettings.getUserAgent()` using the `Constants.USER_AGENT_PREFIX` constant. If the version is unavailable, the fallback value `unknown` is used.
 
-They also send `Accept-Encoding: gzip, br` so CTI responses are transferred compressed. Unlike `User-Agent`, this header is added **per request** (via each request builder) rather than as a client default header: HttpClient5's built-in content-compression handling silently overwrites an `Accept-Encoding` default header with its own value, so setting it on the request itself is required for it to reach the wire unchanged.
+They also send `Accept-Encoding: gzip` (via `Constants.ACCEPT_ENCODING_GZIP`) so CTI responses are transferred compressed. Unlike `User-Agent`, this header is added **per request** (via each request builder) rather than as a client default header: HttpClient5's `ChainElement.COMPRESS` step runs before `ChainElement.PROTOCOL`, where default headers (`RequestDefaultHeaders`) are applied. If no `Accept-Encoding` header is present yet when `COMPRESS` runs, it adds its own — HttpClient5's built-in default (`gzip, x-gzip, deflate`), not ours — and `RequestDefaultHeaders` then skips a header whose name is already present. So a default header would never actually be inserted; it isn't overwritten, it's preempted. Setting it directly on each request is what makes it reach the wire as `gzip`.
 
 Affected clients:
 - **Console `ApiClient`** (`cti/console/client/ApiClient.java`) — async HTTP client for CTI Console authentication and plans.

--- a/docs/ref/modules/content-manager/architecture.md
+++ b/docs/ref/modules/content-manager/architecture.md
@@ -20,7 +20,7 @@ Exposes HTTP endpoints under `/_plugins/_content_manager/` for:
 
 Manages the CTI access token used for all CTI API requests. The token is submitted via `POST /subscription`, persisted in the `.wazuh-internal-state` hidden index, and cached in memory. On node startup, the token is loaded from the index into memory. Without a registered token, sync and update operations are rejected.
 
-All HTTP clients that communicate with CTI services send a custom `User-Agent` header in the format `Wazuh Indexer <version>` (e.g., `Wazuh Indexer 5.0.0`). This applies to the Catalog API client, Snapshot client, and Telemetry client.
+All HTTP clients that communicate with CTI services send a custom `User-Agent` header in the format `Wazuh Indexer <version>` (e.g., `Wazuh Indexer 5.0.0`), and an `Accept-Encoding: gzip, br` header so responses are transferred compressed. This applies to the Catalog API client, Snapshot client, and Telemetry client.
 
 ### Job scheduler
 

--- a/docs/ref/modules/content-manager/architecture.md
+++ b/docs/ref/modules/content-manager/architecture.md
@@ -20,7 +20,7 @@ Exposes HTTP endpoints under `/_plugins/_content_manager/` for:
 
 Manages the CTI access token used for all CTI API requests. The token is submitted via `POST /subscription`, persisted in the `.wazuh-internal-state` hidden index, and cached in memory. On node startup, the token is loaded from the index into memory. Without a registered token, sync and update operations are rejected.
 
-All HTTP clients that communicate with CTI services send a custom `User-Agent` header in the format `Wazuh Indexer <version>` (e.g., `Wazuh Indexer 5.0.0`), and an `Accept-Encoding: gzip, br` header so responses are transferred compressed. This applies to the Catalog API client, Snapshot client, and Telemetry client.
+All HTTP clients that communicate with CTI services send a custom `User-Agent` header in the format `Wazuh Indexer <version>` (e.g., `Wazuh Indexer 5.0.0`), and an `Accept-Encoding: gzip` header so responses are transferred compressed. This applies to the Catalog API client, Snapshot client, and Telemetry client.
 
 ### Job scheduler
 

--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -140,7 +140,7 @@ All HTTP clients that communicate with Wazuh CTI services send a custom `User-Ag
 
 ```
 User-Agent: Wazuh Indexer <version>
-Accept-Encoding: gzip, br
+Accept-Encoding: gzip
 ```
 
 For example: `Wazuh Indexer 5.0.0`. This applies to the Console API client, Catalog API client, Snapshot client, and Telemetry client. The version is read from `VERSION.json` at plugin startup.
@@ -155,7 +155,7 @@ The update check service is enabled by default and runs once per day, with an im
   - Deployment identifier (`wazuh-uid`: cluster UUID)
   - Running version (`wazuh-tag`: `v<version>`)
   - User agent (`Wazuh Indexer <version>`)
-  - Accept-Encoding (`gzip, br`)
+  - Accept-Encoding (`gzip`)
 
 This data allows Wazuh to determine if a newer version is available and notify users in the update check UI.
 

--- a/docs/ref/modules/content-manager/configuration.md
+++ b/docs/ref/modules/content-manager/configuration.md
@@ -136,10 +136,11 @@ plugins.content_manager.catalog.create_detectors: false
 
 #### CTI communication headers
 
-All HTTP clients that communicate with Wazuh CTI services send a custom `User-Agent` header:
+All HTTP clients that communicate with Wazuh CTI services send a custom `User-Agent` header, and an `Accept-Encoding` header so responses are transferred compressed:
 
 ```
 User-Agent: Wazuh Indexer <version>
+Accept-Encoding: gzip, br
 ```
 
 For example: `Wazuh Indexer 5.0.0`. This applies to the Console API client, Catalog API client, Snapshot client, and Telemetry client. The version is read from `VERSION.json` at plugin startup.
@@ -154,6 +155,7 @@ The update check service is enabled by default and runs once per day, with an im
   - Deployment identifier (`wazuh-uid`: cluster UUID)
   - Running version (`wazuh-tag`: `v<version>`)
   - User agent (`Wazuh Indexer <version>`)
+  - Accept-Encoding (`gzip, br`)
 
 This data allows Wazuh to determine if a newer version is available and notify users in the update check UI.
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -189,7 +189,8 @@ public class ApiClient implements AutoCloseable {
     public SimpleHttpResponse getConsumer(String consumerUri)
             throws ExecutionException, InterruptedException, TimeoutException {
         String uri = this.urlResolver.resolve(this.buildConsumerURI(consumerUri));
-        SimpleHttpRequest request = SimpleRequestBuilder.get(uri).build();
+        SimpleHttpRequest request =
+                SimpleRequestBuilder.get(uri).addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br").build();
         return this.executeWithRetry(request);
     }
 
@@ -214,7 +215,8 @@ public class ApiClient implements AutoCloseable {
                                 + "&to_offset="
                                 + toOffset);
 
-        SimpleHttpRequest request = SimpleRequestBuilder.get(uri).build();
+        SimpleHttpRequest request =
+                SimpleRequestBuilder.get(uri).addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br").build();
         return this.executeWithRetry(request);
     }
 
@@ -240,7 +242,8 @@ public class ApiClient implements AutoCloseable {
     public SimpleHttpResponse getReleaseUpdates(String tag)
             throws ExecutionException, InterruptedException, TimeoutException {
         String uri = this.urlResolver.resolve(this.buildReleasesUpdatesURI(tag));
-        SimpleHttpRequest request = SimpleRequestBuilder.get(uri).build();
+        SimpleHttpRequest request =
+                SimpleRequestBuilder.get(uri).addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br").build();
         return this.executeWithRetry(request);
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -190,7 +190,9 @@ public class ApiClient implements AutoCloseable {
             throws ExecutionException, InterruptedException, TimeoutException {
         String uri = this.urlResolver.resolve(this.buildConsumerURI(consumerUri));
         SimpleHttpRequest request =
-                SimpleRequestBuilder.get(uri).addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br").build();
+                SimpleRequestBuilder.get(uri)
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
+                        .build();
         return this.executeWithRetry(request);
     }
 
@@ -216,7 +218,9 @@ public class ApiClient implements AutoCloseable {
                                 + toOffset);
 
         SimpleHttpRequest request =
-                SimpleRequestBuilder.get(uri).addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br").build();
+                SimpleRequestBuilder.get(uri)
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
+                        .build();
         return this.executeWithRetry(request);
     }
 
@@ -243,7 +247,9 @@ public class ApiClient implements AutoCloseable {
             throws ExecutionException, InterruptedException, TimeoutException {
         String uri = this.urlResolver.resolve(this.buildReleasesUpdatesURI(tag));
         SimpleHttpRequest request =
-                SimpleRequestBuilder.get(uri).addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br").build();
+                SimpleRequestBuilder.get(uri)
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
+                        .build();
         return this.executeWithRetry(request);
     }
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SnapshotClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SnapshotClient.java
@@ -84,6 +84,7 @@ public class SnapshotClient {
             // Setup
             final URI uri = new URI(this.urlResolver.resolve(snapshotURI));
             final HttpGet request = new HttpGet(uri);
+            request.addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br");
             final String filename = uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
             final Path path = this.env.tmpDir().resolve(filename);
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SnapshotClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/SnapshotClient.java
@@ -39,6 +39,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
 
 /** Client responsible for downloading CTI snapshots from a remote source. */
 public class SnapshotClient {
@@ -84,7 +85,7 @@ public class SnapshotClient {
             // Setup
             final URI uri = new URI(this.urlResolver.resolve(snapshotURI));
             final HttpGet request = new HttpGet(uri);
-            request.addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br");
+            request.addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP);
             final String filename = uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
             final Path path = this.env.tmpDir().resolve(filename);
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/HttpResponseCallback.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/utils/HttpResponseCallback.java
@@ -52,6 +52,13 @@ public class HttpResponseCallback implements FutureCallback<SimpleHttpResponse> 
     public void completed(SimpleHttpResponse response) {
         log.debug("{}->{}", this.httpRequest, new StatusLine(response));
         log.debug("Got response: {} {}", response.getCode(), response.getBodyText());
+        log.debug(
+                "CTI compression check: request Accept-Encoding=[{}] response Content-Encoding=[{}]"
+                        + " wireContentLength=[{}] decodedBodyBytes=[{}]",
+                this.httpRequest.getFirstHeader("Accept-Encoding"),
+                response.getFirstHeader("Content-Encoding"),
+                response.getFirstHeader("Content-Length"),
+                response.getBodyBytes() != null ? response.getBodyBytes().length : -1);
     }
 
     @Override

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeoutException;
 import com.wazuh.contentmanager.cti.catalog.utils.HttpResponseCallback;
 import com.wazuh.contentmanager.cti.console.model.Token;
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
 
 /** CTI Console API client. */
 public class ApiClient {
@@ -129,7 +130,7 @@ public class ApiClient {
         SimpleHttpRequest request =
                 SimpleRequestBuilder.post(TOKEN_URI)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.toString())
-                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                         .setBody(formBody, ContentType.APPLICATION_FORM_URLENCODED)
                         .build();
 
@@ -172,7 +173,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.toString())
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
-                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                         .setBody(formBody, ContentType.APPLICATION_FORM_URLENCODED)
                         .build();
 
@@ -211,7 +212,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
-                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                         .build();
 
         final Future<SimpleHttpResponse> future =
@@ -244,7 +245,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
-                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                         .build();
 
         final Future<SimpleHttpResponse> future =
@@ -273,7 +274,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
-                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                         .build();
 
         this.client.execute(
@@ -317,7 +318,7 @@ public class ApiClient {
                 SimpleRequestBuilder.get(url)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
-                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                         .build();
 
         final Future<SimpleHttpResponse> future =
@@ -341,7 +342,7 @@ public class ApiClient {
                 SimpleRequestBuilder.get(url)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
-                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                         .build();
 
         this.client.execute(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
@@ -129,6 +129,7 @@ public class ApiClient {
         SimpleHttpRequest request =
                 SimpleRequestBuilder.post(TOKEN_URI)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.toString())
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
                         .setBody(formBody, ContentType.APPLICATION_FORM_URLENCODED)
                         .build();
 
@@ -171,6 +172,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.toString())
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
                         .setBody(formBody, ContentType.APPLICATION_FORM_URLENCODED)
                         .build();
 
@@ -209,6 +211,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
                         .build();
 
         final Future<SimpleHttpResponse> future =
@@ -241,6 +244,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
                         .build();
 
         final Future<SimpleHttpResponse> future =
@@ -269,6 +273,7 @@ public class ApiClient {
                         .addHeader(HttpHeaders.AUTHORIZATION, token)
                         .addHeader("wazuh-uid", PluginSettings.getInstance().getWazuhUid())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
                         .build();
 
         this.client.execute(
@@ -312,6 +317,7 @@ public class ApiClient {
                 SimpleRequestBuilder.get(url)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
                         .build();
 
         final Future<SimpleHttpResponse> future =
@@ -335,6 +341,7 @@ public class ApiClient {
                 SimpleRequestBuilder.get(url)
                         .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
                         .addHeader("wazuh-tag", "v" + PluginSettings.getInstance().getVersion())
+                        .addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, br")
                         .build();
 
         this.client.execute(

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
@@ -20,10 +20,12 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
 import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
 
 /**
  * Client for handling telemetry-related requests to the Wazuh CTI API. This class extends the base
@@ -52,7 +54,7 @@ public class TelemetryClient extends ApiClient {
                             .addHeader("wazuh-uid", uuid)
                             .addHeader("wazuh-tag", "v" + version)
                             .addHeader("Accept", "application/json")
-                            .addHeader("Accept-Encoding", "gzip, br")
+                            .addHeader(HttpHeaders.ACCEPT_ENCODING, Constants.ACCEPT_ENCODING_GZIP)
                             .build();
 
             log.debug("Sending telemetry ping to: {}", pingUrl);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/TelemetryClient.java
@@ -52,6 +52,7 @@ public class TelemetryClient extends ApiClient {
                             .addHeader("wazuh-uid", uuid)
                             .addHeader("wazuh-tag", "v" + version)
                             .addHeader("Accept", "application/json")
+                            .addHeader("Accept-Encoding", "gzip, br")
                             .build();
 
             log.debug("Sending telemetry ping to: {}", pingUrl);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -840,6 +840,7 @@ public class Constants {
 
     // HTTP headers
     public static final String USER_AGENT_PREFIX = "Wazuh Indexer ";
+    public static final String ACCEPT_ENCODING_GZIP = "gzip";
 
     // IOC type hashes
     public static final String IOC_TYPE_HASHES_ID = "__ioc_type_hashes__";


### PR DESCRIPTION
## Description

Every request the XDR Indexer (content-manager plugin) makes against the CTI service must include the compression acceptance header `Accept-Encoding: gzip`, so that response payloads are transferred compressed instead of as plain text.

HttpClient5 already negotiates gzip transparently by default (`Accept-Encoding: gzip, x-gzip, deflate`, auto-decompressed), so this doesn't add a capability the client didn't already have. The point is to make the exact header value explicit **in code**, on every request, instead of leaving it to the library's implicit default: HttpClient5's own default value includes `x-gzip` and `deflate`, which CTI doesn't need, and relying on a default means the actual wire behavior isn't visible anywhere in this codebase.

## Proposed Changes

- Added an explicit `Accept-Encoding: gzip` header to every outbound HTTP request the content-manager plugin makes to CTI:
  - Catalog `ApiClient` (`getConsumer`, `getChanges`, `getReleaseUpdates`)
  - `SnapshotClient` (snapshot downloads)
  - Console `ApiClient` (token exchange, resource token, plans, environment lookup, catalog plans)
  - `TelemetryClient` (`/ping`)
- The header is set **per request** rather than as a client-level default header. HttpClient5's exec chain runs `ChainElement.COMPRESS` before `ChainElement.PROTOCOL` (where default headers are applied), so its content-compression handling adds its own `Accept-Encoding` first if none is present yet, and the default-header step then skips a header name that's already there — a default header would never actually be inserted. Setting it directly on each request is what reaches the wire as `gzip`.
- Centralized the header value in a new `Constants.ACCEPT_ENCODING_GZIP` constant instead of repeating the string literal `"gzip"` at each of the 12 call sites.
- Added debug-level logging in `HttpResponseCallback` reporting the request's `Accept-Encoding`, the response's `Content-Encoding`, the compressed wire size, and the decompressed body size, to verify compression is negotiated correctly. (Useful for testing this PR; can be removed.)

### Results and Evidence

<!-- The two screenshots below were captured while this PR still proposed `gzip, br` / Brotli support. That approach was dropped (CTI/GIP doesn't support Brotli), so please recapture evidence against the current gzip-only behavior before merging, or drop these if they no longer apply. -->

<img width="1600" height="42" alt="Captura desde 2026-09-04 16-16-57" src="https://github.com/user-attachments/assets/57419e1a-ea33-4e19-a940-11be5cacce84" />

<img width="1304" height="24" alt="imagen" src="https://github.com/user-attachments/assets/3722d6d9-d53e-4324-9e5f-9508dd972aec" />


### Artifacts Affected

- wazuh-indexer-plugins -> content-manager

### Configuration Changes

N/A

### Documentation Updates

- docs/ref/modules/content-manager/architecture.md
- docs/ref/modules/content-manager/configuration.md
- docs/dev/plugins/content-manager.md

### Tests Introduced

N/A — no new tests added. The header value change is covered indirectly by the existing `ApiClient`/`SnapshotClient`/`TelemetryClient` test suites, but no dedicated test asserts the `Accept-Encoding` header value itself.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
