### PR TITLE
Fix resource lock index creation for non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@
 - [BUG] `wazuh-threatintel-enrichments-a` is never created, so the CTI writer auto-creates a dynamically mapped index under the alias name and the home overview's Threat catalog fails [(#1476)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1476)
 - [BUG] Retry sending resources to SAP after failure [(#1487)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1487)
 - [BUG] `privacy_default_per_provider` mapped as object under `dynamic:strict` rejects new provider overrides [(#1498)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1498)
+- [BUG] Resource creation requires `indices:admin/create` on `.wazuh-content-manager-resource-locks` for the calling user [(#1520)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1520)
 
 ## Prior versions
 - []()

--- a/docs/ref/modules/content-manager/architecture.md
+++ b/docs/ref/modules/content-manager/architecture.md
@@ -62,6 +62,25 @@ Interfaces with the Security Analytics plugin. Creates, updates, and deletes Sec
 
 Manages the four content spaces (standard, draft, test, custom). Routes CUD operations to the correct space partitions within system indices. Handles promotion by computing diffs between spaces in the promotion chain (draft → test → custom).
 
+### Resource creation lock
+
+Serializes the "count existing resources, then create if under the configured maximum" sequence so
+concurrent create requests cannot all observe a stale count and overshoot the limit. The mutex is a
+short-lived document with a deterministic ID per (resource type, space) in the hidden
+`.wazuh-content-manager-resource-locks` index, written with `op_type=create` so only one request can
+hold it at a time. It is released when the creation chain finishes, and a lock older than 30 seconds
+is stolen by the next caller so a crashed node cannot block creations permanently.
+
+The lock index is plugin-internal bookkeeping and is never addressed by API consumers:
+
+- It is created once per node at plugin startup, not on the request path.
+- Every operation on it (existence check, create, index, get, delete) runs with the caller's security
+  context stashed, so it is evaluated as the plugin rather than as the REST user. **No role needs
+  index-level privileges on `.wazuh-content-manager-resource-locks`** — see
+  [Access control — Plugin-internal indices](../../security/access-control.md#plugin-internal-indices).
+- The stash covers the lock index only. The resource creation that follows runs with the caller's
+  context restored, so the user's own index-level privileges on the content indices still apply.
+
 ### Engine client
 
 Communicates with the Wazuh Engine via Unix domain socket at `/usr/share/wazuh-indexer/engine/sockets/engine-api-http.sock`. Used for logtest execution, content validation, and configuration reload.
@@ -110,8 +129,11 @@ Job scheduler triggers (every 24h thereafter)
 
 ```
 REST request (POST/PUT/DELETE)
+  → (create only) Acquires the per-(resource type, space) resource creation lock
+  → (create only) Checks the configured resource limit for the space
   → Space service routes to draft space
   → Writes to wazuh-threatintel-rules / wazuh-threatintel-decoders / wazuh-threatintel-integrations / wazuh-threatintel-kvdbs
+  → (create only) Releases the lock
   → Returns created/updated/deleted resource
 ```
 
@@ -260,6 +282,25 @@ The `.wazuh-cti-consumers` index stores one document per consumer type:
   }
 }
 ```
+
+The hidden `.wazuh-content-manager-resource-locks` index holds the short-lived mutex documents
+described in [Resource creation lock](#resource-creation-lock). It is created at node startup, is not
+alias-backed, and is not part of the blue/green swap. Each document is keyed by a UUID derived from
+the resource type and space, and only records when the lock was taken:
+
+```json
+{
+  "_index": ".wazuh-content-manager-resource-locks",
+  "_id": "0f3c9a1e-6f0e-3a4c-9a5a-1b8d4f7c2e11",
+  "_source": {
+    "acquired_at": 1773078119040
+  }
+}
+```
+
+Documents are deleted as soon as the creation that took the lock finishes, so the index is normally
+empty. Being hidden and unaliased, it shows up in neither `_cat/aliases` nor a plain `_cat/indices`;
+list it with `GET _cat/indices/.wazuh-content-manager-resource-locks?expand_wildcards=all&v`.
 
 The `status` field reflects the consumer's synchronization lifecycle:
 

--- a/docs/ref/modules/content-manager/troubleshooting.md
+++ b/docs/ref/modules/content-manager/troubleshooting.md
@@ -121,6 +121,55 @@ This means the CTI API rate-limited the request (HTTP 429). The client now honor
 2. If 429s persist across passes, the instance is being rate-limited by CTI for longer than the retry budget. Increase `plugins.content_manager.client.max_retries` and/or `plugins.content_manager.client.retry_backoff_base_seconds`.
 3. Look for the warning `CTI API rate-limited request [...] (HTTP 429); retrying in {}s` in the logs to confirm the retry path is engaging.
 
+### Resource creation fails with a missing `indices:admin/create` permission
+
+A `POST` to `/rules`, `/decoders`, `/integrations`, `/kvdbs` or `/filters` returns HTTP 429 with
+`Too many concurrent requests creating this resource. Please retry.` even though there is no
+concurrency, and the indexer log shows the security plugin denying `indices:admin/create` on the lock
+index for the requesting user:
+
+```
+[INFO ][o.o.s.p.PrivilegesEvaluatorImpl] No index-level perm match for User [name=wazuh-demo, ...]
+  Resolved [... allIndices=[.wazuh-content-manager-resource-locks] ...]:
+  Insufficient permissions for the referenced index [Action [indices:admin/create]]
+[WARN ][c.w.c.t.AbstractTransportCreateAction] Failed to acquire resource-creation lock for [integration]:
+  no permissions for [indices:admin/create] and User [name=wazuh-demo, ...]
+```
+
+The `.wazuh-content-manager-resource-locks` index is created at node startup and every operation on
+it runs as the plugin, so this can only happen on a node that never completed that startup step
+(check the log for `Failed to create .wazuh-content-manager-resource-locks index, due to: ...`).
+
+Note that the index is hidden and has no alias, so its absence cannot be confirmed with
+`_cat/aliases` or a plain `_cat/indices`.
+
+#### Resolution
+
+1. Confirm whether the index exists:
+
+   ```bash
+   curl -k -u user:pass "https://localhost:9200/_cat/indices/.wazuh-content-manager-resource-locks?expand_wildcards=all&v"
+   ```
+
+2. If it is missing, restart the node — the plugin recreates it during initialization — and check the
+   startup log for the reason it failed the first time (a red cluster or a node still joining are the
+   usual causes).
+3. If a restart is not an option, create it manually with an account that holds
+   `indices:admin/create` (for example via the admin certificate). Only the `acquired_at` field is
+   needed:
+
+   ```bash
+   curl -k -u admin:pass -X PUT "https://localhost:9200/.wazuh-content-manager-resource-locks" \
+     -H 'Content-Type: application/json' -d '{
+       "settings": { "index": { "number_of_replicas": 0, "auto_expand_replicas": "0-1", "hidden": true, "refresh_interval": "-1" } },
+       "mappings": { "dynamic": "strict", "properties": { "acquired_at": { "type": "long" } } }
+     }'
+   ```
+
+4. Do **not** add `indices:admin/create` to the user's role to work around this. No role needs
+   index-level privileges on the lock index — see
+   [Access control — Plugin-internal indices](../../security/access-control.md#plugin-internal-indices).
+
 ## Diagnostic commands
 
 ### Check consumer state

--- a/docs/ref/security/access-control.md
+++ b/docs/ref/security/access-control.md
@@ -115,6 +115,31 @@ Grants every authenticated user access to their own AI assistant conversations, 
 
 The per-owner DLS applies to every user, including `wazuh-admin` and `admin`
 
+## Plugin-internal indices
+
+Some indices are bookkeeping owned by a plugin rather than data a user queries. They are created by
+the plugin at node startup and are only ever read or written by the plugin itself, never on behalf of
+a REST caller, so **custom roles must not be given index-level privileges on them** — a role that
+omits them behaves exactly the same:
+
+| Index | Owner | Purpose |
+| --- | --- | --- |
+| `.wazuh-content-manager-resource-locks` | Content Manager | Short-lived mutex documents that serialize the resource-limit check when creating rules, decoders, integrations, KVDBs and filters. See [Content Manager — Resource creation lock](../modules/content-manager/architecture.md#resource-creation-lock). |
+| `.wazuh-cti-consumers` | Content Manager | CTI synchronization state (status, offsets, source URL) per consumer. |
+| `.wazuh-content-manager-jobs` | Content Manager | Job Scheduler metadata for the catalog sync and telemetry ping jobs. |
+
+Where such an index has to be touched while serving a user request — the resource-creation lock is
+taken and released inside a create request — the plugin stashes the caller's identity for the
+duration of that operation, so it is authorized as the plugin and not as the user. This is what keeps
+these indices out of every role, including custom roles that hold only `plugin:content_manager/*`
+permissions. The stash is scoped to the internal index: the content operation the request came for is
+still authorized against the user's own index permissions on `wazuh-threatintel-*`.
+
+`.wazuh-internal-state` is deliberately not in this list. It is also written by the plugin in its own
+context, but it is additionally declared as a security-plugin system index
+(`plugins.security.system_indices.indices`), and the roles above grant it explicitly because the
+Setup plugin's AI assistant endpoints read and write it on behalf of users.
+
 ## AI assistant administrative API
 
 The AI assistant's providers configuration, assistant-wide settings and field policy live together in the hidden `.wazuh-internal-state` index.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -88,6 +88,7 @@ import com.wazuh.contentmanager.cti.catalog.index.CredentialsIndex;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.cti.catalog.service.EngineContentLoader;
 import com.wazuh.contentmanager.cti.catalog.service.LogtestService;
+import com.wazuh.contentmanager.cti.catalog.service.ResourceLockService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsService;
 import com.wazuh.contentmanager.cti.catalog.service.SecurityAnalyticsServiceImpl;
 import com.wazuh.contentmanager.cti.catalog.service.SnapshotServiceImpl;
@@ -126,6 +127,7 @@ public class ContentManagerPlugin extends Plugin
 
     private ConsumersIndex consumersIndex;
     private CredentialsIndex credentialsIndex;
+    private ResourceLockService resourceLockService;
     private boolean isCredentialsIndexProtected;
     private ThreadPool threadPool;
     private Client client;
@@ -202,6 +204,7 @@ public class ContentManagerPlugin extends Plugin
 
         this.consumersIndex = new ConsumersIndex(client);
         this.credentialsIndex = new CredentialsIndex(client, threadPool);
+        this.resourceLockService = new ResourceLockService(client, threadPool);
         this.setupReadiness = new SetupReadiness(client);
         this.plansService = new PlansServiceImpl();
         this.subscriptionService =
@@ -506,6 +509,26 @@ public class ContentManagerPlugin extends Plugin
                                         log.error(
                                                 Constants.E_LOG_PLUGIN_INDEX_CREATE_FAILED,
                                                 CredentialsIndex.INDEX_NAME,
+                                                e.getMessage(),
+                                                e);
+                                    }
+
+                                    // Provision the resource-creation lock index up front. It is
+                                    // plugin-internal bookkeeping, so creating it here (as the plugin)
+                                    // keeps it off the REST request path, where the create would
+                                    // otherwise be evaluated against the calling user's privileges.
+                                    try {
+                                        CreateIndexResponse locksResponse = this.resourceLockService.createIndex();
+                                        if (locksResponse != null && locksResponse.isAcknowledged()) {
+                                            log.info(
+                                                    Constants.I_LOG_PLUGIN_INDEX_CREATED,
+                                                    locksResponse.index(),
+                                                    locksResponse.isAcknowledged());
+                                        }
+                                    } catch (Exception e) {
+                                        log.error(
+                                                Constants.E_LOG_PLUGIN_INDEX_CREATE_FAILED,
+                                                Constants.INDEX_RESOURCE_LOCKS,
                                                 e.getMessage(),
                                                 e);
                                     }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/AbstractConsumerService.java
@@ -189,9 +189,9 @@ public abstract class AbstractConsumerService {
      * @return {@code true} when the caller should retry this consumer immediately instead of waiting
      *     for the next scheduled run: either a catalog URL was configured but the remote feed could
      *     not be reached (the pass still completes by falling back to the local snapshot, and the
-     *     status is still moved to {@link LocalConsumer.Status#READY}), or the target indices were not
-     *     yet provisioned (nothing was synced, status stays {@code RUNNING}). {@code false} when the
-     *     feed was reached, or when no catalog was configured (nothing to reach).
+     *     status is still moved to {@link LocalConsumer.Status#READY}), or the target indices were
+     *     not yet provisioned (nothing was synced, status stays {@code RUNNING}). {@code false} when
+     *     the feed was reached, or when no catalog was configured (nothing to reach).
      */
     public boolean synchronize() {
         this.setConsumerStatus(LocalConsumer.Status.RUNNING);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ResourceLockService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ResourceLockService.java
@@ -22,12 +22,15 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.ContextPreservingActionListener;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.threadpool.ThreadPool;
@@ -39,7 +42,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.ClusterInfo;
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -52,6 +59,18 @@ import com.wazuh.contentmanager.utils.Constants;
  * and space -- the same atomic-guard technique used by {@link SpaceService#initializeSpace}. The
  * resource count itself remains a live search against the resource index; the lock only prevents
  * two requests from evaluating that count concurrently.
+ *
+ * <p>{@link Constants#INDEX_RESOURCE_LOCKS} is plugin-internal bookkeeping and is never addressed
+ * by API consumers, so every operation on it runs with the caller's security context stashed and is
+ * therefore evaluated as the plugin itself. No role needs index-level privileges (in particular
+ * {@code indices:admin/create}) on the lock index for its holder to create content resources. The
+ * index is provisioned at node startup by {@code ContentManagerPlugin.start()}; {@link
+ * #acquire(String, String, ActionListener)} still recreates it on demand in case it is deleted
+ * while the node is running.
+ *
+ * <p>The stash covers the lock index only: the listener passed to {@link #acquire(String, String,
+ * ActionListener)} is invoked with the caller's context restored, so the resource creation it goes
+ * on to perform is still authorized as the REST user.
  */
 public class ResourceLockService {
     private static final Logger log = LogManager.getLogger(ResourceLockService.class);
@@ -65,11 +84,71 @@ public class ResourceLockService {
      * Constructor.
      *
      * @param client OpenSearch client used for index operations.
-     * @param threadPool Thread pool used for scheduling retry backoff.
+     * @param threadPool Thread pool used for scheduling retry backoff and for stashing the caller's
+     *     security context.
      */
     public ResourceLockService(Client client, ThreadPool threadPool) {
         this.client = client;
         this.threadPool = threadPool;
+    }
+
+    /**
+     * Stashes the current thread context (removing the caller's security identity) so that subsequent
+     * client operations run as the plugin itself, which owns the lock index.
+     *
+     * @return a {@link ThreadContext.StoredContext} that must be closed to restore the original
+     *     context (use in try-with-resources).
+     */
+    private ThreadContext.StoredContext stashContext() {
+        return this.threadPool.getThreadContext().stashContext();
+    }
+
+    /**
+     * Creates the lock index if it does not exist yet. Called once per node at plugin startup so the
+     * index is provisioned before any REST request needs it, instead of being created on the request
+     * path.
+     *
+     * @return the CreateIndexResponse, or null if the index already exists or its mapping could not
+     *     be read.
+     * @throws ExecutionException if the client failed to execute the request.
+     * @throws InterruptedException if the current thread was interrupted while waiting for the
+     *     response.
+     * @throws TimeoutException if the operation exceeded the configured client timeout.
+     */
+    public CreateIndexResponse createIndex()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        // Stash the caller's security context so the client runs as the plugin, which owns this index.
+        try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            CreateIndexRequest request;
+            try {
+                request = buildCreateIndexRequest();
+            } catch (IOException e) {
+                log.error(
+                        "Could not read mappings for index [{}]: {}",
+                        Constants.INDEX_RESOURCE_LOCKS,
+                        e.getMessage());
+                return null;
+            }
+
+            try {
+                return this.client
+                        .admin()
+                        .indices()
+                        .create(request)
+                        .get(PluginSettings.getInstance().getClientTimeout(), TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException e) {
+                boolean alreadyExists =
+                        e instanceof ExecutionException
+                                ? ExceptionsHelper.unwrap(e, ResourceAlreadyExistsException.class) != null
+                                : ClusterInfo.indexExists(this.client, Constants.INDEX_RESOURCE_LOCKS);
+                if (alreadyExists) {
+                    log.debug(
+                            "Index [{}] already exists, skipping creation.", Constants.INDEX_RESOURCE_LOCKS);
+                    return null;
+                }
+                throw e;
+            }
+        }
     }
 
     /**
@@ -82,13 +161,20 @@ public class ResourceLockService {
      *     lock could not be acquired after {@link Constants#MAX_LOCK_ACQUIRE_RETRIES} attempts.
      */
     public void acquire(String resourceType, String space, ActionListener<String> listener) {
+        // Only the lock index is touched as the plugin. The caller's continuation creates the actual
+        // content resource, so it must keep running as the REST user for its index-level privileges to
+        // be enforced: capture the caller's context before the first stash and restore it around the
+        // callback.
+        ActionListener<String> callerContextListener =
+                ContextPreservingActionListener.wrapPreservingContext(
+                        listener, this.threadPool.getThreadContext());
         this.ensureIndexExists(
                 ActionListener.wrap(
                         v -> {
                             String lockId = lockId(resourceType, space);
-                            this.tryAcquire(lockId, resourceType, space, 1, listener);
+                            this.tryAcquire(lockId, resourceType, space, 1, callerContextListener);
                         },
-                        listener::onFailure));
+                        callerContextListener::onFailure));
     }
 
     private void tryAcquire(
@@ -115,40 +201,42 @@ public class ResourceLockService {
                         .opType(DocWriteRequest.OpType.CREATE)
                         .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-        this.client.index(
-                request,
-                ActionListener.wrap(
-                        response -> listener.onResponse(lockId),
-                        e -> {
-                            if (ExceptionsHelper.unwrap(e, VersionConflictEngineException.class) == null) {
-                                listener.onFailure(e);
-                                return;
-                            }
-                            this.stealIfStale(
-                                    lockId,
-                                    ActionListener.wrap(
-                                            stolen -> {
-                                                if (stolen) {
-                                                    this.tryAcquire(lockId, resourceType, space, attempt + 1, listener);
-                                                } else {
-                                                    this.threadPool.schedule(
-                                                            () ->
-                                                                    this.tryAcquire(
-                                                                            lockId, resourceType, space, attempt + 1, listener),
-                                                            TimeValue.timeValueMillis(
-                                                                    Constants.LOCK_ACQUIRE_RETRY_BACKOFF_MILLIS),
-                                                            ThreadPool.Names.GENERIC);
-                                                }
-                                            },
-                                            ex ->
-                                                    this.threadPool.schedule(
-                                                            () ->
-                                                                    this.tryAcquire(
-                                                                            lockId, resourceType, space, attempt + 1, listener),
-                                                            TimeValue.timeValueMillis(
-                                                                    Constants.LOCK_ACQUIRE_RETRY_BACKOFF_MILLIS),
-                                                            ThreadPool.Names.GENERIC)));
-                        }));
+        try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            this.client.index(
+                    request,
+                    ActionListener.wrap(
+                            response -> listener.onResponse(lockId),
+                            e -> {
+                                if (ExceptionsHelper.unwrap(e, VersionConflictEngineException.class) == null) {
+                                    listener.onFailure(e);
+                                    return;
+                                }
+                                this.stealIfStale(
+                                        lockId,
+                                        ActionListener.wrap(
+                                                stolen -> {
+                                                    if (stolen) {
+                                                        this.tryAcquire(lockId, resourceType, space, attempt + 1, listener);
+                                                    } else {
+                                                        this.threadPool.schedule(
+                                                                () ->
+                                                                        this.tryAcquire(
+                                                                                lockId, resourceType, space, attempt + 1, listener),
+                                                                TimeValue.timeValueMillis(
+                                                                        Constants.LOCK_ACQUIRE_RETRY_BACKOFF_MILLIS),
+                                                                ThreadPool.Names.GENERIC);
+                                                    }
+                                                },
+                                                ex ->
+                                                        this.threadPool.schedule(
+                                                                () ->
+                                                                        this.tryAcquire(
+                                                                                lockId, resourceType, space, attempt + 1, listener),
+                                                                TimeValue.timeValueMillis(
+                                                                        Constants.LOCK_ACQUIRE_RETRY_BACKOFF_MILLIS),
+                                                                ThreadPool.Names.GENERIC)));
+                            }));
+        }
     }
 
     /**
@@ -160,14 +248,18 @@ public class ResourceLockService {
      *     ActionListener)}.
      */
     public void release(String lockId) {
-        this.client.delete(
-                new DeleteRequest(Constants.INDEX_RESOURCE_LOCKS, lockId)
-                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
-                ActionListener.wrap(
-                        response -> {},
-                        e ->
-                                log.warn(
-                                        "Failed to release resource-creation lock [{}]: {}", lockId, e.getMessage())));
+        try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            this.client.delete(
+                    new DeleteRequest(Constants.INDEX_RESOURCE_LOCKS, lockId)
+                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+                    ActionListener.wrap(
+                            response -> {},
+                            e ->
+                                    log.warn(
+                                            "Failed to release resource-creation lock [{}]: {}",
+                                            lockId,
+                                            e.getMessage())));
+        }
     }
 
     /**
@@ -180,44 +272,52 @@ public class ResourceLockService {
      *     caller should retry immediately.
      */
     private void stealIfStale(String lockId, ActionListener<Boolean> listener) {
-        this.client.get(
-                new GetRequest(Constants.INDEX_RESOURCE_LOCKS, lockId),
-                ActionListener.wrap(
-                        response -> {
-                            if (!response.isExists()) {
-                                listener.onResponse(true);
-                                return;
-                            }
-                            Map<String, Object> source = response.getSourceAsMap();
-                            Object acquiredAt = source != null ? source.get(ACQUIRED_AT_FIELD) : null;
-                            long acquiredAtMillis =
-                                    acquiredAt instanceof Number ? ((Number) acquiredAt).longValue() : 0L;
-                            if (Instant.now().toEpochMilli() - acquiredAtMillis
-                                    <= Constants.LOCK_STALE_THRESHOLD_MILLIS) {
+        try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            this.client.get(
+                    new GetRequest(Constants.INDEX_RESOURCE_LOCKS, lockId),
+                    ActionListener.wrap(
+                            response -> {
+                                if (!response.isExists()) {
+                                    listener.onResponse(true);
+                                    return;
+                                }
+                                Map<String, Object> source = response.getSourceAsMap();
+                                Object acquiredAt = source != null ? source.get(ACQUIRED_AT_FIELD) : null;
+                                long acquiredAtMillis =
+                                        acquiredAt instanceof Number ? ((Number) acquiredAt).longValue() : 0L;
+                                if (Instant.now().toEpochMilli() - acquiredAtMillis
+                                        <= Constants.LOCK_STALE_THRESHOLD_MILLIS) {
+                                    listener.onResponse(false);
+                                    return;
+                                }
+                                log.warn("Stealing stale resource-creation lock [{}].", lockId);
+                                this.deleteStaleLock(lockId, listener);
+                            },
+                            e -> {
+                                log.warn(
+                                        "Failed to check staleness of resource-creation lock [{}]: {}",
+                                        lockId,
+                                        e.getMessage());
                                 listener.onResponse(false);
-                                return;
-                            }
-                            log.warn("Stealing stale resource-creation lock [{}].", lockId);
-                            this.client.delete(
-                                    new DeleteRequest(Constants.INDEX_RESOURCE_LOCKS, lockId)
-                                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
-                                    ActionListener.wrap(
-                                            deleteResponse -> listener.onResponse(true),
-                                            e -> {
-                                                log.warn(
-                                                        "Failed to steal stale resource-creation lock" + " [{}]: {}",
-                                                        lockId,
-                                                        e.getMessage());
-                                                listener.onResponse(false);
-                                            }));
-                        },
-                        e -> {
-                            log.warn(
-                                    "Failed to check staleness of resource-creation lock [{}]: {}",
-                                    lockId,
-                                    e.getMessage());
-                            listener.onResponse(false);
-                        }));
+                            }));
+        }
+    }
+
+    private void deleteStaleLock(String lockId, ActionListener<Boolean> listener) {
+        try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            this.client.delete(
+                    new DeleteRequest(Constants.INDEX_RESOURCE_LOCKS, lockId)
+                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+                    ActionListener.wrap(
+                            deleteResponse -> listener.onResponse(true),
+                            e -> {
+                                log.warn(
+                                        "Failed to steal stale resource-creation lock" + " [{}]: {}",
+                                        lockId,
+                                        e.getMessage());
+                                listener.onResponse(false);
+                            }));
+        }
     }
 
     private static String lockId(String resourceType, String space) {
@@ -227,21 +327,57 @@ public class ResourceLockService {
     }
 
     private void ensureIndexExists(ActionListener<Void> listener) {
-        ClusterInfo.indexExists(
-                this.client,
-                Constants.INDEX_RESOURCE_LOCKS,
-                ActionListener.wrap(
-                        exists -> {
-                            if (exists) {
-                                listener.onResponse(null);
-                                return;
-                            }
-                            this.createIndex(listener);
-                        },
-                        listener::onFailure));
+        try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            ClusterInfo.indexExists(
+                    this.client,
+                    Constants.INDEX_RESOURCE_LOCKS,
+                    ActionListener.wrap(
+                            exists -> {
+                                if (exists) {
+                                    listener.onResponse(null);
+                                    return;
+                                }
+                                this.createIndexAsync(listener);
+                            },
+                            listener::onFailure));
+        }
     }
 
-    private void createIndex(ActionListener<Void> listener) {
+    private void createIndexAsync(ActionListener<Void> listener) {
+        try (ThreadContext.StoredContext ignored = this.stashContext()) {
+            CreateIndexRequest request;
+            try {
+                request = buildCreateIndexRequest();
+            } catch (IOException e) {
+                log.error(
+                        "Could not read mappings for index [{}]: {}",
+                        Constants.INDEX_RESOURCE_LOCKS,
+                        e.getMessage());
+                listener.onResponse(null);
+                return;
+            }
+
+            this.client
+                    .admin()
+                    .indices()
+                    .create(
+                            request,
+                            ActionListener.wrap(
+                                    response -> listener.onResponse(null),
+                                    e -> {
+                                        if (ExceptionsHelper.unwrap(e, ResourceAlreadyExistsException.class) != null) {
+                                            log.debug(
+                                                    "Index [{}] already exists, skipping creation.",
+                                                    Constants.INDEX_RESOURCE_LOCKS);
+                                            listener.onResponse(null);
+                                        } else {
+                                            listener.onFailure(e);
+                                        }
+                                    }));
+        }
+    }
+
+    private static CreateIndexRequest buildCreateIndexRequest() throws IOException {
         Settings settings =
                 Settings.builder()
                         .put("index.number_of_replicas", 0)
@@ -251,40 +387,10 @@ public class ResourceLockService {
                         .put(Constants.KEY_INDEX_REFRESH_INTERVAL, Constants.REFRESH_INTERVAL_DISABLED)
                         .build();
 
-        String mappings;
-        try {
-            mappings = loadMappingFromResources();
-        } catch (IOException e) {
-            log.error(
-                    "Could not read mappings for index [{}]: {}",
-                    Constants.INDEX_RESOURCE_LOCKS,
-                    e.getMessage());
-            listener.onResponse(null);
-            return;
-        }
-
-        CreateIndexRequest request =
-                new CreateIndexRequest()
-                        .index(Constants.INDEX_RESOURCE_LOCKS)
-                        .mapping(mappings)
-                        .settings(settings);
-        this.client
-                .admin()
-                .indices()
-                .create(
-                        request,
-                        ActionListener.wrap(
-                                response -> listener.onResponse(null),
-                                e -> {
-                                    if (ExceptionsHelper.unwrap(e, ResourceAlreadyExistsException.class) != null) {
-                                        log.debug(
-                                                "Index [{}] already exists, skipping creation.",
-                                                Constants.INDEX_RESOURCE_LOCKS);
-                                        listener.onResponse(null);
-                                    } else {
-                                        listener.onFailure(e);
-                                    }
-                                }));
+        return new CreateIndexRequest()
+                .index(Constants.INDEX_RESOURCE_LOCKS)
+                .mapping(loadMappingFromResources())
+                .settings(settings);
     }
 
     private static String loadMappingFromResources() throws IOException {

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ResourceLockServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ResourceLockServiceTests.java
@@ -16,6 +16,7 @@
  */
 package com.wazuh.contentmanager.cti.catalog.service;
 
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
@@ -24,7 +25,9 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.engine.VersionConflictEngineException;
@@ -36,7 +39,10 @@ import org.opensearch.transport.client.IndicesAdminClient;
 import org.junit.Assert;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.wazuh.contentmanager.utils.Constants;
 
@@ -53,19 +59,35 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("unchecked")
 public class ResourceLockServiceTests extends OpenSearchTestCase {
 
+    /** Header the security plugin uses to carry the authenticated user across the transport layer. */
+    private static final String SECURITY_USER_HEADER = "_opendistro_security_user_info";
+
     private static VersionConflictEngineException versionConflict() {
         return new VersionConflictEngineException(
                 new ShardId(Constants.INDEX_RESOURCE_LOCKS, "uuid", 0), "lock-id", "already locked");
     }
 
-    /** Mocks the client.admin().indices().exists() chain to report the lock index already exists. */
-    private static void mockLockIndexExists(Client client) {
+    /**
+     * Mocks the client.admin().indices().exists() chain to report the lock index already exists.
+     *
+     * @return the mocked indices admin client, so callers can assert on index creation.
+     */
+    private static IndicesAdminClient mockLockIndexExists(Client client) {
+        return mockLockIndexExists(client, () -> {});
+    }
+
+    /**
+     * Same as {@link #mockLockIndexExists(Client)}, running {@code onExists} when the existence check
+     * is issued so tests can observe the thread context in effect at that moment.
+     */
+    private static IndicesAdminClient mockLockIndexExists(Client client, Runnable onExists) {
         AdminClient adminClient = mock(AdminClient.class);
         IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
         IndicesExistsResponse existsResponse = mock(IndicesExistsResponse.class);
         when(existsResponse.isExists()).thenReturn(true);
         doAnswer(
                         invocation -> {
+                            onExists.run();
                             ActionListener<IndicesExistsResponse> l = invocation.getArgument(1);
                             l.onResponse(existsResponse);
                             return null;
@@ -74,16 +96,26 @@ public class ResourceLockServiceTests extends OpenSearchTestCase {
                 .exists(any(), any(ActionListener.class));
         when(adminClient.indices()).thenReturn(indicesAdminClient);
         when(client.admin()).thenReturn(adminClient);
+        return indicesAdminClient;
     }
 
     /** Mocks async client.get() to report a lock document last acquired {@code ageMillis} ago. */
     private static void mockLockGet(Client client, long ageMillis) {
+        mockLockGet(client, ageMillis, () -> {});
+    }
+
+    /**
+     * Same as {@link #mockLockGet(Client, long)}, running {@code onGet} when the get is issued so
+     * tests can observe the thread context in effect at that moment.
+     */
+    private static void mockLockGet(Client client, long ageMillis, Runnable onGet) {
         GetResponse getResponse = mock(GetResponse.class);
         when(getResponse.isExists()).thenReturn(true);
         when(getResponse.getSourceAsMap())
                 .thenReturn(Map.of("acquired_at", Instant.now().toEpochMilli() - ageMillis));
         doAnswer(
                         invocation -> {
+                            onGet.run();
                             ActionListener<GetResponse> l = invocation.getArgument(1);
                             l.onResponse(getResponse);
                             return null;
@@ -92,9 +124,13 @@ public class ResourceLockServiceTests extends OpenSearchTestCase {
                 .get(any(GetRequest.class), any(ActionListener.class));
     }
 
-    /** Creates a ThreadPool mock that executes scheduled runnables immediately. */
-    private static ThreadPool immediateThreadPool() {
+    /**
+     * Creates a ThreadPool mock that executes scheduled runnables immediately and exposes the given
+     * thread context, which the service stashes before every lock operation.
+     */
+    private static ThreadPool immediateThreadPool(ThreadContext threadContext) {
         ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
         doAnswer(
                         invocation -> {
                             ((Runnable) invocation.getArgument(0)).run();
@@ -103,6 +139,11 @@ public class ResourceLockServiceTests extends OpenSearchTestCase {
                 .when(threadPool)
                 .schedule(any(Runnable.class), any(TimeValue.class), anyString());
         return threadPool;
+    }
+
+    /** Creates a ThreadPool mock with an empty thread context. */
+    private static ThreadPool immediateThreadPool() {
+        return immediateThreadPool(new ThreadContext(Settings.EMPTY));
     }
 
     public void testAcquireSucceedsImmediatelyWhenNoLockExists() {
@@ -216,6 +257,114 @@ public class ResourceLockServiceTests extends OpenSearchTestCase {
         Throwable cause = e.getCause() != null ? e.getCause() : e;
         Assert.assertTrue(cause.getMessage().contains("Timed out"));
         verify(client, never()).delete(any(DeleteRequest.class), any(ActionListener.class));
+    }
+
+    public void testAcquireDoesNotCreateTheIndexWhenItAlreadyExists() {
+        Client client = mock(Client.class);
+        IndicesAdminClient indicesAdminClient = mockLockIndexExists(client);
+        doAnswer(
+                        invocation -> {
+                            ActionListener<IndexResponse> l = invocation.getArgument(1);
+                            l.onResponse(mock(IndexResponse.class));
+                            return null;
+                        })
+                .when(client)
+                .index(any(IndexRequest.class), any(ActionListener.class));
+
+        ResourceLockService service = new ResourceLockService(client, immediateThreadPool());
+        PlainActionFuture<String> future = new PlainActionFuture<>();
+        service.acquire("rule", "draft", future);
+
+        Assert.assertNotNull(future.actionGet());
+        verify(indicesAdminClient, never())
+                .create(any(CreateIndexRequest.class), any(ActionListener.class));
+    }
+
+    public void testLockOperationsRunWithTheCallerSecurityContextStashed() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putHeader(SECURITY_USER_HEADER, "wazuh-demo");
+        // A null entry means the caller identity was not visible when the request was issued, so the
+        // operation is evaluated as the plugin instead of as the REST user.
+        List<String> observedIdentities = new ArrayList<>();
+        Runnable observe = () -> observedIdentities.add(threadContext.getHeader(SECURITY_USER_HEADER));
+
+        Client client = mock(Client.class);
+        mockLockIndexExists(client, observe);
+        // Stale lock, so the acquire exercises index -> get -> delete -> index.
+        mockLockGet(client, Constants.LOCK_STALE_THRESHOLD_MILLIS + 1000, observe);
+        doAnswer(
+                        invocation -> {
+                            observe.run();
+                            ActionListener<IndexResponse> l = invocation.getArgument(1);
+                            l.onFailure(versionConflict());
+                            return null;
+                        })
+                .doAnswer(
+                        invocation -> {
+                            observe.run();
+                            ActionListener<IndexResponse> l = invocation.getArgument(1);
+                            l.onResponse(mock(IndexResponse.class));
+                            return null;
+                        })
+                .when(client)
+                .index(any(IndexRequest.class), any(ActionListener.class));
+        doAnswer(
+                        invocation -> {
+                            observe.run();
+                            ActionListener<DeleteResponse> l = invocation.getArgument(1);
+                            l.onResponse(mock(DeleteResponse.class));
+                            return null;
+                        })
+                .when(client)
+                .delete(any(DeleteRequest.class), any(ActionListener.class));
+
+        ResourceLockService service =
+                new ResourceLockService(client, immediateThreadPool(threadContext));
+        PlainActionFuture<String> future = new PlainActionFuture<>();
+        service.acquire("rule", "draft", future);
+        String lockId = future.actionGet();
+        service.release(lockId);
+
+        // exists + index + get + delete (steal) + index (retry) + delete (release).
+        Assert.assertEquals(6, observedIdentities.size());
+        observedIdentities.forEach(Assert::assertNull);
+        // The caller's context is restored once each operation has been issued.
+        Assert.assertEquals("wazuh-demo", threadContext.getHeader(SECURITY_USER_HEADER));
+    }
+
+    public void testAcquireCallbackRunsWithTheCallerSecurityContext() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putHeader(SECURITY_USER_HEADER, "wazuh-demo");
+
+        Client client = mock(Client.class);
+        mockLockIndexExists(client);
+        doAnswer(
+                        invocation -> {
+                            ActionListener<IndexResponse> l = invocation.getArgument(1);
+                            l.onResponse(mock(IndexResponse.class));
+                            return null;
+                        })
+                .when(client)
+                .index(any(IndexRequest.class), any(ActionListener.class));
+
+        ResourceLockService service =
+                new ResourceLockService(client, immediateThreadPool(threadContext));
+        AtomicReference<String> identityInCallback = new AtomicReference<>();
+        PlainActionFuture<String> future = new PlainActionFuture<>();
+        service.acquire(
+                "rule",
+                "draft",
+                ActionListener.wrap(
+                        lockId -> {
+                            // The resource creation continues here and must still be authorized as the
+                            // REST user, not as the plugin.
+                            identityInCallback.set(threadContext.getHeader(SECURITY_USER_HEADER));
+                            future.onResponse(lockId);
+                        },
+                        future::onFailure));
+
+        Assert.assertNotNull(future.actionGet());
+        Assert.assertEquals("wazuh-demo", identityInCallback.get());
     }
 
     public void testReleaseSwallowsExceptions() {

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateDecoderActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateDecoderActionTests.java
@@ -29,6 +29,7 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
@@ -78,6 +79,8 @@ public class TransportCreateDecoderActionTests extends OpenSearchTestCase {
         this.engineService = mock(EngineService.class);
         TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        // ResourceLockService stashes the caller's context around every lock operation.
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         doAnswer(
                         invocation -> {
                             ((Runnable) invocation.getArgument(0)).run();

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateFilterActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateFilterActionTests.java
@@ -29,6 +29,7 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
@@ -84,6 +85,8 @@ public class TransportCreateFilterActionTests extends OpenSearchTestCase {
         stubResourceLock(this.client);
         TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        // ResourceLockService stashes the caller's context around every lock operation.
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         doAnswer(
                         invocation -> {
                             ((Runnable) invocation.getArgument(0)).run();

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateIntegrationActionTests.java
@@ -29,6 +29,7 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
@@ -80,6 +81,8 @@ public class TransportCreateIntegrationActionTests extends OpenSearchTestCase {
         stubResourceLock(this.client);
         TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        // ResourceLockService stashes the caller's context around every lock operation.
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         doAnswer(
                         invocation -> {
                             ((Runnable) invocation.getArgument(0)).run();

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateKvdbActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateKvdbActionTests.java
@@ -30,6 +30,7 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
@@ -83,6 +84,8 @@ public class TransportCreateKvdbActionTests extends OpenSearchTestCase {
         stubResourceLock(this.client);
         TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        // ResourceLockService stashes the caller's context around every lock operation.
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         doAnswer(
                         invocation -> {
                             ((Runnable) invocation.getArgument(0)).run();

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateRuleActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportCreateRuleActionTests.java
@@ -30,6 +30,7 @@ import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
@@ -83,6 +84,8 @@ public class TransportCreateRuleActionTests extends OpenSearchTestCase {
         stubResourceLock(this.client);
         TransportService transportService = mock(TransportService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        // ResourceLockService stashes the caller's context around every lock operation.
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         doAnswer(
                         invocation -> {
                             ((Runnable) invocation.getArgument(0)).run();


### PR DESCRIPTION
### Description

Content resource creation (`POST /_plugins/_content_manager/{integrations,rules,decoders,kvdbs,filters}/{id}`) failed for `wazuh-demo` with HTTP 429 `Too many concurrent requests creating this resource. Please retry.`, because the request tried to **create** the `.wazuh-content-manager-resource-locks` index as the calling user:

```
[INFO ][o.o.s.p.PrivilegesEvaluatorImpl] No index-level perm match for User [name=wazuh-demo, ...] Resolved [... allIndices=[.wazuh-content-manager-resource-locks] ...]: Insufficient permissions for the referenced index [Action [indices:admin/create]]
[WARN ][c.w.c.t.AbstractTransportCreateAction] Failed to acquire resource-creation lock for [integration]: no permissions for [indices:admin/create] and User [name=wazuh-demo, ...]
```

Two causes, both fixed here:

1. `ResourceLockService` never stashed the thread context, so every lock-index operation — including the index creation — was evaluated against the REST user's privileges instead of the plugin's.
2. The lock index was created lazily on the request path; unlike `.wazuh-cti-consumers` and `.wazuh-internal-state`, it was not provisioned at plugin startup.

Since `indices:admin/create` on that index is granted to neither `wazuh_demo` nor `wazuh_admin`, on a fresh cluster nothing in the normal user path could ever bring the index into existence, and every resource creation failed until an `all_access` account or the admin certificate created it manually.

**Changes**

`ResourceLockService`:

- Every lock-index operation (existence check, create, index, get, delete) now runs inside `stashContext()`, mirroring `CredentialsIndex` and `CatalogSyncJob`, so it is authorized as the plugin.
- New public blocking `createIndex()` for startup provisioning, sharing `buildCreateIndexRequest()` with the lazy path. The lazy path stays as a safety net for an index deleted while the node is running.
- `acquire()` wraps the caller's listener in `ContextPreservingActionListener.wrapPreservingContext()`. Without it the stash would leak into the rest of the create flow and the writes to `wazuh-threatintel-*` would run unauthorized-as-plugin. The stash is now scoped to the lock index; the content operation the request came for is still authorized against the user's own index permissions.

`ContentManagerPlugin.start()`: provisions the lock index alongside the consumers and credentials indices, before the `setupReadiness` early return so it always runs.

This makes the fix hold for **any** role, present or future, including custom roles that carry only `plugin:content_manager/*` permissions — no role needs index-level privileges on the lock index. Adding `indices:admin/create` to the shipped roles was rejected as the fix: the role's pattern block also covers `wazuh-threatintel-*` and `.opensearch-sap-*`, and it would leave every future custom role needing a grant on an index that is none of its business.

**Tests**

719 unit tests pass. Three new cases in `ResourceLockServiceTests`:

- lock operations are issued with the caller's identity stashed;
- the `acquire()` callback runs with the caller's identity restored (verified as a real guard: removing the `wrapPreservingContext` call fails it with `expected:<wazuh-demo> but was:<null>`);
- no index creation is attempted when the index already exists.

The five `TransportCreate*ActionTests` needed `getThreadContext()` stubbed on their mocked thread pools.

**Documentation**

- `docs/ref/modules/content-manager/architecture.md` — new "Resource creation lock" component, the lock's place in the CUD flow, and the index documented under "Index structure".
- `docs/ref/security/access-control.md` — new "Plugin-internal indices" section: these indices are plugin-owned, are touched in the plugin's own context, and must not be granted to roles.
- `docs/ref/modules/content-manager/troubleshooting.md` — the symptom and log signature, the `_cat/aliases` red herring (the index is hidden and unaliased, so it shows up in neither `_cat/aliases` nor a plain `_cat/indices`), and a manual-creation escape hatch.

mdBook builds clean and the new cross-links and anchors resolve.

**Notes for reviewers**

- The `.wazuh-content-manager-resource-locks` entries in the `wazuh_admin` and `wazuh_demo` index-permission blocks of `roles.wazuh.yml` (`wazuh-indexer` repo) are now vestigial and can be dropped in a follow-up. Removing them requires a `securityadmin` reapply on existing clusters, so it is not a prerequisite for this fix.
- `spotlessCheck` reports one pre-existing violation in `AbstractConsumerService.java` (a javadoc rewrap from google-java-format version drift, unrelated to this change). Left untouched to keep the diff focused; CI disables `enforceCheck`.

### Issues Resolved

Closes #1520
