### PR TITLE
Add helper function to release PITs

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocService.java
@@ -176,10 +176,35 @@ public class ConsumerIocService extends AbstractConsumerService {
         } catch (Exception e) {
             log.error(Constants.E_LOG_IOC_TYPE_HASHES_FAILED, e.getMessage(), e);
         } finally {
-            DeletePitRequest deletePitRequest = new DeletePitRequest(pitId);
-            this.client.execute(DeletePitAction.INSTANCE, deletePitRequest).actionGet();
+            this.releasePit(pitId);
         }
         return typeHashes;
+    }
+
+    /**
+     * Releases a point-in-time context on a best-effort basis.
+     *
+     * <p>Both PIT users call this from a {@code finally} block, so it must never throw: a failure to
+     * release is not a failure of the work the PIT was opened for. Letting it propagate would either
+     * mask the exception that is already unwinding (in {@link #export()}, whose {@code try} has no
+     * {@code catch}) or turn a completed pass into a failed one (in {@link
+     * #computeAndStoreTypeHashes()}, where the {@code finally} is the only thing that can throw out
+     * of the method, which would mark the consumer FAILED and skip the Engine IOC update).
+     *
+     * <p>Nothing is leaked by giving up: the context expires on its own after {@code
+     * plugins.content_manager.pit_keepalive}, and contexts held by a node that has left the cluster
+     * died with it. The most likely cause is exactly that — a node stopping or restarting while the
+     * IOC sync runs — so this is logged at debug.
+     *
+     * @param pitId The identifier of the PIT to release.
+     */
+    private void releasePit(String pitId) {
+        try {
+            DeletePitRequest deletePitRequest = new DeletePitRequest(pitId);
+            this.client.execute(DeletePitAction.INSTANCE, deletePitRequest).actionGet();
+        } catch (Exception e) {
+            log.debug(Constants.D_LOG_IOC_PIT_RELEASE_FAILED, pitId, e.getMessage());
+        }
     }
 
     /**
@@ -335,8 +360,7 @@ public class ConsumerIocService extends AbstractConsumerService {
                         }
                     });
         } finally {
-            DeletePitRequest deletePitRequest = new DeletePitRequest(pitId);
-            this.client.execute(DeletePitAction.INSTANCE, deletePitRequest).actionGet();
+            this.releasePit(pitId);
         }
 
         log.debug(Constants.D_LOG_IOC_EXPORT_COMPLETE, outputPath);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -449,6 +449,8 @@ public class Constants {
     public static final String E_LOG_IOC_TYPE_HASHES_FAILED =
             "Failed to compute and store IOC type hashes: {}";
     public static final String D_LOG_IOC_ENGINE_REPLY = "Engine reply to IOC load request: {}";
+    public static final String D_LOG_IOC_PIT_RELEASE_FAILED =
+            "Failed to release the IOC point-in-time context [{}]: {}";
 
     // Log messages - space / index / index swap (SpaceService, ContentIndex, IndexSwapHelper)
     public static final String E_LOG_DELETE_SPACE_RESOURCES_FAILED =

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/ConsumerIocServiceTests.java
@@ -176,6 +176,41 @@ public class ConsumerIocServiceTests extends OpenSearchTestCase {
         when(this.client.index(any(IndexRequest.class))).thenReturn(indexFuture);
     }
 
+    /** Mocks a search that returns no documents, so the single pass terminates immediately. */
+    @SuppressWarnings("unchecked")
+    private void mockEmptySearch() {
+        SearchResponse emptySearchResponse = mock(SearchResponse.class);
+        when(emptySearchResponse.getHits()).thenReturn(SearchHits.empty());
+        ActionFuture<SearchResponse> emptyFuture = mock(ActionFuture.class);
+        when(emptyFuture.actionGet()).thenReturn(emptySearchResponse);
+        when(this.client.search(any(SearchRequest.class))).thenReturn(emptyFuture);
+    }
+
+    /**
+     * Mocks PIT creation, and PIT release such that the release identified by {@code failingRelease}
+     * (1-based: 1 is the hash pass, 2 is the export) fails the way a node leaving the cluster
+     * mid-sync makes it fail.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void mockPitLifecycleWithFailingRelease(int failingRelease) {
+        CreatePitResponse pitResponse = mock(CreatePitResponse.class);
+        when(pitResponse.getId()).thenReturn("test-pit-id");
+        ActionFuture<CreatePitResponse> pitFuture = mock(ActionFuture.class);
+        when(pitFuture.actionGet()).thenReturn(pitResponse);
+        when(this.client.execute(eq(CreatePitAction.INSTANCE), any(CreatePitRequest.class)))
+                .thenReturn(pitFuture);
+
+        ActionFuture<Object> okFuture = mock(ActionFuture.class);
+        ActionFuture<Object> failingFuture = mock(ActionFuture.class);
+        when(failingFuture.actionGet())
+                .thenThrow(new RuntimeException("[node-8][172.31.33.24:9300] Node not connected"));
+
+        when(this.client.execute(eq(DeletePitAction.INSTANCE), any(DeletePitRequest.class)))
+                .thenReturn(
+                        (ActionFuture) (failingRelease == 1 ? failingFuture : okFuture),
+                        (ActionFuture) (failingRelease == 2 ? failingFuture : okFuture));
+    }
+
     /** Tests that onSyncComplete does nothing when isUpdated is false. */
     public void testOnSyncCompleteSkipsWhenNotUpdated() {
         this.service.onSyncComplete(false);
@@ -325,6 +360,47 @@ public class ConsumerIocServiceTests extends OpenSearchTestCase {
 
         // Index should NOT have been called since the exception happened before indexing
         verify(this.client, never()).index(any(IndexRequest.class));
+    }
+
+    /**
+     * A failing PIT release during the hash pass must not abort the rest of the post-sync cascade.
+     * The release sits in a {@code finally} whose {@code try} already catches everything, so before
+     * this was guarded it was the only statement that could throw out of {@code
+     * computeAndStoreTypeHashes()}: the failure propagated through {@code onSyncComplete()} into
+     * {@code AbstractConsumerService.synchronize()}, which marks the consumer FAILED, and the export
+     * and Engine notification that follow it never ran. Releasing a PIT is best-effort — the context
+     * expires on its own keepalive, and one held by a departed node died with it.
+     */
+    @SuppressWarnings("unchecked")
+    public void testHashPassPitReleaseFailureStillExportsAndNotifiesEngine() {
+        this.mockPitLifecycleWithFailingRelease(1);
+        this.mockEmptySearch();
+        this.mockIndexResponse();
+
+        this.service.onSyncComplete(true);
+
+        verify(this.client).index(any(IndexRequest.class));
+        verify(this.client, times(2))
+                .execute(eq(DeletePitAction.INSTANCE), any(DeletePitRequest.class));
+        verify(this.engineService).updateIoc(anyString(), anyString());
+    }
+
+    /**
+     * The same for the export's PIT, which is released after the NDJSON file has been written but
+     * before {@code export()} returns its path. A failing release used to discard a completed export
+     * and, with it, the Engine notification.
+     */
+    @SuppressWarnings("unchecked")
+    public void testExportPitReleaseFailureStillNotifiesEngine() {
+        this.mockPitLifecycleWithFailingRelease(2);
+        this.mockEmptySearch();
+        this.mockIndexResponse();
+
+        this.service.onSyncComplete(true);
+
+        verify(this.client, times(2))
+                .execute(eq(DeletePitAction.INSTANCE), any(DeletePitRequest.class));
+        verify(this.engineService).updateIoc(anyString(), anyString());
     }
 
     /** Tests that getMappings returns the IOC mappings. */


### PR DESCRIPTION
### Description

`ConsumerIocService` is the only point-in-time (PIT) client in the whole indexer. It opens one PIT per
IOC sync to compute the per-type hashes and a second one to export the IOCs to NDJSON, and both were
released the same way:

```java
try {
    ...
} finally {
    DeletePitRequest deletePitRequest = new DeletePitRequest(pitId);
    this.client.execute(DeletePitAction.INSTANCE, deletePitRequest).actionGet();   // unguarded
}
```

Releasing the PIT in a `finally` is right. Doing it with a bare `actionGet()` is not: a PIT release is
best-effort by nature — the context expires on its own after `plugins.content_manager.pit_keepalive`
(default 120s), and a context held by a node that has left the cluster died with that node's JVM — yet
this line could turn a failed cleanup into a failed sync. Each site failed differently, and both
badly:

- **`computeAndStoreTypeHashes()`** — its `try` already catches `Exception`, so the `finally` was the
  *only* statement that could throw out of the method. The failure propagated through
  `onSyncComplete()` into `AbstractConsumerService.synchronize()`, which marks the consumer
  `LocalConsumer.Status.FAILED` and rethrows. Because the hash pass runs *before* `export()` and
  `notifyEngine()` in `onSyncComplete()`, the Engine never received the updated IOC file for that
  pass.
- **`export()`** — worse: that `try` has no `catch` at all. A release failure would replace whichever
  exception was already unwinding out of the search loop, destroying the real diagnostic before
  anyone could see it. And since the release sits after the NDJSON file is written but before
  `export()` returns its path, a failing release also discarded a *completed* export along with the
  Engine notification that follows it.

This was found while triaging the DIT-CC nightly of 2026-09-02
(build [#1063](https://jenkins-production.qa.wazuh.info/job/5.0.0/job/deployability_testing/1063/),
incident wazuh/devel-major-incidents#239), which reported this ERROR from a node being restarted:

```
[2026-09-02T04:16:59,796][ERROR][o.o.a.s.PitService       ] [node-9] Delete PITs failed on node [node-8]
org.opensearch.transport.NodeNotConnectedException: [node-8][172.31.33.24:9300] Node not connected
```

> [!IMPORTANT]
> **This PR does not remove that log line, and is not expected to.** `PitService.deletePitContexts` is
> unmodified upstream code that catches the per-node transport failure itself, logs it at ERROR and
> completes the request with `DeletePitInfo(successful = false)` — so the observed occurrence never
> reached our `actionGet()`. That line is an expected transient of a planned restart and is catalogued
> as such (known-logs entry 9). What this PR fixes is the *other* outcome the same window can produce:
> a release that fails one layer higher — `NodeClient.executeLocally` on a closing node, a thread-pool
> rejection, an action-filter failure — where the exception does reach us and, before this change,
> took down the IOC sync with it.

**Changes**

- Both `finally` bodies now call a single new `ConsumerIocService.releasePit(String)` helper, which
  wraps the delete in `try`/`catch` and logs a failure at `debug`. Routing both sites through one
  method is what makes the "cannot throw" property structural rather than something each site has to
  remember — this is exactly the kind of guard that gets applied to one call site and missed at the
  others.
- New `Constants.D_LOG_IOC_PIT_RELEASE_FAILED`: `"Failed to release the IOC point-in-time context [{}]: {}"`.
  `debug` is the right level — the overwhelmingly likely cause is a node stopping or restarting while
  the IOC sync runs, which is not an error on our side and needs no action.

**Testing**

Two regression tests in `ConsumerIocServiceTests`, one per site, each driving `onSyncComplete(true)`
with a PIT release that fails the way a departing node makes it fail, and asserting the post-sync
cascade survives it:

| Test | Failing release | Asserts |
|---|---|---|
| `testHashPassPitReleaseFailureStillExportsAndNotifiesEngine` | hash pass | hash document still stored, both PITs still released, Engine still notified |
| `testExportPitReleaseFailureStillNotifiesEngine` | export | both PITs still released, Engine still notified |

Both **fail** against the unguarded code (verified by temporarily reverting the guard: `18 tests
completed, 2 failed`) and pass against the fix. Full content-manager unit suite: **726/726 across 97
classes**, `spotlessCheck` clean.

No behavior changes on the success path, no API or index-mapping changes, and nothing to migrate.

### Issues Resolved

Closes https://github.com/wazuh/wazuh-indexer/issues/1872

