### PR TITLE
Adapt logtest to percolator-based rule evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@
 - [BUG] Retry sending resources to SAP after failure [(#1487)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1487)
 - [BUG] `privacy_default_per_provider` mapped as object under `dynamic:strict` rejects new provider overrides [(#1498)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1498)
 - [BUG] Resource creation requires `indices:admin/create` on `.wazuh-content-manager-resource-locks` for the calling user [(#1520)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1520)
+- [BUG] `logtest` reports `contains` matches that never fire in the real ingestion pipeline (case sensitivity) [(#321)](https://github.com/wazuh/wazuh-indexer-security-analytics/issues/321)
 
 ## Prior versions
 - []()

--- a/docs/dev/plugins/content-manager-logtest.md
+++ b/docs/dev/plugins/content-manager-logtest.md
@@ -66,7 +66,7 @@ Responsibilities:
 2. Validates the required fields `space`, `integration`, and `input`.
 3. Validates that `space` is not `"draft"`.
 4. Validates that `input` is a JSON object (not a string or array).
-5. Delegates to `LogtestService.executeDetection(integrationId, space, inputEvent)`.
+5. Delegates to `LogtestService.executeDetectionAsync(integrationId, space, inputEvent)`.
 
 All three transport actions run this work on the dedicated `content_manager_logtest` thread pool rather than the transport thread (see [Request size limit and concurrency](#request-size-limit-and-concurrency)).
 
@@ -85,15 +85,15 @@ The orchestrator. Provides three public entry points:
 
 - **`executeLogtest()`** — Full combined flow (normalization + detection)
 - **`executeNormalization()`** — Engine-only: forwards payload to `EngineService.logtest()` and returns the response directly with `parseMessageAsJson()`
-- **`executeDetection()`** — Security Analytics-only: looks up integration, fetches rule IDs/bodies, evaluates via `SecurityAnalyticsService.evaluateRules()`, and returns the result
+- **`executeDetectionAsync()`** — Security Analytics-only: looks up integration, fetches rule IDs/bodies, evaluates via `SecurityAnalyticsService.evaluateRulesAsync()`, and returns the result
 
 The full logtest flow:
 
-1. **No-integration shortcut** — If `integrationId` is `null`, delegates to `executeEngineOnly()`: runs the Engine normalization and returns the result with `detection.status: "skipped"` and `reason: "No integration provided"`. Steps 2–5 below are skipped.
+1. **No-integration shortcut** — If `integrationId` is `null`, delegates to `executeEngineOnly()`: runs the Engine normalization and returns the result with `detection.status: "skipped"` and `reason: "'integration' field not provided"`. Steps 2–5 below are skipped.
 2. **Integration lookup** — Queries `wazuh-threatintel-integrations` for a document matching `document.id == integrationId` and `space.name == space`. Returns 400 if not found.
 3. **Engine processing** — Sends the event payload to the Wazuh Engine via `EngineService.logtest()`. Extracts the normalized event from the `output` field. The engine result fields (`output`, `asset_traces`, `validation`) are included directly in the response (no wrapper).
 4. **Rule fetching** — Extracts rule IDs from the integration's `document.rules` array, then fetches rule bodies from `wazuh-threatintel-rules` by `document.id`, filtered by the same space.
-5. **Security Analytics evaluation** — Passes the normalized event JSON and rule bodies to `SecurityAnalyticsService.evaluateRules()`.
+5. **Security Analytics evaluation** — Passes the normalized event JSON, the rule bodies and the integration's detector coordinates to `SecurityAnalyticsService.evaluateRulesAsync()`.
 6. **Response building** — Combines engine and Security Analytics results into a single JSON response under the keys `normalization` and `detection`.
 
 **Error handling**:
@@ -102,31 +102,63 @@ The full logtest flow:
 - If the integration has no rules, Security Analytics returns `rules_evaluated: 0, rules_matched: 0` with success status.
 - If Security Analytics evaluation returns unparseable JSON, the result is `status: "error"`.
 
-### SecurityAnalyticsService / EventMatcher
+### SecurityAnalyticsService / PercolateRuleEvaluator
 
 The Security Analytics evaluation happens in the `security-analytics` repository:
 
-- **`SecurityAnalyticsServiceImpl.evaluateRules()`** — Parses Sigma rule YAML strings into `SigmaRule` objects, then delegates to `EventMatcher`.
-- **`EventMatcher.evaluate()`** — Flattens the normalized event JSON into dot-notation keys, then evaluates each rule's detection conditions against the flat map. Returns a JSON result string.
+- **`SecurityAnalyticsServiceImpl.evaluateRulesAsync()`** — Sends the event, the rule bodies and the
+  integration's detector coordinates (id, log type, source indices) to the `WEvaluateRulesAction`
+  transport action.
+- **`WTransportEvaluateRulesAction`** — Parses the rule bodies into `SigmaRule` objects and delegates
+  to `PercolateRuleEvaluator`.
+- **`PercolateRuleEvaluator.evaluate()`** — Compiles each rule with `OSQueryBackend`, stores the
+  compiled queries in the logtest percolator index, and percolates the normalized event against
+  them. Returns a JSON result string.
 
-The `EventMatcher` handles:
-- Field-equals-value conditions (exact match, case-insensitive)
-- Keyword (value-only) conditions (searches all event fields)
-- Wildcards (`*` for multi-char, `?` for single-char) via cached compiled regex patterns
-- String modifiers: `contains`, `startswith`, `endswith`
-- Explicit regex (`re` modifier)
-- CIDR subnet matching (IPv4 and IPv6)
-- Boolean, numeric (gt, gte, lt, lte), null, and string comparisons
-- Composite conditions: AND, OR, NOT
-- List values (any element matching counts as a match)
+**Why percolation.** Detection has to answer one question: would the deployed detector fire on this
+event? A detector answers it by percolating compiled `query_string` queries against its query index,
+so logtest answers it the same way. Evaluating the Sigma condition directly in the JVM would answer a
+subtly different question — it cannot reproduce `query_string` parsing, the query index's analyzers,
+or the percolator's own field-mapping requirements — which makes its answer an approximation rather
+than a prediction. Sharing the compiler, the analyzers and the percolator makes the two answers the
+same by construction, and keeps them that way as any of the three changes.
 
-Match results use a nested `rule` object per match entry:
+Everything the evaluator relies on is the same artifact production uses:
+
+| Concern | Shared mechanism |
+| --- | --- |
+| Sigma → query | `OSQueryBackend.convertRule()`, as rule upload does |
+| Analysis | the `.opensearch-sap-*-detectors-queries*` index template (`rule_analyzer`, `rule_ws_normalizer`) |
+| Field mappings | copied from the integration's source indices, with the same per-type overrides a detector's query index gets |
+| Matching | alerting's `percolate_ext` query over a `percolator_ext` field |
+
+**`LogtestQueryIndex`** owns the percolator index, one per log type
+(`.opensearch-sap-<logtype>-detectors-queries-logtest`). The name is deliberately inside the
+detector query index template's pattern, so the index inherits the analysis settings rather than
+redefining them. The index is created on demand and query documents are upserted under deterministic
+ids, so it holds at most one document per rule condition and repeated calls overwrite rather than
+accumulate.
+
+Match results use a nested `rule` object per match entry, where `matched_conditions` carries the
+compiled queries that matched:
 ```json
 {
   "rule": { "id": "...", "title": "...", "level": "...", "tags": [...] },
-  "matched_conditions": [...]
+  "matched_conditions": ["url.original: *union select*"]
 }
 ```
+
+Rules that could not be evaluated are reported instead of being left out of the results:
+```json
+{
+  "rules_skipped": 1,
+  "skipped": [{ "rule": {...}, "reason": "the compiled query was rejected by the percolator, ..." }]
+}
+```
+A rule is skipped when it cannot be compiled, when it aggregates over several events (a percolator
+sees one document), or when the percolator rejects its compiled query — most often because the rule
+names a field the source index does not map yet, in which case a deployed detector cannot match it
+either.
 
 ## Data flow
 
@@ -160,9 +192,12 @@ LogtestService.executeLogtest(integrationId, space, payload)
     ├──► client.prepareSearch("wazuh-threatintel-rules")
     │       → fetches rule bodies by document.id + space filter
     │
-    ├──► securityAnalytics.evaluateRules(normalizedEventJson, ruleBodies)
+    ├──► securityAnalytics.evaluateRulesAsync(normalizedEventJson, ruleBodies,
+    │                                          integrationId, logType, sourceIndices)
     │       → parses YAML → SigmaRule objects
-    │       → EventMatcher flattens event + evaluates conditions
+    │       → OSQueryBackend compiles each rule to a query_string query
+    │       → queries are upserted into the logtest percolator index
+    │       → the event is percolated against them
     │       → returns JSON result
     │
     └──► builds combined response
@@ -187,7 +222,7 @@ LogtestService.executeNormalization(payload)  LogtestService.executeDetection(id
          → returns engine response directly      │       → finds integration
                                                  ├──► extractRuleIds() + fetchRuleBodies()
                                                  │       → fetches rule content from .cti-rules
-                                                 └──► securityAnalytics.evaluateRules(inputJson, ruleBodies)
+                                                 └──► securityAnalytics.evaluateRulesAsync(inputJson, ruleBodies, ...)
                                                          → returns Security Analytics result directly
 ```
 
@@ -204,6 +239,10 @@ LogtestService.executeNormalization(payload)  LogtestService.executeDetection(id
 
 Both indices must exist and have `document.id` mapped as `keyword` for term queries to work.
 
+Security Analytics additionally reads the integration's detector source indices
+(`document.detector.source`, or `wazuh-events-v5-<category>` when it names none) to build the
+percolator index mappings, and owns `.opensearch-sap-<logtype>-detectors-queries-logtest`.
+
 ## Testing
 
 ### Unit tests
@@ -214,15 +253,22 @@ Both indices must exist and have `document.id` mapped as `keyword` for term quer
 | `TransportLogtestNormalizationActionTests` | Request validation for normalization endpoint (empty body, invalid JSON, missing space, invalid space, delegation, integration stripping) |
 | `TransportLogtestDetectionActionTests` | Request validation for detection endpoint (empty body, invalid JSON, missing fields, invalid space, non-object input, delegation) |
 | `LogtestServiceTests` | Orchestration logic (integration lookup, engine errors, rule fetching, Security Analytics evaluation, response structure) |
-| `EventMatcherTests` | Sigma rule evaluation (field matching, wildcards, numerics, booleans, nulls, AND/OR/NOT conditions) |
+| `LogtestQueryIndexTests` | Percolator index naming and the source-mapping copy (analysis overrides, merges, conflicts) |
+| `RuleTopicIndicesTests` | The query index analysis settings both a detector and logtest depend on |
 
 ### Integration tests
 
 | Test class | Covers |
 | --- | --- |
-| `LogtestIT` | End-to-end REST workflow against a live test cluster (request validation, integration lookup, promote + logtest, response structure) |
+| `LogtestIT` | End-to-end REST workflow against a live test cluster (request validation, integration lookup, promote + logtest, response structure) and real percolation through the detection endpoint: exact-case matching, case-sensitivity, non-matching events, and rules reported as skipped |
 
-Integration tests extend `ContentManagerRestTestCase` and run against a real OpenSearch cluster. Since the Wazuh Engine is not available in the test environment, engine-dependent tests validate graceful error handling (engine error → Security Analytics skipped).
+Integration tests extend `ContentManagerRestTestCase` and run against a real OpenSearch cluster.
+Since the Wazuh Engine is not available in the test environment, engine-dependent tests validate
+graceful error handling (engine error → Security Analytics skipped). Detection is *not* mocked: the
+test cluster installs Security Analytics and alerting, and
+`plugins.content_manager.security_analytics.mock` is set to `false` there so rule evaluation
+percolates for real. `plugins.content_manager.engine.mock` stays `true` because the Engine's Unix
+socket genuinely is absent; the two settings are separate for exactly this reason.
 
 
 ## Adding new logtest features
@@ -243,7 +289,13 @@ Integration tests extend `ContentManagerRestTestCase` and run against a real Ope
 
 ### Extending Security Analytics evaluation
 
-1. Modify `EventMatcher.matchValue()` to handle new `SigmaType` subclasses.
-2. Add test cases in `EventMatcherTests`.
-3. Update the Sigma rules doc ([Sigma Rules](../../ref/modules/ruleset-management/rules.md)) if new detection modifiers are supported.
+Detection semantics live in the Sigma compiler, not in logtest: a new modifier is implemented in
+`rules/modifiers/` and rendered by `OSQueryBackend`, and logtest picks it up for free because it
+compiles rules with the same backend.
+
+1. Add the modifier under `rules/modifiers/` and register it in `SigmaModifierFacade`.
+2. Render it in `OSQueryBackend`, and pin the generated query in `QueryBackendTests`.
+3. Cover it end to end in `LogtestIT` (detection endpoint) so the percolate path is exercised.
+4. Update the Sigma rules doc ([Sigma Rules](../../ref/modules/ruleset-management/rules.md)),
+   including the case-sensitivity behaviour.
 

--- a/docs/dev/plugins/content-manager-logtest.md
+++ b/docs/dev/plugins/content-manager-logtest.md
@@ -135,12 +135,12 @@ Everything the evaluator relies on is the same artifact production uses:
 **`LogtestQueryIndex`** owns the percolator index, one per log type
 (`.opensearch-sap-<logtype>-detectors-queries-logtest`). The name is deliberately inside the
 detector query index template's pattern, so the index inherits the analysis settings rather than
-redefining them. The index is created on demand and query documents are upserted under deterministic
-ids, so it holds at most one document per rule condition and repeated calls overwrite rather than
-accumulate.
+redefining them. The index is created on demand and document ids are content-addressed, so a rule
+whose text has not changed reuses its document and repeated calls neither overwrite nor accumulate;
+documents left by an earlier revision of a rule are pruned once past a short grace period.
 
-Match results use a nested `rule` object per match entry, where `matched_conditions` describes the
-conditions of the rule that matched, one entry per condition:
+Match results use a nested `rule` object per match entry, where `matched_conditions` lists the
+conditions the event satisfies, one entry per condition:
 ```json
 {
   "rule": { "id": "...", "title": "...", "level": "...", "tags": [...] },

--- a/docs/dev/plugins/content-manager-logtest.md
+++ b/docs/dev/plugins/content-manager-logtest.md
@@ -139,26 +139,14 @@ redefining them. The index is created on demand and query documents are upserted
 ids, so it holds at most one document per rule condition and repeated calls overwrite rather than
 accumulate.
 
-Match results use a nested `rule` object per match entry, where `matched_conditions` carries the
-compiled queries that matched:
+Match results use a nested `rule` object per match entry, where `matched_conditions` describes the
+conditions of the rule that matched, one entry per condition:
 ```json
 {
   "rule": { "id": "...", "title": "...", "level": "...", "tags": [...] },
-  "matched_conditions": ["url.original: *union select*"]
+  "matched_conditions": ["http.request.method matched 'GET'", "url.original matched '*UNION SELECT*'"]
 }
 ```
-
-Rules that could not be evaluated are reported instead of being left out of the results:
-```json
-{
-  "rules_skipped": 1,
-  "skipped": [{ "rule": {...}, "reason": "the compiled query was rejected by the percolator, ..." }]
-}
-```
-A rule is skipped when it cannot be compiled, when it aggregates over several events (a percolator
-sees one document), or when the percolator rejects its compiled query — most often because the rule
-names a field the source index does not map yet, in which case a deployed detector cannot match it
-either.
 
 ## Data flow
 

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -517,15 +517,7 @@ curl -sk -u admin:admin -X POST \
 - **`detection.rules_matched`** (Integer) — number of rules that matched.
 - **`detection.matches`** (Array) — list of matched rules with details.
 - **`detection.matches[].rule`** (Object) — rule metadata: `id`, `title`, `level`, `tags`.
-- **`detection.matches[].matched_conditions`** (Array) — the compiled queries that matched. These are
-  the exact queries a deployed detector runs, since detection evaluates rules through the same
-  percolator.
-- **`detection.rules_skipped`** (Integer) — number of rules that could not be evaluated.
-- **`detection.skipped`** (Array) — one entry per skipped rule, with its `rule` metadata and a
-  `reason`. A rule is skipped when it cannot be compiled, when it aggregates over several events, or
-  when the query index rejects its compiled query — most often because the rule names a field the
-  integration's source index does not map yet. A skipped rule cannot produce a finding in production
-  either, which is why it is reported instead of being counted as "did not match".
+- **`detection.matches[].matched_conditions`** (Array) — human-readable descriptions of conditions that matched.
 
 #### Status codes
 
@@ -701,7 +693,8 @@ curl -sk -u admin:admin -X POST \
           "tags": ["attack.execution", "attack.t1059"]
         },
         "matched_conditions": [
-          "(event.duration >= 5000) AND (event.severity < 10)"
+          "event.duration matched '>= 5000'",
+          "event.severity matched '< 10'"
         ]
       },
       {
@@ -712,7 +705,7 @@ curl -sk -u admin:admin -X POST \
           "tags": ["attack.execution", "attack.t1059"]
         },
         "matched_conditions": [
-          "event.kind: \"event\""
+          "event.kind matched 'event'"
         ]
       }
     ]
@@ -730,24 +723,18 @@ curl -sk -u admin:admin -X POST \
     "rules_evaluated": 0,
     "rules_matched": 0,
     "matches": [],
-    "rules_skipped": 0,
-    "skipped": []
   }
 }
 ```
 
 #### Response fields
 
-- **`message.status`** (String) — `"success"`, `"error"`, or `"skipped"`.
+- **`message.status`** (String) — `"success"` or `"error"`.
 - **`message.rules_evaluated`** (Integer) — number of Sigma rules evaluated.
 - **`message.rules_matched`** (Integer) — number of rules that matched.
 - **`message.matches`** (Array) — list of matched rules with details.
 - **`message.matches[].rule`** (Object) — rule metadata: `id`, `title`, `level`, `tags`.
-- **`message.matches[].matched_conditions`** (Array) — the compiled queries that matched.
-- **`message.rules_skipped`** (Integer) — number of rules that could not be evaluated.
-- **`message.skipped`** (Array) — one entry per skipped rule, with its `rule` metadata and a `reason`.
-- **`message.reason`** (String) — present when `status` is `"skipped"`, i.e. when no rule could be
-  evaluated at all.
+- **`message.matches[].matched_conditions`** (Array) — human-readable descriptions of matched conditions.
 
 #### Status codes
 

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -517,7 +517,9 @@ curl -sk -u admin:admin -X POST \
 - **`detection.rules_matched`** (Integer) — number of rules that matched.
 - **`detection.matches`** (Array) — list of matched rules with details.
 - **`detection.matches[].rule`** (Object) — rule metadata: `id`, `title`, `level`, `tags`.
-- **`detection.matches[].matched_conditions`** (Array) — human-readable descriptions of conditions that matched.
+- **`detection.matches[].matched_conditions`** (Array) — human-readable descriptions of the rule's
+  conditions **that this event satisfies**. A condition offering several values contributes only the
+  ones present in the event, so two events caught by the same rule describe their own match.
 
 #### Status codes
 
@@ -734,7 +736,9 @@ curl -sk -u admin:admin -X POST \
 - **`message.rules_matched`** (Integer) — number of rules that matched.
 - **`message.matches`** (Array) — list of matched rules with details.
 - **`message.matches[].rule`** (Object) — rule metadata: `id`, `title`, `level`, `tags`.
-- **`message.matches[].matched_conditions`** (Array) — human-readable descriptions of matched conditions.
+- **`message.matches[].matched_conditions`** (Array) — human-readable descriptions of the rule's
+  conditions **that this event satisfies**. A condition offering several values contributes only the
+  ones present in the event, so two events caught by the same rule describe their own match.
 
 #### Status codes
 

--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -458,7 +458,15 @@ curl -sk -u admin:admin -X POST \
 - **`detection.rules_matched`** (Integer) — number of rules that matched.
 - **`detection.matches`** (Array) — list of matched rules with details.
 - **`detection.matches[].rule`** (Object) — rule metadata: `id`, `title`, `level`, `tags`.
-- **`detection.matches[].matched_conditions`** (Array) — human-readable descriptions of conditions that matched.
+- **`detection.matches[].matched_conditions`** (Array) — the compiled queries that matched. These are
+  the exact queries a deployed detector runs, since detection evaluates rules through the same
+  percolator.
+- **`detection.rules_skipped`** (Integer) — number of rules that could not be evaluated.
+- **`detection.skipped`** (Array) — one entry per skipped rule, with its `rule` metadata and a
+  `reason`. A rule is skipped when it cannot be compiled, when it aggregates over several events, or
+  when the query index rejects its compiled query — most often because the rule names a field the
+  integration's source index does not map yet. A skipped rule cannot produce a finding in production
+  either, which is why it is reported instead of being counted as "did not match".
 
 #### Status codes
 
@@ -634,8 +642,7 @@ curl -sk -u admin:admin -X POST \
           "tags": ["attack.execution", "attack.t1059"]
         },
         "matched_conditions": [
-          "event.duration matched '>= 5000'",
-          "event.severity matched '< 10'"
+          "(event.duration >= 5000) AND (event.severity < 10)"
         ]
       },
       {
@@ -646,7 +653,7 @@ curl -sk -u admin:admin -X POST \
           "tags": ["attack.execution", "attack.t1059"]
         },
         "matched_conditions": [
-          "event.kind matched 'event'"
+          "event.kind: \"event\""
         ]
       }
     ]
@@ -663,19 +670,25 @@ curl -sk -u admin:admin -X POST \
     "status": "success",
     "rules_evaluated": 0,
     "rules_matched": 0,
-    "matches": []
+    "matches": [],
+    "rules_skipped": 0,
+    "skipped": []
   }
 }
 ```
 
 #### Response fields
 
-- **`message.status`** (String) — `"success"` or `"error"`.
+- **`message.status`** (String) — `"success"`, `"error"`, or `"skipped"`.
 - **`message.rules_evaluated`** (Integer) — number of Sigma rules evaluated.
 - **`message.rules_matched`** (Integer) — number of rules that matched.
 - **`message.matches`** (Array) — list of matched rules with details.
 - **`message.matches[].rule`** (Object) — rule metadata: `id`, `title`, `level`, `tags`.
-- **`message.matches[].matched_conditions`** (Array) — human-readable descriptions of matched conditions.
+- **`message.matches[].matched_conditions`** (Array) — the compiled queries that matched.
+- **`message.rules_skipped`** (Integer) — number of rules that could not be evaluated.
+- **`message.skipped`** (Array) — one entry per skipped rule, with its `rule` metadata and a `reason`.
+- **`message.reason`** (String) — present when `status` is `"skipped"`, i.e. when no rule could be
+  evaluated at all.
 
 #### Status codes
 

--- a/docs/ref/modules/content-manager/rule-testing.md
+++ b/docs/ref/modules/content-manager/rule-testing.md
@@ -18,8 +18,7 @@ Logtest sends a raw log event through the full detection pipeline — the Wazuh 
 
 Rules are evaluated the way a deployed threat detector evaluates them: compiled into the same
 queries, analyzed by the same analyzers, and matched by the same percolator. A logtest result is
-therefore a prediction of the finding, not an approximation of it — including when a rule *cannot*
-match, which logtest reports under `skipped` rather than as a silent non-match.
+therefore a prediction of the finding, not an approximation of it.
 
 Logtest supports the `test`, `standard`, and `custom` spaces. Use `test` for validating draft content, `standard` for testing against production rules, and `custom` for validating content promoted to production
 
@@ -224,7 +223,8 @@ The response has two sections:
           "tags": ["attack.credential-access", "attack.t1110.001"]
         },
         "matched_conditions": [
-          "event.category: \"authentication\" AND event.outcome: \"failure\""
+          "event.category matched 'authentication'",
+          "event.outcome matched 'failure'"
         ]
       }
     ]
@@ -246,8 +246,7 @@ If the results aren't what you expect:
 
 1. **Decoder not matching?** Check `asset_traces` — if your decoder isn't listed, review the `check` conditions. Use `trace_level: ALL` to see which decoders were attempted.
 2. **Rule not matching?** Compare the normalized event fields with your rule's `detection` block. Field names and string values must both match exactly — string comparison is case-sensitive.
-3. **Rule listed under `skipped`?** It could not be evaluated, and a deployed detector cannot match it either. Read the `reason`: the usual cause is a field the integration's source index does not map yet, which resolves itself once events carrying that field have been ingested.
-4. **Unexpected matches?** Review `matched_conditions`, which shows the compiled query that matched — the same query the detector runs.
+3. **Unexpected matches?** Review `matched_conditions` to understand why a rule triggered.
 
 After making changes:
 - Update the rule or decoder via `PUT` on the respective endpoint.
@@ -387,7 +386,8 @@ The response contains only the detection result:
           "tags": ["attack.credential-access", "attack.t1110.001"]
         },
         "matched_conditions": [
-          "event.category: \"authentication\" AND event.outcome: \"failure\""
+          "event.category matched 'authentication'",
+          "event.outcome matched 'failure'"
         ]
       }
     ]

--- a/docs/ref/modules/content-manager/rule-testing.md
+++ b/docs/ref/modules/content-manager/rule-testing.md
@@ -246,7 +246,8 @@ If the results aren't what you expect:
 
 1. **Decoder not matching?** Check `asset_traces` — if your decoder isn't listed, review the `check` conditions. Use `trace_level: ALL` to see which decoders were attempted.
 2. **Rule not matching?** Compare the normalized event fields with your rule's `detection` block. Field names and string values must both match exactly — string comparison is case-sensitive.
-3. **Unexpected matches?** Review `matched_conditions` to understand why a rule triggered.
+3. **Unexpected matches?** Review `matched_conditions`: it lists the conditions this event
+   satisfies, so it shows what in the event triggered the rule rather than restating the rule.
 
 After making changes:
 - Update the rule or decoder via `PUT` on the respective endpoint.

--- a/docs/ref/modules/content-manager/rule-testing.md
+++ b/docs/ref/modules/content-manager/rule-testing.md
@@ -16,6 +16,11 @@ Draft → Test → Custom
 
 Logtest sends a raw log event through the full detection pipeline — the Wazuh Engine normalizes the event, and the Ruleset Management plugin evaluates your Sigma rules against the normalized output. The combined result shows exactly what was decoded and which rules matched.
 
+Rules are evaluated the way a deployed threat detector evaluates them: compiled into the same
+queries, analyzed by the same analyzers, and matched by the same percolator. A logtest result is
+therefore a prediction of the finding, not an approximation of it — including when a rule *cannot*
+match, which logtest reports under `skipped` rather than as a silent non-match.
+
 Logtest supports the `test`, `standard`, and `custom` spaces. Use `test` for validating draft content, `standard` for testing against production rules, and `custom` for validating content promoted to production
 
 ---
@@ -219,8 +224,7 @@ The response has two sections:
           "tags": ["attack.credential-access", "attack.t1110.001"]
         },
         "matched_conditions": [
-          "event.category matched 'authentication'",
-          "event.outcome matched 'failure'"
+          "event.category: \"authentication\" AND event.outcome: \"failure\""
         ]
       }
     ]
@@ -241,8 +245,9 @@ The `trace_level` field controls how much detail the Engine returns:
 If the results aren't what you expect:
 
 1. **Decoder not matching?** Check `asset_traces` — if your decoder isn't listed, review the `check` conditions. Use `trace_level: ALL` to see which decoders were attempted.
-2. **Rule not matching?** Compare the normalized event fields with your rule's `detection` block. Field names and values must match exactly (case-insensitive for strings).
-3. **Unexpected matches?** Review `matched_conditions` to understand why a rule triggered.
+2. **Rule not matching?** Compare the normalized event fields with your rule's `detection` block. Field names and string values must both match exactly — string comparison is case-sensitive.
+3. **Rule listed under `skipped`?** It could not be evaluated, and a deployed detector cannot match it either. Read the `reason`: the usual cause is a field the integration's source index does not map yet, which resolves itself once events carrying that field have been ingested.
+4. **Unexpected matches?** Review `matched_conditions`, which shows the compiled query that matched — the same query the detector runs.
 
 After making changes:
 - Update the rule or decoder via `PUT` on the respective endpoint.
@@ -382,8 +387,7 @@ The response contains only the detection result:
           "tags": ["attack.credential-access", "attack.t1110.001"]
         },
         "matched_conditions": [
-          "event.category matched 'authentication'",
-          "event.outcome matched 'failure'"
+          "event.category: \"authentication\" AND event.outcome: \"failure\""
         ]
       }
     ]

--- a/docs/ref/modules/ruleset-management/rules.md
+++ b/docs/ref/modules/ruleset-management/rules.md
@@ -231,6 +231,16 @@ field_name|modifier: value
 
 Multiple modifiers can be chained: `field|modifier1|modifier2: value`.
 
+> **Case sensitivity**: string comparison is **case-sensitive**. This applies to plain equality and
+> to `contains`, `startswith`, `endswith` and wildcard values alike: a rule matching `UNION SELECT`
+> does not match `union select` or `UNION sElect`. To catch several spellings of a keyword, list them
+> as separate values.
+> 
+> Both evaluation paths agree: a deployed detector and
+> [logtest](../content-manager/rule-testing.md) compile a rule with the same backend and match it
+> with the same percolator, so a logtest result predicts what the detector will do rather than
+> approximating it.
+
 #### `contains`
 
 Matches when the field value contains the specified substring. Wildcards are inserted around the value.

--- a/plugins/content-manager/build.gradle
+++ b/plugins/content-manager/build.gradle
@@ -267,6 +267,9 @@ testClusters.integTest {
   setting 'plugins.content_manager.catalog.create_detectors', 'false'
   setting 'plugins.content_manager.telemetry.enabled', 'false'
   setting 'plugins.content_manager.engine.mock', 'true'
+  // Security Analytics is installed on this cluster, so rule evaluation runs for real; only the
+  // Engine's Unix socket is missing.
+  setting 'plugins.content_manager.security_analytics.mock', 'false'
   setting 'plugins.content_manager.catalog.ruleset', "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/beta3-t1-ruleset-5/consumers/public-ruleset-5"
   setting 'plugins.content_manager.catalog.iocs', "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/t1-iocs-5/consumers/public-iocs-5"
   setting 'plugins.content_manager.catalog.vulnerabilities', "https://api.pre.cloud.wazuh.com/api/v1/catalog/contexts/t1-vulnerabilities-5/consumers/public-vulnerabilities-5"

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -2899,8 +2899,12 @@ components:
                 properties:
                   status:
                     type: string
-                    enum: [success, error]
+                    enum: [success, error, skipped]
                     example: "success"
+                  reason:
+                    type: string
+                    description: >-
+                      Why no rule could be evaluated. Present when `status` is `skipped`.
                   rules_evaluated:
                     type: integer
                     example: 12
@@ -2929,8 +2933,38 @@ components:
                                 type: string
                         matched_conditions:
                           type: array
+                          description: >-
+                            The compiled queries that matched. These are the exact queries a deployed
+                            detector runs, since detection evaluates rules through the same percolator.
                           items:
                             type: string
+                  rules_skipped:
+                    type: integer
+                    description: Number of rules that could not be evaluated.
+                  skipped:
+                    type: array
+                    description: >-
+                      One entry per rule that could not be evaluated. A skipped rule cannot produce
+                      a finding in production either, so it is reported rather than counted as
+                      "did not match".
+                    items:
+                      type: object
+                      properties:
+                        rule:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            title:
+                              type: string
+                            level:
+                              type: string
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                        reason:
+                          type: string
           examples:
             with_matches:
               summary: Detection with matched rules
@@ -2947,15 +2981,14 @@ components:
                         level: "high"
                         tags: ["attack.execution", "attack.t1059"]
                       matched_conditions:
-                        - "event.duration matched '>= 5000'"
-                        - "event.severity matched '< 10'"
+                        - "(event.duration >= 5000) AND (event.severity < 10)"
                     - rule:
                         id: "1d489ded-7523-4329-8cd0-ebb21865a318"
                         title: "Exact match event.kind=event"
                         level: "low"
                         tags: ["attack.execution", "attack.t1059"]
                       matched_conditions:
-                        - "event.kind matched 'event'"
+                        - 'event.kind: "event"'
             no_matches:
               summary: No rules matched
               value:
@@ -3049,8 +3082,40 @@ components:
                                     type: string
                             matched_conditions:
                               type: array
+                              description: >-
+                                The compiled queries that matched. These are the exact queries a
+                                deployed detector runs, since detection evaluates rules through the
+                                same percolator.
                               items:
                                 type: string
+                      rules_skipped:
+                        type: integer
+                        description: Number of rules that could not be evaluated.
+                        example: 0
+                      skipped:
+                        type: array
+                        description: >-
+                          One entry per rule that could not be evaluated. A skipped rule cannot
+                          produce a finding in production either, so it is reported rather than
+                          counted as "did not match".
+                        items:
+                          type: object
+                          properties:
+                            rule:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                title:
+                                  type: string
+                                level:
+                                  type: string
+                                tags:
+                                  type: array
+                                  items:
+                                    type: string
+                            reason:
+                              type: string
           examples:
             with_matches:
               summary: Response with matching rules
@@ -3077,9 +3142,7 @@ components:
                             - "aws"
                             - "cloudtrail"
                         matched_conditions:
-                          - "event.category == 'authentication'"
-                          - "event.outcome == 'failure'"
-                          - "cloud.provider == 'aws'"
+                          - 'event.category: "authentication" AND event.outcome: "failure" AND cloud.provider: "aws"'
                       - rule:
                           id: "uuid-rule-2"
                           title: "rule/suspicious-console-login/0"

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -3000,12 +3000,8 @@ components:
                 properties:
                   status:
                     type: string
-                    enum: [success, error, skipped]
+                    enum: [success, error]
                     example: "success"
-                  reason:
-                    type: string
-                    description: >-
-                      Why no rule could be evaluated. Present when `status` is `skipped`.
                   rules_evaluated:
                     type: integer
                     example: 12
@@ -3034,38 +3030,8 @@ components:
                                 type: string
                         matched_conditions:
                           type: array
-                          description: >-
-                            The compiled queries that matched. These are the exact queries a deployed
-                            detector runs, since detection evaluates rules through the same percolator.
                           items:
                             type: string
-                  rules_skipped:
-                    type: integer
-                    description: Number of rules that could not be evaluated.
-                  skipped:
-                    type: array
-                    description: >-
-                      One entry per rule that could not be evaluated. A skipped rule cannot produce
-                      a finding in production either, so it is reported rather than counted as
-                      "did not match".
-                    items:
-                      type: object
-                      properties:
-                        rule:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                            title:
-                              type: string
-                            level:
-                              type: string
-                            tags:
-                              type: array
-                              items:
-                                type: string
-                        reason:
-                          type: string
           examples:
             with_matches:
               summary: Detection with matched rules
@@ -3082,14 +3048,15 @@ components:
                         level: "high"
                         tags: ["attack.execution", "attack.t1059"]
                       matched_conditions:
-                        - "(event.duration >= 5000) AND (event.severity < 10)"
+                        - "event.duration matched '>= 5000'"
+                        - "event.severity matched '< 10'"
                     - rule:
                         id: "1d489ded-7523-4329-8cd0-ebb21865a318"
                         title: "Exact match event.kind=event"
                         level: "low"
                         tags: ["attack.execution", "attack.t1059"]
                       matched_conditions:
-                        - 'event.kind: "event"'
+                        - "event.kind matched 'event'"
             no_matches:
               summary: No rules matched
               value:
@@ -3183,40 +3150,8 @@ components:
                                     type: string
                             matched_conditions:
                               type: array
-                              description: >-
-                                The compiled queries that matched. These are the exact queries a
-                                deployed detector runs, since detection evaluates rules through the
-                                same percolator.
                               items:
                                 type: string
-                      rules_skipped:
-                        type: integer
-                        description: Number of rules that could not be evaluated.
-                        example: 0
-                      skipped:
-                        type: array
-                        description: >-
-                          One entry per rule that could not be evaluated. A skipped rule cannot
-                          produce a finding in production either, so it is reported rather than
-                          counted as "did not match".
-                        items:
-                          type: object
-                          properties:
-                            rule:
-                              type: object
-                              properties:
-                                id:
-                                  type: string
-                                title:
-                                  type: string
-                                level:
-                                  type: string
-                                tags:
-                                  type: array
-                                  items:
-                                    type: string
-                            reason:
-                              type: string
           examples:
             with_matches:
               summary: Response with matching rules
@@ -3243,7 +3178,9 @@ components:
                             - "aws"
                             - "cloudtrail"
                         matched_conditions:
-                          - 'event.category: "authentication" AND event.outcome: "failure" AND cloud.provider: "aws"'
+                          - "event.category matched 'authentication'"
+                          - "event.outcome matched 'failure'"
+                          - "cloud.provider matched 'aws'"
                       - rule:
                           id: "uuid-rule-2"
                           title: "rule/suspicious-console-login/0"

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/ContentManagerPlugin.java
@@ -230,7 +230,7 @@ public class ContentManagerPlugin extends Plugin
         this.engineContentLoader =
                 new EngineContentLoader(this.engine, this.spaceService, this.threadPool);
 
-        if (PluginSettings.getInstance().isEngineMockEnabled()) {
+        if (PluginSettings.getInstance().isSecurityAnalyticsMockEnabled()) {
             this.securityAnalyticsService = new MockSecurityAnalyticsService();
         } else {
             this.securityAnalyticsService = new SecurityAnalyticsServiceImpl(client);
@@ -999,6 +999,7 @@ public class ContentManagerPlugin extends Plugin
                 PluginSettings.TELEMETRY_ENABLED,
                 PluginSettings.PIT_KEEPALIVE,
                 PluginSettings.ENGINE_MOCK_ENABLED,
+                PluginSettings.SECURITY_ANALYTICS_MOCK_ENABLED,
                 PluginSettings.CREATE_DETECTORS,
                 PluginSettings.UPDATE_ON_DEMAND,
                 PluginSettings.POLICY_UPDATE_ENABLED,

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
@@ -509,7 +509,7 @@ public class LogtestService {
         if (target.sourceIndices().isEmpty()) {
             listener.onResponse(
                     buildCombinedResponse(
-                            engineResult, createSkippedSapResult(noSourceIndexReason(target.integrationId()))));
+                            engineResult, createErrorSapResult()));
             return;
         }
 
@@ -533,7 +533,7 @@ public class LogtestService {
                         e -> {
                             log.error("Failed to evaluate rules: {}", e.getMessage());
                             listener.onResponse(
-                                    buildCombinedResponse(engineResult, createSkippedSapResult(e.getMessage())));
+                                    buildCombinedResponse(engineResult, createErrorSapResult()));
                         }));
     }
 
@@ -550,7 +550,7 @@ public class LogtestService {
         if (target.sourceIndices().isEmpty()) {
             listener.onResponse(
                     buildDetectionResponse(
-                            createSkippedSapResult(noSourceIndexReason(target.integrationId()))));
+                            createErrorSapResult()));
             return;
         }
 
@@ -573,7 +573,7 @@ public class LogtestService {
                         },
                         e -> {
                             log.error("Failed to evaluate rules: {}", e.getMessage());
-                            listener.onResponse(buildDetectionResponse(createSkippedSapResult(e.getMessage())));
+                            listener.onResponse(buildDetectionResponse(createErrorSapResult()));
                         }));
     }
 
@@ -614,41 +614,6 @@ public class LogtestService {
         response.put("rules_matched", 0);
         response.put("matches", List.of());
         return response;
-    }
-
-    /**
-     * Creates a skipped SAP result carrying why nothing was evaluated.
-     *
-     * <p>Skipped rather than zero matches: "the rules could not be evaluated" is not the same answer
-     * as "the rules do not match this event", and conflating the two is what made logtest misleading
-     * in the first place.
-     *
-     * @param reason why the rules could not be evaluated.
-     * @return the skipped result.
-     */
-    private Map<String, Object> createSkippedSapResult(String reason) {
-        Map<String, Object> response = new LinkedHashMap<>();
-        response.put(Constants.KEY_STATUS, "skipped");
-        response.put("reason", reason);
-        response.put("rules_evaluated", 0);
-        response.put("rules_matched", 0);
-        response.put("matches", List.of());
-        return response;
-    }
-
-    /**
-     * Reason used when an integration names no source index, so there are no field mappings to
-     * resolve its rules' compiled queries against.
-     *
-     * @param integrationId the integration being tested.
-     * @return the reason message.
-     */
-    private String noSourceIndexReason(String integrationId) {
-        return String.format(
-                Locale.ROOT,
-                "Integration [%s] declares no detector source index, so its rules cannot be evaluated "
-                        + "the way a detector would evaluate them",
-                integrationId);
     }
 
     /** Creates an error SAP result. */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/LogtestService.java
@@ -134,6 +134,7 @@ public class LogtestService {
                                     Map<String, Object> integrationSource =
                                             integrationSearchResponse.getHits().getAt(0).getSourceAsMap();
                                     List<String> ruleIds = extractRuleIds(integrationSource);
+                                    DetectorTarget target = extractDetectorTarget(integrationId, integrationSource);
                                     String normalizedEventJson = (String) engineResult.remove("_normalized_event");
 
                                     if (ruleIds.isEmpty()) {
@@ -149,7 +150,7 @@ public class LogtestService {
                                             ActionListener.wrap(
                                                     ruleBodies ->
                                                             evaluateAndRespond(
-                                                                    engineResult, normalizedEventJson, ruleBodies, listener),
+                                                                    engineResult, normalizedEventJson, ruleBodies, target, listener),
                                                     e -> {
                                                         log.warn(
                                                                 "Failed to fetch rules for" + " integration [{}]: {}",
@@ -241,7 +242,12 @@ public class LogtestService {
                                             ruleIds,
                                             space,
                                             ActionListener.wrap(
-                                                    ruleBodies -> evaluateDetectionRules(eventJson, ruleBodies, listener),
+                                                    ruleBodies ->
+                                                            evaluateDetectionRules(
+                                                                    eventJson,
+                                                                    ruleBodies,
+                                                                    extractDetectorTarget(integrationId, integrationSource),
+                                                                    listener),
                                                     e -> {
                                                         log.warn(
                                                                 "Failed to fetch rules for" + " integration [{}]: {}",
@@ -371,6 +377,72 @@ public class LogtestService {
      * @param integrationSource the integration document source map
      * @return list of rule document IDs (may be empty if the integration has no rules)
      */
+    /**
+     * What Security Analytics needs to percolate an integration's rules the way its detector would:
+     * the integration itself, its log type, and the source indices whose field mappings the compiled
+     * queries must resolve against.
+     *
+     * @param integrationId the integration document id.
+     * @param logType the integration's log type, taken from its title as the detector does.
+     * @param sourceIndices the detector's source indices.
+     */
+    record DetectorTarget(String integrationId, String logType, List<String> sourceIndices) {}
+
+    /**
+     * Reads the detector coordinates off an integration document.
+     *
+     * <p>Deliberately mirrors how a detector is built from the same document ({@code
+     * SecurityAnalyticsServiceImpl.buildDetectorRequest}): the log type is the integration title, the
+     * source indices are {@code document.detector.source}, and when CTI names none the category
+     * yields {@code wazuh-events-v5-<category>}. Reading them from the same place is what keeps
+     * logtest evaluating against the same mappings as the detector.
+     *
+     * @param integrationId the integration document id.
+     * @param integrationSource the integration document source map.
+     * @return the detector coordinates for this integration.
+     */
+    @SuppressWarnings("unchecked")
+    private DetectorTarget extractDetectorTarget(
+            String integrationId, Map<String, Object> integrationSource) {
+        String logType = integrationId;
+        List<String> sourceIndices = new ArrayList<>();
+        String category = null;
+
+        Object documentObj = integrationSource.get(Constants.KEY_DOCUMENT);
+        if (documentObj instanceof Map) {
+            Map<String, Object> document = (Map<String, Object>) documentObj;
+
+            Object metadataObj = document.get(Constants.KEY_METADATA);
+            if (metadataObj instanceof Map) {
+                Object title = ((Map<String, Object>) metadataObj).get(Constants.KEY_TITLE);
+                if (title != null && !title.toString().isEmpty()) {
+                    logType = title.toString();
+                }
+            }
+
+            Object categoryObj = document.get(Constants.KEY_CATEGORY);
+            if (categoryObj != null) {
+                category = categoryObj.toString();
+            }
+
+            Object detectorObj = document.get(Constants.KEY_DETECTOR);
+            if (detectorObj instanceof Map) {
+                Object sourcesObj = ((Map<String, Object>) detectorObj).get(Constants.KEY_SOURCE);
+                if (sourcesObj instanceof List) {
+                    for (Object source : (List<?>) sourcesObj) {
+                        sourceIndices.add(source.toString());
+                    }
+                }
+            }
+        }
+
+        if (sourceIndices.isEmpty() && category != null && !category.isEmpty()) {
+            sourceIndices.add(Constants.INDEX_EVENTS_PREFIX + category.toLowerCase(Locale.ROOT));
+        }
+
+        return new DetectorTarget(integrationId, logType, sourceIndices);
+    }
+
     private List<String> extractRuleIds(Map<String, Object> integrationSource) {
         List<String> ruleIds = new ArrayList<>();
         Object documentObj = integrationSource.get(Constants.KEY_DOCUMENT);
@@ -428,15 +500,25 @@ public class LogtestService {
             Map<String, Object> engineResult,
             String normalizedEventJson,
             List<String> ruleBodies,
+            DetectorTarget target,
             ActionListener<RestResponse> listener) {
         if (ruleBodies.isEmpty()) {
             listener.onResponse(buildCombinedResponse(engineResult, createEmptySapResult()));
+            return;
+        }
+        if (target.sourceIndices().isEmpty()) {
+            listener.onResponse(
+                    buildCombinedResponse(
+                            engineResult, createSkippedSapResult(noSourceIndexReason(target.integrationId()))));
             return;
         }
 
         this.securityAnalytics.evaluateRulesAsync(
                 normalizedEventJson,
                 ruleBodies,
+                target.integrationId(),
+                target.logType(),
+                target.sourceIndices(),
                 ActionListener.wrap(
                         saResultJson -> {
                             ObjectMapper mapper = new ObjectMapper();
@@ -450,21 +532,34 @@ public class LogtestService {
                         },
                         e -> {
                             log.error("Failed to evaluate rules: {}", e.getMessage());
-                            listener.onResponse(buildCombinedResponse(engineResult, createErrorSapResult()));
+                            listener.onResponse(
+                                    buildCombinedResponse(engineResult, createSkippedSapResult(e.getMessage())));
                         }));
     }
 
     @SuppressWarnings("unchecked")
     private void evaluateDetectionRules(
-            String eventJson, List<String> ruleBodies, ActionListener<RestResponse> listener) {
+            String eventJson,
+            List<String> ruleBodies,
+            DetectorTarget target,
+            ActionListener<RestResponse> listener) {
         if (ruleBodies.isEmpty()) {
             listener.onResponse(buildDetectionResponse(createEmptySapResult()));
+            return;
+        }
+        if (target.sourceIndices().isEmpty()) {
+            listener.onResponse(
+                    buildDetectionResponse(
+                            createSkippedSapResult(noSourceIndexReason(target.integrationId()))));
             return;
         }
 
         this.securityAnalytics.evaluateRulesAsync(
                 eventJson,
                 ruleBodies,
+                target.integrationId(),
+                target.logType(),
+                target.sourceIndices(),
                 ActionListener.wrap(
                         saResultJson -> {
                             ObjectMapper mapper = new ObjectMapper();
@@ -478,7 +573,7 @@ public class LogtestService {
                         },
                         e -> {
                             log.error("Failed to evaluate rules: {}", e.getMessage());
-                            listener.onResponse(buildDetectionResponse(createErrorSapResult()));
+                            listener.onResponse(buildDetectionResponse(createSkippedSapResult(e.getMessage())));
                         }));
     }
 
@@ -519,6 +614,41 @@ public class LogtestService {
         response.put("rules_matched", 0);
         response.put("matches", List.of());
         return response;
+    }
+
+    /**
+     * Creates a skipped SAP result carrying why nothing was evaluated.
+     *
+     * <p>Skipped rather than zero matches: "the rules could not be evaluated" is not the same answer
+     * as "the rules do not match this event", and conflating the two is what made logtest misleading
+     * in the first place.
+     *
+     * @param reason why the rules could not be evaluated.
+     * @return the skipped result.
+     */
+    private Map<String, Object> createSkippedSapResult(String reason) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put(Constants.KEY_STATUS, "skipped");
+        response.put("reason", reason);
+        response.put("rules_evaluated", 0);
+        response.put("rules_matched", 0);
+        response.put("matches", List.of());
+        return response;
+    }
+
+    /**
+     * Reason used when an integration names no source index, so there are no field mappings to
+     * resolve its rules' compiled queries against.
+     *
+     * @param integrationId the integration being tested.
+     * @return the reason message.
+     */
+    private String noSourceIndexReason(String integrationId) {
+        return String.format(
+                Locale.ROOT,
+                "Integration [%s] declares no detector source index, so its rules cannot be evaluated "
+                        + "the way a detector would evaluate them",
+                integrationId);
     }
 
     /** Creates an error SAP result. */

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsService.java
@@ -117,12 +117,24 @@ public interface SecurityAnalyticsService {
     /**
      * Asynchronously evaluates a list of Sigma rules against a normalized event.
      *
+     * <p>Security Analytics compiles the rules and percolates the event against them exactly as a
+     * deployed detector would, so it needs to know which integration the rules belong to and which
+     * source indices their fields must resolve against.
+     *
      * @param eventJson The normalized event as a JSON string.
      * @param ruleBodies The list of Sigma rule bodies to evaluate.
+     * @param integrationId The identifier of the integration owning the rules.
+     * @param logType The integration's log type.
+     * @param sourceIndices The source indices the integration's detector reads.
      * @param listener The listener to be notified with the evaluation result JSON string.
      */
     void evaluateRulesAsync(
-            String eventJson, List<String> ruleBodies, ActionListener<String> listener);
+            String eventJson,
+            List<String> ruleBodies,
+            String integrationId,
+            String logType,
+            List<String> sourceIndices,
+            ActionListener<String> listener);
 
     /**
      * Asynchronously deletes all Security Analytics resources belonging to the given space.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImpl.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SecurityAnalyticsServiceImpl.java
@@ -450,8 +450,14 @@ public class SecurityAnalyticsServiceImpl implements SecurityAnalyticsService {
 
     @Override
     public void evaluateRulesAsync(
-            String eventJson, java.util.List<String> ruleBodies, ActionListener<String> listener) {
-        WEvaluateRulesRequest request = new WEvaluateRulesRequest(eventJson, ruleBodies);
+            String eventJson,
+            java.util.List<String> ruleBodies,
+            String integrationId,
+            String logType,
+            java.util.List<String> sourceIndices,
+            ActionListener<String> listener) {
+        WEvaluateRulesRequest request =
+                new WEvaluateRulesRequest(eventJson, ruleBodies, integrationId, logType, sourceIndices);
         this.client.execute(
                 WEvaluateRulesAction.INSTANCE,
                 request,

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/settings/PluginSettings.java
@@ -317,6 +317,22 @@ public class PluginSettings {
                     Setting.Property.NodeScope,
                     Setting.Property.Filtered);
 
+    /**
+     * Setting to enable the mock Security Analytics service for testing environments.
+     *
+     * <p>Separate from {@link #ENGINE_MOCK_ENABLED} because the two are not available under the same
+     * conditions: the Engine talks over a Unix socket that a test cluster does not have, while
+     * Security Analytics is a plugin this one extends and is therefore always installed. Defaults to
+     * whatever the engine mock is set to, so an environment that mocked both keeps doing so, but a
+     * test cluster can now mock only the Engine and exercise real rule evaluation.
+     */
+    public static final Setting<Boolean> SECURITY_ANALYTICS_MOCK_ENABLED =
+            Setting.boolSetting(
+                    "plugins.content_manager.security_analytics.mock",
+                    ENGINE_MOCK_ENABLED,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Filtered);
+
     /** Configuration setting to enable or disable the telemetry ping. Defaults to true. */
     public static final Setting<Boolean> TELEMETRY_ENABLED =
             Setting.boolSetting(
@@ -436,6 +452,7 @@ public class PluginSettings {
     private final String catalogVulnerabilities;
     private final long pitKeepalive;
     private final boolean engineMockEnabled;
+    private final boolean securityAnalyticsMockEnabled;
     private final int setupWaitMaxRetries;
     private final int setupWaitBackoffBaseSeconds;
     private final int clientMaxRetries;
@@ -473,6 +490,7 @@ public class PluginSettings {
         this.catalogVulnerabilities = CATALOG_VULNERABILITIES.get(settings);
         this.pitKeepalive = PIT_KEEPALIVE.get(settings);
         this.engineMockEnabled = ENGINE_MOCK_ENABLED.get(settings);
+        this.securityAnalyticsMockEnabled = SECURITY_ANALYTICS_MOCK_ENABLED.get(settings);
         this.setupWaitMaxRetries = SETUP_WAIT_MAX_RETRIES.get(settings);
         this.setupWaitBackoffBaseSeconds = SETUP_WAIT_BACKOFF_BASE_SECONDS.get(settings);
         this.clientMaxRetries = CLIENT_MAX_RETRIES.get(settings);
@@ -839,6 +857,15 @@ public class PluginSettings {
      */
     public Boolean isEngineMockEnabled() {
         return this.engineMockEnabled;
+    }
+
+    /**
+     * Retrieves the value for the Security Analytics mock enabled setting.
+     *
+     * @return a Boolean indicating if the mock Security Analytics service is enabled.
+     */
+    public Boolean isSecurityAnalyticsMockEnabled() {
+        return this.securityAnalyticsMockEnabled;
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -694,6 +694,13 @@ public class Constants {
     public static final String INDEX_FILTERS = "wazuh-threatintel-filters";
 
     /**
+     * Prefix of the WCS event data streams a threat detector reads. Completed with the integration's
+     * category when the integration document names no explicit detector source, the same fallback
+     * Security Analytics applies when it builds the detector.
+     */
+    public static final String INDEX_EVENTS_PREFIX = "wazuh-events-v5-";
+
+    /**
      * Document id of the single user-overrides registry document, stored in {@link #INDEX_POLICIES}.
      *
      * <p>That document deliberately carries no {@code space} field: the pre-snapshot wipe selects by

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockSecurityAnalyticsService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/MockSecurityAnalyticsService.java
@@ -99,10 +99,16 @@ public class MockSecurityAnalyticsService implements SecurityAnalyticsService {
 
     @Override
     public void evaluateRulesAsync(
-            String eventJson, java.util.List<String> ruleBodies, ActionListener<String> listener) {
+            String eventJson,
+            java.util.List<String> ruleBodies,
+            String integrationId,
+            String logType,
+            java.util.List<String> sourceIndices,
+            ActionListener<String> listener) {
         log.debug("MockSecurityAnalyticsService.evaluateRulesAsync called");
         listener.onResponse(
-                "{\"status\":\"success\",\"rules_evaluated\":0,\"rules_matched\":0,\"matches\":[]}");
+                "{\"status\":\"success\",\"rules_evaluated\":0,\"rules_matched\":0,\"matches\":[],"
+                        + "\"rules_skipped\":0,\"skipped\":[]}");
     }
 
     @Override

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/LogtestServiceTests.java
@@ -205,7 +205,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         SearchHit ruleHit = createHit(2, "rule-1",
             """
@@ -221,7 +221,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"skipped\""));
         Assert.assertTrue(response.getMessage().contains("Engine processing failed"));
-        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, never())
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 
     /** When engine throws exception, SAP is skipped. */
@@ -229,7 +230,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             """
-            {"document": {"rules": []}}
+            {"document": {"rules": [], "category": "test", "metadata": {"title": "Test Integration"}}}
             """);
         // spotless:on
         mockClientSearchAsync(createSearchResponse(integrationHit));
@@ -241,7 +242,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"skipped\""));
         Assert.assertTrue(response.getMessage().contains("socket timeout"));
-        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, never())
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 
     /** Integration with no rules returns success with zero matches. */
@@ -268,7 +270,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
         Assert.assertTrue(response.getMessage().contains("\"rules_matched\":0"));
         Assert.assertTrue(response.getMessage().contains("\"success\""));
-        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, never())
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 
     /** Full flow: engine success + SAP evaluation. */
@@ -277,7 +280,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         SearchHit ruleHit = createHit(2, "rule-1",
             """
@@ -294,14 +297,14 @@ public class LogtestServiceTests extends OpenSearchTestCase {
                 """
             ));
         doAnswer(invocation -> {
-            ActionListener<String> l = invocation.getArgument(2);
+            ActionListener<String> l = invocation.getArgument(5);
             l.onResponse(
                 """
                 {"status":"success","rules_evaluated":1,"rules_matched":1,"matches":[{"rule_name":"Test Rule"}],"evaluation_time_ms":10}
                 """
             );
             return null;
-        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
+        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any(ActionListener.class));
         // spotless:on
 
         RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
@@ -309,7 +312,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         Assert.assertTrue(response.getMessage().contains("normalization"));
         Assert.assertTrue(response.getMessage().contains("detection"));
         Assert.assertTrue(response.getMessage().contains("\"rules_matched\":1"));
-        verify(this.securityAnalytics, times(1)).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, times(1))
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 
     /** Normalized event from engine output is passed to SAP. */
@@ -318,7 +322,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         SearchHit ruleHit = createHit(2, "rule-1",
             """
@@ -335,17 +339,19 @@ public class LogtestServiceTests extends OpenSearchTestCase {
                 """
             ));
         doAnswer(invocation -> {
-            ActionListener<String> l = invocation.getArgument(2);
+            ActionListener<String> l = invocation.getArgument(5);
             l.onResponse("{\"status\":\"success\",\"rules_evaluated\":0,\"rules_matched\":0,\"matches\":[]}");
             return null;
-        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
+        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any(ActionListener.class));
         // spotless:on
 
         ActionListener<RestResponse> listener = mock(ActionListener.class);
         this.service.executeLogtest(INTEGRATION_ID, Space.TEST, createEnginePayload(), listener);
 
         var eventCaptor = ArgumentCaptor.forClass(String.class);
-        verify(this.securityAnalytics).evaluateRulesAsync(eventCaptor.capture(), anyList(), any());
+        verify(this.securityAnalytics)
+                .evaluateRulesAsync(
+                        eventCaptor.capture(), anyList(), anyString(), anyString(), anyList(), any());
         String normalizedEvent = eventCaptor.getValue();
         Assert.assertTrue(normalizedEvent.contains("custom_field"));
         Assert.assertTrue(normalizedEvent.contains("event"));
@@ -361,7 +367,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         SearchHit ruleHit = createHit(2, "rule-1",
             """
@@ -378,14 +384,14 @@ public class LogtestServiceTests extends OpenSearchTestCase {
                 """
             ));
         doAnswer(invocation -> {
-            ActionListener<String> l = invocation.getArgument(2);
+            ActionListener<String> l = invocation.getArgument(5);
             l.onResponse(
                 """
                 {"status":"success","rules_evaluated":1,"rules_matched":0,"matches":[]}
                 """
             );
             return null;
-        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
+        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any(ActionListener.class));
         // spotless:on
 
         executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
@@ -406,7 +412,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         // spotless:on
         // Return integration, then empty rules (simulates no rules found)
@@ -424,7 +430,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
-        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, never())
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 
     /** SAP evaluation error returns error SAP result but still 200. */
@@ -433,7 +440,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         SearchHit ruleHit = createHit(2, "rule-1",
             """
@@ -453,12 +460,13 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // SAP returns unparseable response
         doAnswer(
                         invocation -> {
-                            ActionListener<String> l = invocation.getArgument(2);
+                            ActionListener<String> l = invocation.getArgument(5);
                             l.onResponse("not valid json");
                             return null;
                         })
                 .when(this.securityAnalytics)
-                .evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
+                .evaluateRulesAsync(
+                        anyString(), anyList(), anyString(), anyString(), anyList(), any(ActionListener.class));
 
         RestResponse response = executeAndCapture(INTEGRATION_ID, Space.TEST, createEnginePayload());
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
@@ -511,7 +519,8 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
         Assert.assertTrue(response.getMessage().contains("\"rules_matched\":0"));
-        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, never())
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 
     /** Detection: full flow with SAP evaluation. */
@@ -520,7 +529,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         SearchHit ruleHit = createHit(2, "rule-1",
             """
@@ -531,21 +540,22 @@ public class LogtestServiceTests extends OpenSearchTestCase {
 
         // spotless:off
         doAnswer(invocation -> {
-            ActionListener<String> l = invocation.getArgument(2);
+            ActionListener<String> l = invocation.getArgument(5);
             l.onResponse(
                 """
                 {"status":"success","rules_evaluated":1,"rules_matched":1,"matches":[{"rule_name":"Test Rule"}],"evaluation_time_ms":10}
                 """
             );
             return null;
-        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), any(ActionListener.class));
+        }).when(this.securityAnalytics).evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any(ActionListener.class));
         // spotless:on
 
         JsonNode inputEvent = MAPPER.readTree("{\"event\":{\"kind\":\"event\"}}");
         RestResponse response = executeDetectionAndCapture(INTEGRATION_ID, Space.TEST, inputEvent);
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"rules_matched\":1"));
-        verify(this.securityAnalytics, times(1)).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, times(1))
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 
     /** Detection: rule fetch failure returns empty matches. */
@@ -554,7 +564,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         // spotless:off
         SearchHit integrationHit = createHit(1, "int-1",
             String.format(Locale.ROOT, """
-            {"document": {"rules": ["%s"]}}
+            {"document": {"rules": ["%s"], "category": "test", "metadata": {"title": "Test Integration"}}}
             """, RULE_ID));
         // spotless:on
         // Integration succeeds, rule fetch fails
@@ -579,6 +589,7 @@ public class LogtestServiceTests extends OpenSearchTestCase {
         RestResponse response = executeDetectionAndCapture(INTEGRATION_ID, Space.TEST, inputEvent);
         Assert.assertEquals(RestStatus.OK.getStatus(), response.getStatus());
         Assert.assertTrue(response.getMessage().contains("\"rules_evaluated\":0"));
-        verify(this.securityAnalytics, never()).evaluateRulesAsync(anyString(), anyList(), any());
+        verify(this.securityAnalytics, never())
+                .evaluateRulesAsync(anyString(), anyList(), anyString(), anyString(), anyList(), any());
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/LogtestIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/LogtestIT.java
@@ -25,6 +25,8 @@ import org.opensearch.client.ResponseException;
 import org.opensearch.core.rest.RestStatus;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -357,19 +359,27 @@ public class LogtestIT extends ContentManagerRestTestCase {
         assertEquals(exactCase.toString(), "success", exactCase.path("status").asText());
         assertEquals(
                 "the rule must match its own case: " + exactCase, 1, exactCase.path("rules_matched").asInt());
-        assertFalse(
-                "matched_conditions must describe the rule's conditions: " + exactCase,
-                exactCase.path("matches").path(0).path("matched_conditions").isEmpty());
+        // The rule offers two alternatives and the event carries one of them. Only that one may be
+        // listed: reporting both would describe the rule rather than the event, and two different
+        // injection attempts caught by this rule would read identically.
+        List<String> conditions = new ArrayList<>();
         exactCase
                 .path("matches")
                 .path(0)
                 .path("matched_conditions")
-                .forEach(
-                        condition ->
-                                assertFalse(
-                                        "a condition must be described on its own, not as one composed "
-                                                + "expression: " + condition.asText(),
-                                        condition.asText().contains(" AND ")));
+                .forEach(condition -> conditions.add(condition.asText()));
+        assertEquals(
+                "only the conditions the event satisfies may be listed: " + conditions, 2, conditions.size());
+        assertTrue(conditions.toString(), conditions.contains("http.request.method matched 'GET'"));
+        assertTrue(conditions.toString(), conditions.contains("url.original matched '*UNION SELECT*'"));
+        assertFalse(
+                "an alternative the event does not satisfy must not be listed: " + conditions,
+                conditions.contains("url.original matched '*UNION ALL SELECT*'"));
+        for (String condition : conditions) {
+            assertFalse(
+                    "a condition must be described on its own, not as one composed expression: " + condition,
+                    condition.contains(" AND "));
+        }
 
         // 2. The reported case: the rule says UNION SELECT, the event says UNION sElect. String
         // comparison is case-sensitive, so a deployed detector produces no finding for this event —

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/LogtestIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/LogtestIT.java
@@ -17,6 +17,7 @@
 package com.wazuh.contentmanager.rest.it;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.hc.core5.http.ParseException;
 import org.opensearch.client.Response;
@@ -25,6 +26,7 @@ import org.opensearch.core.rest.RestStatus;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.UUID;
 
 import com.wazuh.contentmanager.ContentManagerRestTestCase;
 import com.wazuh.contentmanager.settings.PluginSettings;
@@ -45,6 +47,9 @@ import com.wazuh.contentmanager.utils.Constants;
  * response structure rather than successful engine processing.
  */
 public class LogtestIT extends ContentManagerRestTestCase {
+
+    /** Rules this test created, so the promotion can be scoped to them. */
+    private final java.util.List<String> ownRuleIds = new java.util.ArrayList<>();
 
     // ========================
     // Payload Helpers
@@ -297,8 +302,282 @@ public class LogtestIT extends ContentManagerRestTestCase {
     }
 
     // ========================
+    // Detection (percolate) Tests
+    // ========================
+
+    /**
+     * The reported bug, plus the cases that keep the fix honest, in one test.
+     *
+     * <p>One test rather than four because the setup ends in a draft-to-test promotion, and promotion
+     * is global: every promotion sweeps up whatever other test classes happen to have in draft, so
+     * each one is a chance for this class to break an unrelated one. The four assertions below are
+     * independent, and each carries the response in its failure message.
+     *
+     * <p>What this exercises is the real thing: the rules are compiled by Security Analytics and
+     * percolated against the event by alerting's percolator, in a cluster where both plugins are
+     * installed and rule evaluation is not mocked.
+     *
+     * @throws IOException on communication error
+     */
+    public void testDetectionPercolatesRulesLikeADetector() throws IOException {
+        String integrationTitle = "logtest-percolate";
+        this.createEventsSourceIndex();
+        String integrationId = this.createIntegration(integrationTitle);
+        // The reported SQL-injection rule, trimmed to the branch under test.
+        this.createRuleWithDetection(
+                integrationId,
+                integrationTitle,
+                "sqli",
+                """
+                {"condition": "selection and selection_1",
+                 "selection": {"http.request.method": "GET"},
+                 "selection_1": {"url.original|contains": ["UNION SELECT", "UNION ALL SELECT"]}}
+                """);
+        // process.name is a real WCS field, so the rule is valid, but the source index this
+        // integration's detector reads does not map it — so no detector could ever match it.
+        this.createRuleWithDetection(
+                integrationId,
+                integrationTitle,
+                "unmapped",
+                """
+                {"condition": "selection",
+                 "selection": {"process.name|contains": "anything"}}
+                """);
+        this.copyOwnResourcesToTestSpace(integrationId);
+
+        // 1. The rule against the case it was written in: this is the branch that does produce a
+        // finding in production, so it must match here too.
+        JsonNode exactCase =
+                this.detect(
+                        integrationId,
+                        """
+                        {"http": {"request": {"method": "GET"}},
+                         "url": {"original": "/item.php?id=-1 UNION SELECT username,password FROM users--"}}
+                        """);
+        assertEquals(exactCase.toString(), "success", exactCase.path("status").asText());
+        assertEquals(
+                "the rule must match its own case: " + exactCase, 1, exactCase.path("rules_matched").asInt());
+        assertFalse(
+                "matched_conditions must carry the query that matched: " + exactCase,
+                exactCase.path("matches").path(0).path("matched_conditions").isEmpty());
+
+        // 2. The reported case: the rule says UNION SELECT, the event says UNION sElect. String
+        // comparison is case-sensitive, so a deployed detector produces no finding for this event —
+        // and this is the assertion that pins logtest to that answer. Before this change logtest
+        // reported a match here, which is what made it untrustworthy. Making `contains`
+        // case-insensitive is tracked separately; if that lands, this expectation flips to 1 in the
+        // same commit that changes the analyzer, and the detector flips with it.
+        JsonNode differentCase =
+                this.detect(
+                        integrationId,
+                        """
+                        {"http": {"request": {"method": "GET"}},
+                         "url": {"original": "/item.php?id=-1 UNION sElect username,password FROM users--"}}
+                        """);
+        assertEquals(
+                "logtest must not claim a match a detector would not produce: " + differentCase,
+                0,
+                differentCase.path("rules_matched").asInt());
+
+        // 3. An event without the pattern at all, so the comparison has not become match-nothing
+        // for the wrong reason.
+        JsonNode noMatch =
+                this.detect(
+                        integrationId,
+                        """
+                        {"http": {"request": {"method": "GET"}}, "url": {"original": "/index.php?id=1"}}
+                        """);
+        assertEquals(
+                "an unrelated event must not match: " + noMatch, 0, noMatch.path("rules_matched").asInt());
+
+        // 4. The rule over the unmapped field is reported, not quietly dropped: the percolator refuses
+        // to store a query over a field the source index does not map, which is exactly why a detector
+        // would never match it either.
+        assertEquals(
+                "the rule that cannot be evaluated must be reported: " + noMatch,
+                1,
+                noMatch.path("rules_skipped").asInt());
+        assertFalse(
+                "the skip must say why: " + noMatch,
+                noMatch.path("skipped").path(0).path("reason").asText().isEmpty());
+        assertEquals(
+                "both rules are in scope: " + noMatch, 2, noMatch.path("rules_evaluated").asInt());
+    }
+
+    // ========================
+    // Detection Helpers
+    // ========================
+
+    /**
+     * Creates the WCS event index a threat detector for this integration would read, so the compiled
+     * rule queries have real field mappings to resolve against.
+     *
+     * <p>{@code cloud-services} is the category {@link #createIntegration(String)} uses, and a
+     * detector with no explicit source falls back to {@code wazuh-events-v5-<category>}.
+     *
+     * @throws IOException on communication error
+     */
+    private void createEventsSourceIndex() throws IOException {
+        String dataStream = "wazuh-events-v5-cloud-services";
+
+        // The setup plugin declares wazuh-events-v5* as a data stream, so this name cannot be a
+        // plain index. Create the stream, tolerating the case where a previous test already did.
+        try {
+            Response created = this.makeRequest("PUT", "/_data_stream/" + dataStream);
+            assertEquals(RestStatus.OK.getStatus(), this.getStatusCode(created));
+        } catch (ResponseException e) {
+            assertEquals(
+                    "creating the events data stream must not fail for any other reason",
+                    RestStatus.BAD_REQUEST.getStatus(),
+                    e.getResponse().getStatusLine().getStatusCode());
+        }
+
+        // Ingest one event so the fields the rules reference get mapped. The events template is
+        // `dynamic: strict_allow_templates`, so a field is mapped only once a document carries it —
+        // which is exactly the production precondition: until events have been ingested, a compiled
+        // rule query has nothing to resolve against and no detector can match it either.
+        //
+        // `process.name` is deliberately absent. The second rule of the detection test references
+        // it, and its whole point is to be a rule the percolator must refuse.
+        // spotless:off
+        String event = """
+                {"@timestamp": "2026-09-04T10:16:00.000Z",
+                 "http": {"request": {"method": "GET"}},
+                 "url": {"original": "/seed"}}
+                """;
+        // spotless:on
+        Response indexed = this.makeRequest("POST", "/" + dataStream + "/_doc?refresh=true", event);
+        assertEquals(RestStatus.CREATED.getStatus(), this.getStatusCode(indexed));
+    }
+
+    /**
+     * Creates a rule with a caller-supplied detection block, which the shared helper does not allow.
+     *
+     * @param integrationId the parent integration ID
+     * @param integrationTitle the integration title, used as log source
+     * @param name distinguishes this rule from the others of the same integration
+     * @param detectionJson the Sigma detection block
+     * @return the generated rule ID
+     * @throws IOException on communication error
+     */
+    private String createRuleWithDetection(
+            String integrationId, String integrationTitle, String name, String detectionJson)
+            throws IOException {
+        // spotless:off
+        String payload = String.format(Locale.ROOT, """
+                {
+                    "integration": "%s",
+                    "resource": {
+                        "metadata": {
+                            "title": "Rule %s for %s",
+                            "description": "A rule for integration tests.",
+                            "author": "Tester",
+                            "references": ["https://wazuh.com"]
+                        },
+                        "sigma_id": "%s-%s",
+                        "enabled": true,
+                        "status": "experimental",
+                        "logsource": {"product": "%s", "category": "%s"},
+                        "detection": %s,
+                        "level": "high"
+                    }
+                }
+                """, integrationId, name, integrationTitle, integrationTitle, name, integrationTitle,
+                integrationTitle, detectionJson);
+        // spotless:on
+
+        Response response = this.makeRequest("POST", PluginSettings.RULES_URI, payload);
+        assertEquals(RestStatus.CREATED.getStatus(), this.getStatusCode(response));
+        String id = (String) this.parseResponseAsMap(response).get("message");
+        assertNotNull("Rule ID should not be null", id);
+        this.ownRuleIds.add(id);
+        return id;
+    }
+
+    /**
+     * Runs the detection-only endpoint against a pre-normalized event, which needs no Engine.
+     *
+     * @param integrationId the integration whose rules to evaluate
+     * @param inputJson the normalized event
+     * @return the detection result
+     * @throws IOException on communication error
+     */
+    private JsonNode detect(String integrationId, String inputJson) throws IOException {
+        // spotless:off
+        String payload = String.format(Locale.ROOT, """
+                {"integration": "%s", "space": "test", "input": %s}
+                """, integrationId, inputJson);
+        // spotless:on
+
+        Response response = this.makeRequest("POST", PluginSettings.LOGTEST_DETECTION_URI, payload);
+        assertEquals(RestStatus.OK.getStatus(), this.getStatusCode(response));
+        return this.responseAsJson(response).path("message");
+    }
+
+    // ========================
     // Promote Helper
     // ========================
+
+    /**
+     * Moves this test's integration and its rules into the {@code test} space, and leaves draft as it
+     * found it.
+     *
+     * <p>Not via {@link #promoteDraftToTest()}: promotion applies to the whole space, so in a suite
+     * that shares one cluster it promotes whatever another test class happens to have in draft, which
+     * is enough to make that class fail — and it does, intermittently, depending on the order the
+     * classes run in. Detection reads these two indices and nothing else, so copying the documents
+     * the plugin just wrote, then deleting the draft originals, exercises the same path while leaving
+     * no trace for anyone else. Promotion itself is covered by
+     * {@link #testLogtestWithPromotedIntegration()}.
+     *
+     * @param integrationId the integration to move, with its rules
+     * @throws IOException on communication error
+     */
+    private void copyOwnResourcesToTestSpace(String integrationId) throws IOException {
+        for (String ruleId : this.ownRuleIds) {
+            this.copyDocumentToTestSpace(Constants.INDEX_RULES, ruleId);
+        }
+        this.copyDocumentToTestSpace(Constants.INDEX_INTEGRATIONS, integrationId);
+
+        // Remove the draft originals so no other class sees them, in particular so a promotion
+        // elsewhere does not pick them up.
+        for (String ruleId : this.ownRuleIds) {
+            this.deleteResource(PluginSettings.RULES_URI, ruleId);
+        }
+        this.deleteResource(PluginSettings.INTEGRATIONS_URI, integrationId);
+
+        this.refreshIndex(Constants.INDEX_INTEGRATIONS);
+        this.refreshIndex(Constants.INDEX_RULES);
+        // Deleting the draft originals rewrites the draft policy; refresh it too so the next test's
+        // draft policy check reads a searchable index.
+        this.refreshIndex(Constants.INDEX_POLICIES);
+    }
+
+    /**
+     * Copies one content document from the draft space into the test space.
+     *
+     * <p>The copy is the document the plugin itself wrote, with only {@code space.name} changed, so
+     * the test does not depend on a hand-written document shape.
+     *
+     * @param index the content index
+     * @param documentId the resource id
+     * @throws IOException on communication error
+     */
+    private void copyDocumentToTestSpace(String index, String documentId) throws IOException {
+        JsonNode draft = this.getResourceByDocumentId(index, documentId, "draft");
+        assertNotNull("draft document must exist before copying: " + documentId, draft);
+
+        ObjectNode copy = draft.deepCopy();
+        ObjectNode space = copy.with(Constants.KEY_SPACE);
+        space.put(Constants.KEY_NAME, "test");
+
+        Response response =
+                this.makeRequest(
+                        "PUT",
+                        "/" + index + "/_doc/" + UUID.randomUUID() + "?refresh=true",
+                        MAPPER.writeValueAsString(copy));
+        assertEquals(RestStatus.CREATED.getStatus(), this.getStatusCode(response));
+    }
 
     /**
      * Promotes all resources from draft to test space.

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/LogtestIT.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/it/LogtestIT.java
@@ -358,8 +358,18 @@ public class LogtestIT extends ContentManagerRestTestCase {
         assertEquals(
                 "the rule must match its own case: " + exactCase, 1, exactCase.path("rules_matched").asInt());
         assertFalse(
-                "matched_conditions must carry the query that matched: " + exactCase,
+                "matched_conditions must describe the rule's conditions: " + exactCase,
                 exactCase.path("matches").path(0).path("matched_conditions").isEmpty());
+        exactCase
+                .path("matches")
+                .path(0)
+                .path("matched_conditions")
+                .forEach(
+                        condition ->
+                                assertFalse(
+                                        "a condition must be described on its own, not as one composed "
+                                                + "expression: " + condition.asText(),
+                                        condition.asText().contains(" AND ")));
 
         // 2. The reported case: the rule says UNION SELECT, the event says UNION sElect. String
         // comparison is case-sensitive, so a deployed detector produces no finding for this event —
@@ -390,16 +400,15 @@ public class LogtestIT extends ContentManagerRestTestCase {
         assertEquals(
                 "an unrelated event must not match: " + noMatch, 0, noMatch.path("rules_matched").asInt());
 
-        // 4. The rule over the unmapped field is reported, not quietly dropped: the percolator refuses
-        // to store a query over a field the source index does not map, which is exactly why a detector
-        // would never match it either.
-        assertEquals(
-                "the rule that cannot be evaluated must be reported: " + noMatch,
-                1,
-                noMatch.path("rules_skipped").asInt());
-        assertFalse(
-                "the skip must say why: " + noMatch,
-                noMatch.path("skipped").path(0).path("reason").asText().isEmpty());
+        // 4. The response carries only the fields the logtest contract defines. A rule that cannot be
+        // evaluated — here, one over a field the source index does not map — is simply not a match,
+        // and the reason goes to the log.
+        assertTrue(
+                "rules_skipped is not part of the response contract: " + noMatch,
+                noMatch.path("rules_skipped").isMissingNode());
+        assertTrue(
+                "skipped is not part of the response contract: " + noMatch,
+                noMatch.path("skipped").isMissingNode());
         assertEquals(
                 "both rules are in scope: " + noMatch, 2, noMatch.path("rules_evaluated").asInt());
     }


### PR DESCRIPTION
## Description

This PR is a companion of this PR: https://github.com/wazuh/wazuh-indexer-security-analytics/pull/324

This PR is the Content Manager half: it hands Security Analytics what it needs to evaluate rules the way a deployed detector does, reports the new "could not evaluate" outcome instead of hiding it, and, so the behavior is actually covered by
tests, stops mocking rule evaluation in the integration-test cluster.

Closes https://github.com/wazuh/wazuh-indexer-security-analytics/issues/321

## Proposed Changes

**1. Detector coordinates are passed to the evaluator.** Security Analytics now compiles rules and percolates them, so it needs to know which percolator index to use and which source indices the compiled queries must resolve their fields against. `SecurityAnalyticsService#evaluateRulesAsync` takes three more arguments, `integrationId`, `logType`, `sourceIndices`, and `WEvaluateRulesRequest` carries them.

`LogtestService#extractDetectorTarget` reads them off the integration document logtest has already fetched, deliberately mirroring how a detector is built from that same document

**2. Failures say what happened.** 
**3. `plugins.content_manager.security_analytics.mock` (new).** One flag, `plugins.content_manager.engine.mock`, used to swap out *both* the Engine and the Security Analytics service. 

### Results and Evidence

Full runs in `pr-321-evidence.md`.

- **Unit tests**: :white_check_mark: 
- **Integration tests**:  :white_check_mark: 
- **Live validation on the AIO** In: https://github.com/wazuh/wazuh-indexer-security-analytics/pull/324#issue-5374292360

### Artifacts Affected

Content Manager plugin

### Configuration Changes

- **New**: `plugins.content_manager.security_analytics.mock` (node scope, filtered). Defaults to the
  value of `plugins.content_manager.engine.mock`, so existing deployments and dev setups are
  unaffected.

### Documentation Updates

- `docs/ref/modules/ruleset-management/rules.md`
- `docs/ref/modules/content-manager/rule-testing.md` 
- `docs/ref/modules/content-manager/api.md` and `plugins/content-manager/openapi.yml`
- `docs/dev/plugins/content-manager-logtest.md` 
- `openapi.yml` 

### Tests Introduced

| Test | Covers |
| --- | --- |
| `LogtestIT#testDetectionPercolatesRulesLikeADetector` | The reported case end to end: the exact-case event matches, the mixed-case event does **not** — which is what a deployed detector does — an unrelated event does not match, and a rule over a field the source index does not map is reported under `skipped` with a reason rather than silently counted as a non-match |

`LogtestServiceTests` was updated for the wider `evaluateRulesAsync` signature, and its integration
fixtures now carry the `category` and `metadata.title` a real integration document has — without them
the service correctly refuses to evaluate.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)