### PR TITLE
Add permissions check on endpoint to set subscription to CTI

### DIFF
--- a/docs/ref/modules/content-manager/api.md
+++ b/docs/ref/modules/content-manager/api.md
@@ -96,6 +96,8 @@ YAML parsing preserves numeric type fidelity. Floating-point values like `5.0` a
 
 Stores the provided CTI access token in the `.wazuh-internal-state` hidden index and loads it into memory. If the index does not exist it is recreated automatically before writing.
 
+> To find out whether the current user is allowed to register, without registering, see [Check registration permission](#check-registration-permission).
+
 #### Request
 
 - Method: `POST`
@@ -131,6 +133,63 @@ curl -sk -u admin:admin -X POST \
 - **400** — missing or empty `access_token` field.
 - **412** — a required precondition is not met (for example, the credentials index is not declared as a system index — see `plugins.security.system_indices.indices` in `opensearch.yml`).
 - **500** — internal error.
+
+---
+
+### Check registration permission
+
+Answers whether the current user is allowed to register a CTI subscription, without registering one. Intended for callers that need to decide before starting the CTI OAuth device flow, since approving that flow creates the environment on the CTI side and an authorization failure afterwards leaves it orphaned.
+
+The check is performed with the `perform_permission_check` query parameter, which is provided natively by the OpenSearch security plugin for any REST endpoint. The permission evaluated is the same one a real registration requires: `plugin:content_manager/subscription/post`, mapped to the `cluster:admin/content_manager/subscription/create` action. Under the default role set, only `wazuh_admin` holds it.
+
+> The request has **no side effects**: the security plugin answers before the action executes, so no CTI API call is made and no credentials are written. It is idempotent and safe to call repeatedly.
+
+#### Request
+
+- Method: `POST`
+- Path: `/_plugins/_content_manager/subscription`
+
+#### Query parameters
+
+- **`perform_permission_check`** (Boolean, optional, default `false`) — when `true`, return the authorization decision instead of registering a subscription. An empty value is treated as `true`.
+
+#### Request body
+
+None. The body is not read in this mode, and `access_token` is not required.
+
+#### Example request
+
+```bash
+curl -sk -u admin:admin -X POST \
+  "https://127.0.0.1:9200/_plugins/_content_manager/subscription?perform_permission_check=true"
+```
+
+#### Example response (allowed)
+
+```json
+{
+  "accessAllowed": true,
+  "missingPrivileges": []
+}
+```
+
+#### Example response (denied)
+
+```json
+{
+  "accessAllowed": false,
+  "missingPrivileges": ["cluster:admin/content_manager/subscription/create"]
+}
+```
+
+#### Status codes
+
+- **200** — decision returned. Both the allowed and the denied case use this status.
+- **401** — missing or invalid credentials.
+
+> **Note**: This mode always responds with `200`; the outcome is carried by the `accessAllowed` field. Branch on that field, not on the status code. The `missingPrivileges` array contains raw action names intended for logs and support, not for display to end users.
+
+The response fields are produced by the security plugin and are therefore camelCase, identical on every endpoint that supports this parameter.
 
 ---
 

--- a/docs/ref/security/permissions.md
+++ b/docs/ref/security/permissions.md
@@ -21,7 +21,7 @@ Other Content Manager permissions:
 - `plugin:content_manager/policy/update` — create/update a policy (`PUT /_plugins/_content_manager/policy/{space}`)
 - `plugin:content_manager/update` — trigger an on-demand CTI catalog sync (`POST /_plugins/_content_manager/update`)
 - `plugin:content_manager/subscription/get` — read the CTI subscription
-- `plugin:content_manager/subscription/post` — create/update the CTI subscription
+- `plugin:content_manager/subscription/post` — create/update the CTI subscription. Also the permission evaluated by `POST /_plugins/_content_manager/subscription?perform_permission_check=true`, which reports whether the caller holds it instead of registering.
 - `plugin:content_manager/subscription/delete` — delete the CTI subscription
 - `plugin:content_manager/promote/get` — preview a promotion diff
 - `plugin:content_manager/promote/post` — execute a space promotion (and `plugin:content_manager/promote/*`)

--- a/plugins/content-manager/openapi.yml
+++ b/plugins/content-manager/openapi.yml
@@ -59,9 +59,38 @@ paths:
       description: |
         Stores the provided CTI access token used to authenticate against the CTI API.
         The token is persisted in a hidden internal index and loaded into memory.
+
+        With `perform_permission_check=true` the endpoint instead answers *"may the current
+        user register a subscription?"* without registering anything: no request body is
+        read, no access token is required and the operation has no side effects. The
+        permission evaluated is the same one a real registration needs,
+        `cluster:admin/content_manager/subscription/create` (action group
+        `plugin:content_manager/subscription/post`, granted to `wazuh_admin` in the stock
+        role set).
+
+        In that mode the response is **always `200`** — permitted and denied differ only in
+        the body — so clients must branch on `accessAllowed`, never on the HTTP status.
+        `missingPrivileges` carries raw transport action names, useful for logs and support;
+        do not render it to end users.
       operationId: storeCredentials
       tags:
         - Subscription Management
+      parameters:
+        - name: perform_permission_check
+          in: query
+          required: false
+          description: |
+            Answer whether the caller holds the permission this endpoint requires, instead of
+            executing it. Implemented generically by the OpenSearch security plugin for any
+            REST endpoint (available since OpenSearch 3.2), not by the Content Manager. An
+            empty value means `true`.
+          schema:
+            type: boolean
+            default: false
+          examples:
+            check:
+              summary: Ask for the authorization decision only
+              value: true
       requestBody:
         required: true
         content:
@@ -74,6 +103,8 @@ paths:
                 value:
                   access_token: "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS"
       responses:
+        "200":
+          $ref: "#/components/responses/SubscriptionPermissionCheck"
         "201":
           $ref: "#/components/responses/SubscriptionCreated"
         "400":
@@ -1362,6 +1393,28 @@ components:
           description: The CTI access token used to authenticate against the CTI API.
           example: "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS"
 
+    PermissionCheckResponse:
+      type: object
+      description: |
+        Authorization decision returned when `perform_permission_check=true`. Produced by the
+        OpenSearch security plugin (`PermissionCheckResponse`), so the field names are
+        camelCase and identical on every endpoint of the cluster that supports the parameter.
+      required:
+        - accessAllowed
+        - missingPrivileges
+      properties:
+        accessAllowed:
+          type: boolean
+          description: Whether the caller holds every permission the operation requires.
+          example: true
+        missingPrivileges:
+          type: array
+          description: |
+            Transport action names the caller lacks. Empty when `accessAllowed` is `true`.
+          items:
+            type: string
+          example: ["cluster:admin/content_manager/subscription/create"]
+
     # Version check response models
     VersionCheckData:
       type: object
@@ -2431,6 +2484,27 @@ components:
               value:
                 message: "Access token received successfully."
                 status: 201
+
+    SubscriptionPermissionCheck:
+      description: |
+        OK - Authorization decision for `perform_permission_check=true`. Returned for both the
+        permitted and the denied case; branch on `accessAllowed`, not on the status code.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PermissionCheckResponse"
+          examples:
+            allowed:
+              summary: Caller holds the permission (e.g. wazuh_admin)
+              value:
+                accessAllowed: true
+                missingPrivileges: []
+            denied:
+              summary: Caller lacks the permission (e.g. wazuh_readonly)
+              value:
+                accessAllowed: false
+                missingPrivileges:
+                  - "cluster:admin/content_manager/subscription/create"
 
     SubscriptionStatus:
       description: OK - Subscription status and active plan details.

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/IndexSubscriptionRequest.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/action/IndexSubscriptionRequest.java
@@ -25,24 +25,78 @@ import java.io.IOException;
 
 import static org.opensearch.action.ValidateActions.addValidationError;
 
+/**
+ * Request for {@link IndexSubscriptionAction}.
+ *
+ * <p>Two shapes, distinguished by {@link #isPermissionCheckOnly()}:
+ *
+ * <ul>
+ *   <li>a real registration, carrying the CTI {@code access_token};
+ *   <li>a permission check, carrying no token, built with {@link #permissionCheck()}. It exists
+ *       only so the request reaches the security plugin's action filter, which answers it instead
+ *       of letting the action execute.
+ * </ul>
+ */
 public class IndexSubscriptionRequest extends ActionRequest {
 
     public static final String ACCESS_TOKEN_IS_MISSING = "Access token is missing";
     private static final String ACCESS_TOKEN_FIELD = "access_token";
     private final String token;
+    private final boolean permissionCheckOnly;
 
+    /**
+     * Builds a registration request.
+     *
+     * @param token the CTI access token
+     */
     public IndexSubscriptionRequest(String token) {
+        this(token, false);
+    }
+
+    private IndexSubscriptionRequest(String token, boolean permissionCheckOnly) {
         super();
         this.token = token;
+        this.permissionCheckOnly = permissionCheckOnly;
     }
 
+    /**
+     * Builds a request that only exercises the authorization filter. It carries no access token and
+     * must never perform registration work.
+     *
+     * @return a permission-check-only request
+     */
+    public static IndexSubscriptionRequest permissionCheck() {
+        return new IndexSubscriptionRequest(null, true);
+    }
+
+    /**
+     * Deserializing constructor.
+     *
+     * @param sin the stream to read from
+     * @throws IOException on read failure
+     */
     public IndexSubscriptionRequest(StreamInput sin) throws IOException {
         super(sin);
-        this.token = sin.readString();
+        this.token = sin.readOptionalString();
+        this.permissionCheckOnly = sin.readBoolean();
     }
 
+    /**
+     * Validates the request.
+     *
+     * <p>The access token check is skipped for a permission check, and that is load-bearing rather
+     * than a convenience: {@code TransportAction.execute} runs validation <em>before</em> the {@code
+     * ActionFilters} chain, so a blank token would be answered {@code 400} and the security filter
+     * would never get to evaluate the request.
+     *
+     * @return the validation error, or {@code null} when the request is valid
+     */
     @Override
     public ActionRequestValidationException validate() {
+        if (this.permissionCheckOnly) {
+            return null;
+        }
+
         ActionRequestValidationException validationException = null;
 
         if (this.token == null || this.token.isBlank()) {
@@ -56,10 +110,18 @@ public class IndexSubscriptionRequest extends ActionRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(token);
+        out.writeOptionalString(token);
+        out.writeBoolean(permissionCheckOnly);
     }
 
     public String getToken() {
         return token;
+    }
+
+    /**
+     * @return true when this request must not perform any registration work
+     */
+    public boolean isPermissionCheckOnly() {
+        return permissionCheckOnly;
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionAction.java
@@ -18,8 +18,13 @@ package com.wazuh.contentmanager.rest.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.common.xcontent.StatusToXContentObject;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
@@ -36,6 +41,7 @@ import com.wazuh.contentmanager.action.IndexSubscriptionAction;
 import com.wazuh.contentmanager.action.IndexSubscriptionRequest;
 import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
 
 import static org.opensearch.rest.RestRequest.Method.POST;
 
@@ -54,11 +60,31 @@ import static org.opensearch.rest.RestRequest.Method.POST;
  *   <li>412 Precondition Failed: Credentials index is not a system index.
  *   <li>500 Internal Server Error: Unexpected error during processing.
  * </ul>
+ *
+ * <p>With {@code ?perform_permission_check=true} the endpoint answers "may the current user
+ * register a subscription?" instead of registering one. No body is read, no access token is
+ * required and the request has no side effects: the security plugin's action filter answers it
+ * before {@code TransportIndexSubscriptionAction} executes. The response is always {@code 200}, and
+ * the caller must branch on the {@code accessAllowed} field rather than on the status:
+ *
+ * <ul>
+ *   <li>{@code {"accessAllowed": true, "missingPrivileges": []}}
+ *   <li>{@code {"accessAllowed": false, "missingPrivileges":
+ *       ["cluster:admin/content_manager/subscription/create"]}}
+ * </ul>
  */
 public class RestPostSubscriptionAction extends BaseRestHandler {
     private static final Logger log = LogManager.getLogger(RestPostSubscriptionAction.class);
     private static final String ENDPOINT_NAME = "content_manager_subscription_post";
     private static final String ACCESS_TOKEN_FIELD = "access_token";
+
+    /**
+     * Owned by the security plugin: {@code ConfigConstants.SECURITY_PERFORM_PERMISSION_CHECK_PARAM}.
+     * {@code SecurityRestFilter} has already consumed it by the time this handler runs — which is
+     * also what stops {@link BaseRestHandler} from rejecting it as unrecognized — but the handler
+     * reads it again so it stays self-contained.
+     */
+    private static final String PERFORM_PERMISSION_CHECK_PARAM = "perform_permission_check";
 
     /** Return a short identifier for this handler. */
     @Override
@@ -78,7 +104,7 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
 
     /**
      * Parses the {@code access_token} field from the request body and delegates to the transport
-     * action via {@link IndexSubscriptionAction}.
+     * action via {@link IndexSubscriptionAction}. In permission-check mode no body is parsed.
      *
      * @param request the incoming REST request
      * @param client the node client
@@ -90,6 +116,20 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
 
         log.debug("{} {}", request.method(), PluginSettings.SUBSCRIPTION_URI);
 
+        boolean permissionCheckOnly = request.paramAsBoolean(PERFORM_PERMISSION_CHECK_PARAM, false);
+
+        // Check-only mode: no body is parsed, no access token is read. The dispatch is otherwise
+        // unchanged, so the security filter evaluates exactly the permission a real registration
+        // would need.
+        IndexSubscriptionRequest subscriptionRequest =
+                permissionCheckOnly
+                        ? IndexSubscriptionRequest.permissionCheck()
+                        : new IndexSubscriptionRequest(parseAccessToken(request));
+
+        return channel -> execute(client, subscriptionRequest, channel, permissionCheckOnly);
+    }
+
+    private String parseAccessToken(RestRequest request) throws IOException {
         String accessToken = null;
         try (XContentParser parser = request.contentParser()) {
             XContentParser.Token token;
@@ -103,24 +143,68 @@ public class RestPostSubscriptionAction extends BaseRestHandler {
                 }
             }
         }
-
-        IndexSubscriptionRequest subscriptionRequest = new IndexSubscriptionRequest(accessToken);
-        return channel ->
-                client.execute(
-                        IndexSubscriptionAction.INSTANCE,
-                        subscriptionRequest,
-                        createSubscriptionResponse(channel));
+        return accessToken;
     }
 
-    private RestResponseListener<MessageStatusResponse> createSubscriptionResponse(
-            RestChannel channel) {
+    /**
+     * Dispatches the request with a listener typed over {@link ActionResponse}.
+     *
+     * <p>The raw cast is deliberate and mirrors what the security plugin already does on its side:
+     * {@code SecurityFilter} hands its own {@code PermissionCheckResponse} to this listener through
+     * an unchecked cast. A listener declared over the concrete {@link MessageStatusResponse} would
+     * generate a bridge method casting to that class and throw {@code ClassCastException}, which
+     * {@code RestActionListener} turns into a {@code 500}. Declaring it over {@code ActionResponse} —
+     * the common supertype of both responses — makes the bridge cast succeed.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void execute(
+            NodeClient client,
+            IndexSubscriptionRequest subscriptionRequest,
+            RestChannel channel,
+            boolean permissionCheckOnly) {
+        client.execute(
+                IndexSubscriptionAction.INSTANCE,
+                subscriptionRequest,
+                (ActionListener) createSubscriptionResponse(channel, permissionCheckOnly));
+    }
+
+    private RestResponseListener<ActionResponse> createSubscriptionResponse(
+            RestChannel channel, boolean permissionCheckOnly) {
         return new RestResponseListener<>(channel) {
             @Override
-            public RestResponse buildResponse(MessageStatusResponse response) throws Exception {
+            public RestResponse buildResponse(ActionResponse response) throws Exception {
+                // The security plugin answered the permission check. Pass its body through
+                // unchanged so this endpoint is indistinguishable from any other in the cluster.
+                if (response instanceof StatusToXContentObject permissionCheck) {
+                    return new BytesRestResponse(
+                            permissionCheck.status(),
+                            permissionCheck.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
+                }
+
+                // No filter intercepted a check-mode request: security is disabled, so the answer
+                // is "allowed". Same field names, so a client cannot tell the two producers apart.
+                if (permissionCheckOnly) {
+                    return permissionGrantedResponse();
+                }
+
+                MessageStatusResponse subscriptionResponse = (MessageStatusResponse) response;
                 return new BytesRestResponse(
-                        response.getStatus(),
-                        response.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
+                        subscriptionResponse.getStatus(),
+                        subscriptionResponse.toXContent(
+                                XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
             }
         };
+    }
+
+    /** Builds the security-disabled fallback body, matching {@code PermissionCheckResponse}. */
+    private static RestResponse permissionGrantedResponse() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder
+                .startObject()
+                .field(Constants.KEY_ACCESS_ALLOWED, true)
+                .startArray(Constants.KEY_MISSING_PRIVILEGES)
+                .endArray()
+                .endObject();
+        return new BytesRestResponse(RestStatus.OK, builder);
     }
 }

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportIndexSubscriptionAction.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/transport/TransportIndexSubscriptionAction.java
@@ -51,6 +51,15 @@ public class TransportIndexSubscriptionAction
     @Override
     protected void doExecute(
             Task task, IndexSubscriptionRequest request, ActionListener<MessageStatusResponse> listener) {
+        // With the security plugin enabled this branch is unreachable in check mode: SecurityFilter
+        // answers with its own PermissionCheckResponse before the action executes. Reaching it means
+        // no filter intercepted -> security is disabled -> every caller may register.
+        if (request.isPermissionCheckOnly()) {
+            listener.onResponse(
+                    new MessageStatusResponse(Constants.S_200_PERMISSION_CHECK_ALLOWED, RestStatus.OK));
+            return;
+        }
+
         String accessToken = request.getToken();
         this.subscriptionService.register(
                 accessToken,

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -42,6 +42,8 @@ public class Constants {
     // success.
     public static final String S_200_PROMOTION_COMPLETED = "Promotion completed successfully.";
     public static final String S_201_ACCESS_TOKEN_RECEIVED = "Access token received successfully.";
+    public static final String S_200_PERMISSION_CHECK_ALLOWED =
+            "Permission check passed: security plugin disabled.";
     public static final String E_400_INVALID_REQUEST_BODY = "Invalid request body.";
     public static final String E_400_MISSING_FIELD = "Missing [%s] field.";
     public static final String E_400_INVALID_FIELD_FORMAT = "Invalid '%s' format.";
@@ -762,6 +764,10 @@ public class Constants {
     public static final String KEY_UPDATING = "updating";
     public static final String KEY_PAYLOAD = "payload";
     public static final String KEY_MESSAGE = "message";
+    // Owned by the security plugin: field names of
+    // org.opensearch.security.action.simulate.PermissionCheckResponse.
+    public static final String KEY_ACCESS_ALLOWED = "accessAllowed";
+    public static final String KEY_MISSING_PRIVILEGES = "missingPrivileges";
     public static final String KEY_STATUS = "status";
     public static final String KEY_INPUT = "input";
     public static final String KEY_YAML = "yaml";

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/action/IndexSubscriptionRequestTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/action/IndexSubscriptionRequestTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.action;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Assert;
+
+import java.io.IOException;
+
+public class IndexSubscriptionRequestTests extends OpenSearchTestCase {
+
+    // --- registration requests: unchanged behaviour ------------------------------
+
+    public void testRegistrationRequest_isNotPermissionCheckOnly() {
+        IndexSubscriptionRequest request = new IndexSubscriptionRequest("a-token");
+        Assert.assertFalse(request.isPermissionCheckOnly());
+        Assert.assertEquals("a-token", request.getToken());
+    }
+
+    public void testRegistrationRequest_validTokenPassesValidation() {
+        Assert.assertNull(new IndexSubscriptionRequest("a-token").validate());
+    }
+
+    public void testRegistrationRequest_nullTokenFailsValidation() {
+        ActionRequestValidationException e = new IndexSubscriptionRequest((String) null).validate();
+        Assert.assertNotNull(e);
+        Assert.assertTrue(e.getMessage().contains("Missing [access_token] field."));
+    }
+
+    public void testRegistrationRequest_blankTokenFailsValidation() {
+        ActionRequestValidationException e = new IndexSubscriptionRequest("   ").validate();
+        Assert.assertNotNull(e);
+        Assert.assertTrue(e.getMessage().contains("Missing [access_token] field."));
+    }
+
+    // --- permission-check requests ----------------------------------------------
+
+    public void testPermissionCheck_carriesNoTokenAndIsFlagged() {
+        IndexSubscriptionRequest request = IndexSubscriptionRequest.permissionCheck();
+        Assert.assertTrue(request.isPermissionCheckOnly());
+        Assert.assertNull(request.getToken());
+    }
+
+    /**
+     * Load-bearing: {@code TransportAction.execute} validates before running the {@code
+     * ActionFilters} chain, so a permission check that failed validation would be answered 400 and
+     * the security filter would never evaluate it.
+     */
+    public void testPermissionCheck_skipsTokenValidation() {
+        Assert.assertNull(IndexSubscriptionRequest.permissionCheck().validate());
+    }
+
+    // --- wire format -------------------------------------------------------------
+
+    public void testSerialization_registrationRoundTrip() throws IOException {
+        assertRoundTrip(new IndexSubscriptionRequest("a-token"), "a-token", false);
+    }
+
+    public void testSerialization_permissionCheckRoundTrip() throws IOException {
+        assertRoundTrip(IndexSubscriptionRequest.permissionCheck(), null, true);
+    }
+
+    public void testSerialization_nullTokenRoundTrip() throws IOException {
+        assertRoundTrip(new IndexSubscriptionRequest((String) null), null, false);
+    }
+
+    private void assertRoundTrip(
+            IndexSubscriptionRequest request, String expectedToken, boolean expectedCheckOnly)
+            throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                IndexSubscriptionRequest read = new IndexSubscriptionRequest(in);
+                Assert.assertEquals(expectedToken, read.getToken());
+                Assert.assertEquals(expectedCheckOnly, read.isPermissionCheckOnly());
+                Assert.assertEquals(0, in.available());
+            }
+        }
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/rest/service/RestPostSubscriptionActionTests.java
@@ -16,22 +16,56 @@
  */
 package com.wazuh.contentmanager.rest.service;
 
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionType;
+import org.opensearch.common.xcontent.StatusToXContentObject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestResponse;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.client.NoOpNodeClient;
+import org.opensearch.test.rest.FakeRestChannel;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import com.wazuh.contentmanager.action.IndexSubscriptionRequest;
+import com.wazuh.contentmanager.action.MessageStatusResponse;
 import com.wazuh.contentmanager.settings.PluginSettings;
+import com.wazuh.contentmanager.utils.Constants;
 
 public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
     private RestPostSubscriptionAction action;
+    private CapturingNodeClient client;
 
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
         this.action = new RestPostSubscriptionAction();
+        this.client = new CapturingNodeClient(getTestName());
     }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        this.client.close();
+        super.tearDown();
+    }
+
+    // --- route metadata ----------------------------------------------------------
 
     public void testRouteMethod() {
         Assert.assertEquals(1, this.action.routes().size());
@@ -44,5 +78,206 @@ public class RestPostSubscriptionActionTests extends OpenSearchTestCase {
 
     public void testName() {
         Assert.assertEquals("content_manager_subscription_post", this.action.getName());
+    }
+
+    // --- dispatch: which transport request is built -------------------------------
+
+    public void testDispatch_withoutParameter_parsesBodyAndRegisters() throws Exception {
+        dispatch(Map.of(), "{\"access_token\":\"a-token\"}", null);
+
+        IndexSubscriptionRequest dispatched = this.client.captured;
+        Assert.assertNotNull(dispatched);
+        Assert.assertFalse(dispatched.isPermissionCheckOnly());
+        Assert.assertEquals("a-token", dispatched.getToken());
+    }
+
+    public void testDispatch_parameterFalse_parsesBodyAndRegisters() throws Exception {
+        dispatch(Map.of("perform_permission_check", "false"), "{\"access_token\":\"a-token\"}", null);
+
+        IndexSubscriptionRequest dispatched = this.client.captured;
+        Assert.assertNotNull(dispatched);
+        Assert.assertFalse(dispatched.isPermissionCheckOnly());
+        Assert.assertEquals("a-token", dispatched.getToken());
+    }
+
+    /** No body is read in check mode: the request carries no content at all here. */
+    public void testDispatch_parameterTrue_readsNoBodyAndFlagsTheRequest() throws Exception {
+        dispatch(Map.of("perform_permission_check", "true"), null, null);
+
+        IndexSubscriptionRequest dispatched = this.client.captured;
+        Assert.assertNotNull(dispatched);
+        Assert.assertTrue(dispatched.isPermissionCheckOnly());
+        Assert.assertNull(dispatched.getToken());
+    }
+
+    /** An empty value means true, per the OpenSearch boolean-parameter contract. */
+    public void testDispatch_parameterEmptyValue_flagsTheRequest() throws Exception {
+        dispatch(Map.of("perform_permission_check", ""), null, null);
+
+        Assert.assertNotNull(this.client.captured);
+        Assert.assertTrue(this.client.captured.isPermissionCheckOnly());
+    }
+
+    /** A body sent in check mode is ignored rather than parsed. */
+    public void testDispatch_parameterTrueWithBody_ignoresTheBody() throws Exception {
+        dispatch(Map.of("perform_permission_check", "true"), "{\"access_token\":\"a-token\"}", null);
+
+        Assert.assertNotNull(this.client.captured);
+        Assert.assertTrue(this.client.captured.isPermissionCheckOnly());
+        Assert.assertNull(this.client.captured.getToken());
+    }
+
+    // --- response rendering ------------------------------------------------------
+
+    /**
+     * The regression this whole change is about: the security plugin answers with its own {@code
+     * PermissionCheckResponse}, which is not a {@link MessageStatusResponse}. A listener typed over
+     * the concrete class threw {@code ClassCastException} and produced a 500; the body must now be
+     * passed through unchanged.
+     */
+    public void testResponse_securityPluginAnswer_isPassedThroughUnchanged() throws Exception {
+        FakeRestChannel channel =
+                dispatch(
+                        Map.of("perform_permission_check", "true"),
+                        null,
+                        new PermissionCheckResponseDouble(
+                                false, Set.of("cluster:admin/content_manager/subscription/create")));
+
+        RestResponse response = channel.capturedResponse();
+        Assert.assertEquals(RestStatus.OK, response.status());
+        Assert.assertEquals(
+                "{\"accessAllowed\":false,"
+                        + "\"missingPrivileges\":[\"cluster:admin/content_manager/subscription/create\"]}",
+                response.content().utf8ToString());
+    }
+
+    public void testResponse_securityPluginAllows_isPassedThroughUnchanged() throws Exception {
+        FakeRestChannel channel =
+                dispatch(
+                        Map.of("perform_permission_check", "true"),
+                        null,
+                        new PermissionCheckResponseDouble(true, Set.of()));
+
+        RestResponse response = channel.capturedResponse();
+        Assert.assertEquals(RestStatus.OK, response.status());
+        Assert.assertEquals(
+                "{\"accessAllowed\":true,\"missingPrivileges\":[]}", response.content().utf8ToString());
+    }
+
+    /**
+     * Security disabled: no filter intercepts, so the transport action's own fallback comes back. The
+     * handler must still answer the native permission-check body.
+     */
+    public void testResponse_securityDisabledFallback_rendersAccessAllowed() throws Exception {
+        FakeRestChannel channel =
+                dispatch(
+                        Map.of("perform_permission_check", "true"),
+                        null,
+                        new MessageStatusResponse(Constants.S_200_PERMISSION_CHECK_ALLOWED, RestStatus.OK));
+
+        RestResponse response = channel.capturedResponse();
+        Assert.assertEquals(RestStatus.OK, response.status());
+        Assert.assertEquals(
+                "{\"accessAllowed\":true,\"missingPrivileges\":[]}", response.content().utf8ToString());
+    }
+
+    public void testResponse_registration_rendersMessageAndStatus() throws Exception {
+        FakeRestChannel channel =
+                dispatch(
+                        Map.of(),
+                        "{\"access_token\":\"a-token\"}",
+                        new MessageStatusResponse(Constants.S_201_ACCESS_TOKEN_RECEIVED, RestStatus.CREATED));
+
+        RestResponse response = channel.capturedResponse();
+        Assert.assertEquals(RestStatus.CREATED, response.status());
+        Assert.assertEquals(
+                "{\"message\":\"" + Constants.S_201_ACCESS_TOKEN_RECEIVED + "\",\"status\":201}",
+                response.content().utf8ToString());
+    }
+
+    // --- helpers -----------------------------------------------------------------
+
+    /**
+     * Runs the handler end to end.
+     *
+     * @param params query parameters
+     * @param body request body, or null for a bodyless request
+     * @param response what the transport layer answers, or null to answer nothing
+     * @return the channel the response was written to
+     */
+    private FakeRestChannel dispatch(Map<String, String> params, String body, ActionResponse response)
+            throws Exception {
+        this.client.response = response;
+
+        FakeRestRequest.Builder builder =
+                new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+                        .withMethod(RestRequest.Method.POST)
+                        .withPath(PluginSettings.SUBSCRIPTION_URI)
+                        .withParams(new java.util.HashMap<>(params));
+        if (body != null) {
+            builder.withContent(new BytesArray(body), MediaTypeRegistry.JSON);
+        }
+
+        RestRequest request = builder.build();
+        FakeRestChannel channel = new FakeRestChannel(request, true, 1);
+        this.action.handleRequest(request, channel, this.client);
+        return channel;
+    }
+
+    /** Captures the dispatched request and replies with a caller-supplied response. */
+    private static class CapturingNodeClient extends NoOpNodeClient {
+        private IndexSubscriptionRequest captured;
+        private ActionResponse response;
+
+        CapturingNodeClient(String testName) {
+            super(testName);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                ActionType<Response> action, Request request, ActionListener<Response> listener) {
+            this.captured = (IndexSubscriptionRequest) request;
+            if (this.response != null) {
+                listener.onResponse((Response) this.response);
+            }
+        }
+    }
+
+    /**
+     * Stand-in for {@code org.opensearch.security.action.simulate.PermissionCheckResponse}, which
+     * lives in the security plugin's classloader and cannot be referenced from here. It reproduces
+     * the two properties that matter: it is an {@link ActionResponse} but not a {@link
+     * MessageStatusResponse}, and it is a {@link StatusToXContentObject}.
+     */
+    private static class PermissionCheckResponseDouble extends ActionResponse
+            implements StatusToXContentObject {
+        private final boolean accessAllowed;
+        private final Set<String> missingPrivileges;
+
+        PermissionCheckResponseDouble(boolean accessAllowed, Set<String> missingPrivileges) {
+            this.accessAllowed = accessAllowed;
+            this.missingPrivileges = missingPrivileges;
+        }
+
+        @Override
+        public RestStatus status() {
+            return RestStatus.OK;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder
+                    .startObject()
+                    .field("accessAllowed", this.accessAllowed)
+                    .field("missingPrivileges", this.missingPrivileges)
+                    .endObject();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(this.accessAllowed);
+            out.writeStringCollection(this.missingPrivileges);
+        }
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportIndexSubscriptionActionTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/transport/TransportIndexSubscriptionActionTests.java
@@ -46,6 +46,30 @@ public class TransportIndexSubscriptionActionTests extends OpenSearchTestCase {
                         mock(TransportService.class), mock(ActionFilters.class), this.subscriptionService);
     }
 
+    /**
+     * Security-disabled fallback. With the security plugin enabled this branch is unreachable —
+     * SecurityFilter answers before the action runs — so reaching it means no filter intercepted and
+     * every caller may register. Either way the registration work must not happen.
+     */
+    @SuppressWarnings("unchecked")
+    public void testDoExecute_PermissionCheckOnly_shortCircuitsWithoutRegistering() {
+        IndexSubscriptionRequest request = IndexSubscriptionRequest.permissionCheck();
+        ActionListener<MessageStatusResponse> listener = mock(ActionListener.class);
+        this.action.doExecute(mock(Task.class), request, listener);
+
+        verify(this.subscriptionService, never()).register(any(), any(ActionListener.class));
+        verify(listener)
+                .onResponse(
+                        argThat(
+                                response -> {
+                                    Assert.assertEquals(RestStatus.OK, response.getStatus());
+                                    Assert.assertEquals(
+                                            Constants.S_200_PERMISSION_CHECK_ALLOWED, response.getMessage());
+                                    return true;
+                                }));
+        verify(listener, never()).onFailure(any());
+    }
+
     @SuppressWarnings("unchecked")
     public void testDoExecute_Created() {
         doAnswer(


### PR DESCRIPTION
## Description

CTI registration is an OAuth device flow, and authorization is only evaluated at the very
end of it: the user approves in the CTI console — which already **creates the environment
on the CTI side** — and only then does the indexer get to answer `403`. That leaves an
orphaned environment, and gives the dashboard no way to know in advance whether the
current user may register.

This PR lets a caller ask **"am I allowed to register a CTI subscription?"** *before*
starting the flow, via `perform_permission_check=true` on
`POST /_plugins/_content_manager/subscription`.

Closes #6224

## Proposed Changes

**We do not implement the check.** `perform_permission_check` is a native OpenSearch
parameter: the security plugin evaluates the action and answers with its own
`PermissionCheckResponse` *instead of executing it*, so there are no side effects. Our
only job was to stop getting in the way. Three things blocked it:

| Obstacle | Fix |
|---|---|
| The handler always parsed the body ⇒ `400 request body is required` | No body is read in check mode |
| `validate()` rejected the missing token, and validation runs **before** the action filters ⇒ `400` before the filter ever saw it | `validate()` skips the token check in check mode |
| The listener was typed on `MessageStatusResponse` ⇒ `ClassCastException` ⇒ **`500`** | Listener typed on `ActionResponse`, discriminating with `instanceof StatusToXContentObject` |

### The contract

```http
POST /_plugins/_content_manager/subscription?perform_permission_check=true
```

No body, no access token, no side effects, idempotent. **Always answers `200`** — permitted
and denied differ only in the body:

```json
{ "accessAllowed": true,  "missingPrivileges": [] }
{ "accessAllowed": false, "missingPrivileges": ["cluster:admin/content_manager/subscription/create"] }
```

**Clients must branch on `accessAllowed`, not on the HTTP status.**

Without the parameter, behaviour is unchanged.

### Results and Evidence

Before this PR the endpoint could not answer at all: `400` without a body, and **`500
class_cast_exception`** with one. That `500` is what proved the security filter *was*
working and our listener was the thing breaking.

**1. Permitted** — as `wazuh-admin`:

```
POST _plugins/_content_manager/subscription?perform_permission_check=true
```
Expected `200` → `{"accessAllowed": true, "missingPrivileges": []}`

<details><summary>Details</summary>
<p>


<img width="1896" height="187" alt="image" src="https://github.com/user-attachments/assets/95abdfde-7688-4a6f-8a1d-b2a2710be2d4" />



</p>
</details> 



**2. Denied** — as `wazuh-readonly`, same request.

Expected **`200` (not `403`)** → `{"accessAllowed": false, "missingPrivileges": ["cluster:admin/content_manager/subscription/create"]}`

<details><summary>Details</summary>
<p>

<img width="1899" height="449" alt="image" src="https://github.com/user-attachments/assets/058d74f0-c3e4-49a0-95c3-6087ca92bbe6" />

</p>
</details> 

**3. No side effects** — `GET _plugins/_content_manager/subscription` before and after.

Expected `is_registered` stays `false`.

<details><summary>Details</summary>
<p>

<img width="1899" height="275" alt="image" src="https://github.com/user-attachments/assets/05d7e54b-8c9c-4430-9e6d-21a5088f6d3f" />

</p>
</details> 


**4. Backwards compatible** — as `wazuh-readonly`, without the parameter:

```
POST _plugins/_content_manager/subscription
{ "access_token": "dummy" }
```
Expected `403 security_exception`, same as before this PR.


<details><summary>Details</summary>
<p>

<img width="1899" height="449" alt="image" src="https://github.com/user-attachments/assets/4be1d26d-22b3-410b-895b-8bf66b6405b4" />

</p>
</details> 


Also verified: the security-disabled fallback (`plugins.security.disabled=true`) returns
the same `accessAllowed: true` body, and the full 16-probe before/after set is green.

### Artifacts Affected

`wazuh-indexer-content-manager` plugin only. No packaging, no config files, no changes to
`roles.wazuh.yml` or `action_groups.wazuh.yml`.

### Configuration Changes

None. One new optional query parameter (`perform_permission_check`, boolean, default
`false`), owned by the OpenSearch security plugin. Fully backwards compatible.

### Documentation Updates

- `plugins/content-manager/openapi.yml` — parameter, `200` response and
  `PermissionCheckResponse` schema, with permitted/denied examples.
- Javadoc on `RestPostSubscriptionAction`.

### Tests Introduced

**19 new unit tests.** Full suite: **745 tests, 0 failures.**

| Class | New | Scope |
|---|---|---|
| `IndexSubscriptionRequestTests` *(new)* | 9 | Both request shapes, validation skip, wire round trip |
| `RestPostSubscriptionActionTests` | +9 | Parameter parsing and all three response paths |
| `TransportIndexSubscriptionActionTests` | +1 | Security-disabled fallback never calls `register` |

`PermissionCheckResponse` can't be referenced from a test — it lives in the security
plugin's classloader, which is exactly what the `class_cast_exception` reports — so the
tests use a double with the same two relevant properties.

### Known limitation

`GET` and `DELETE /subscription` still return `500` with this parameter, for the same
listener-typing reason. **Pre-existing, not a regression.** Left out because it needs its
own decision: what a permission check means on `GET` (where `wazuh_readonly` *does* hold
the permission), and whether a shared listener helper beats patching routes one by one.
Worth a follow-up issue.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] CHANGELOG entry added, or `no-changelog` label applied
- [ ] Follow-up issue opened for the `GET`/`DELETE` limitation
