### PR TITLE
Force TLS certificate validation when communicating with CTI

### DIFF
--- a/plugins/content-manager/imposter/README.md
+++ b/plugins/content-manager/imposter/README.md
@@ -319,6 +319,77 @@ curl -k -X GET https://localhost:8443/api/v1/instances/me \
 }
 ```
 
+## Testing Against a Real wazuh-indexer Node
+
+The examples above call Imposter directly with `curl`, which is enough to check the mock
+responses themselves but doesn't exercise the actual Content Manager plugin. To verify the
+plugin's CTI clients end-to-end, point a real `wazuh-indexer` node (running anywhere — bare
+metal, a container, a VM) at Imposter instead of the real CTI endpoint.
+
+### 1. Start Imposter
+
+```bash
+./imposter.sh up
+```
+
+### 2. Trust Imposter's certificate on the indexer's JVM
+
+Imposter serves HTTPS with a self-signed certificate. The Content Manager's CTI clients validate
+certificates against the JVM truststore, so an unmodified indexer will reject Imposter's
+certificate with something like `unable to find valid certification path to requested target` /
+`PKIXCertPathValidatorException`. To let the indexer trust Imposter for local testing, import
+`images/nginx/certs/cert.pem` into the truststore of **the JVM that runs `wazuh-indexer`** (not
+necessarily the machine you ran `./imposter.sh up` from, if the indexer runs elsewhere):
+
+```bash
+keytool -importcert -trustcacerts -noprompt \
+  -alias imposter -file images/nginx/certs/cert.pem \
+  -keystore <path-to-that-jdk>/lib/security/cacerts -storepass changeit
+```
+
+The indexer bundles its own JDK; find its `cacerts` file with something like
+`find <wazuh-indexer-install-dir> -iname cacerts` on the host/container/VM where the indexer
+actually runs. The default `cacerts` password is `changeit` unless it has been changed.
+
+### 3. Confirm the indexer can reach Imposter over the network
+
+If the indexer and Imposter run on the same host, `https://localhost:8443` (or the container's
+host-network address) is reachable directly. If the indexer runs elsewhere (a separate VM,
+container, or remote host), confirm connectivity first from that environment, e.g.:
+
+```bash
+curl -k https://<host-running-imposter>:8443/system/status
+```
+
+and adjust Docker/VM network settings (port publishing, firewall rules) until this succeeds
+before moving on — TLS trust and sync configuration won't matter if the endpoint isn't reachable
+at all.
+
+### 4. Point the indexer at Imposter
+
+Setting `plugins.content_manager.cti.api` alone is not enough: the actual per-consumer resource
+URLs used to fetch content are separate settings —
+`plugins.content_manager.catalog.ruleset`, `plugins.content_manager.catalog.iocs`, and
+`plugins.content_manager.catalog.vulnerabilities`. Redirect all four settings to Imposter,
+**changing only the scheme/host/port; keep the rest of each URL (context and consumer path
+segments) exactly as it is configured today** — Imposter matches context/consumer as path
+parameters, so it accepts whatever value you already use, no need to know it in advance:
+
+```yaml
+plugins.content_manager.cti.api: "https://<host-running-imposter>:8443/api/v1"
+plugins.content_manager.catalog.ruleset: "https://<host-running-imposter>:8443/api/v1/catalog/contexts/<same-context-as-before>/consumers/<same-consumer-as-before>"
+plugins.content_manager.catalog.iocs: "https://<host-running-imposter>:8443/api/v1/catalog/contexts/<same-context-as-before>/consumers/<same-consumer-as-before>"
+plugins.content_manager.catalog.vulnerabilities: "https://<host-running-imposter>:8443/api/v1/catalog/contexts/<same-context-as-before>/consumers/<same-consumer-as-before>"
+```
+
+Restart the node after changing these.
+
+> [!NOTE]
+> This mock is not actively maintained against the current plugin behavior, and the settings
+> above are not sufficient on their own for a full end-to-end sync — some requests the plugin
+> makes may not have a matching mock response configured. Treat this as a starting point for
+> checking TLS/connectivity, not a guarantee that a full sync will complete against it.
+
 ## Stopping the Server
 
 To stop the server, use the helper script:

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/client/ApiClient.java
@@ -26,19 +26,15 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.ssl.TLS;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOReactorConfig;
-import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.net.ssl.SSLContext;
-
 import java.net.URI;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -81,24 +77,12 @@ public class ApiClient implements AutoCloseable {
         this(new RegularUrlResolver());
     }
 
-    /**
-     * Builds and starts the asynchronous HTTP client.
-     *
-     * @throws RuntimeException if the SSL context cannot be initialized.
-     */
+    /** Builds and starts the asynchronous HTTP client. */
     private void buildClient() {
         IOReactorConfig ioReactorConfig =
                 IOReactorConfig.custom()
                         .setSoTimeout(Timeout.ofSeconds(PluginSettings.getInstance().getClientTimeout()))
                         .build();
-
-        SSLContext sslContext;
-        try {
-            sslContext =
-                    SSLContextBuilder.create().loadTrustMaterial(null, (chains, authType) -> true).build();
-        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
-            throw new RuntimeException("Failed to initialize HttpClient", e);
-        }
 
         List<Header> defaultHeaders =
                 List.of(
@@ -115,7 +99,14 @@ public class ApiClient implements AutoCloseable {
                         .setConnectionManager(
                                 PoolingAsyncClientConnectionManagerBuilder.create()
                                         .setTlsStrategy(
-                                                ClientTlsStrategyBuilder.create().setSslContext(sslContext).build())
+                                                ClientTlsStrategyBuilder.create()
+                                                        // JDK truststore + DefaultHostnameVerifier. Honours
+                                                        // javax.net.ssl.trustStore* so an operator behind a
+                                                        // TLS-terminating proxy adds a CA instead of disabling
+                                                        // checks.
+                                                        .setSslContext(SSLContexts.createSystemDefault())
+                                                        .setTlsVersions(TLS.V_1_2, TLS.V_1_3)
+                                                        .build())
                                         .build())
                         .build();
 

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/console/client/ApiClient.java
@@ -25,19 +25,15 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.ssl.TLS;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.IOReactorConfig;
-import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Timeout;
 import org.opensearch.core.action.ActionListener;
 
-import javax.net.ssl.SSLContext;
-
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
@@ -77,14 +73,6 @@ public class ApiClient {
         IOReactorConfig ioReactorConfig =
                 IOReactorConfig.custom().setSoTimeout(Timeout.ofSeconds(this.TIMEOUT)).build();
 
-        SSLContext sslContext;
-        try {
-            sslContext =
-                    SSLContextBuilder.create().loadTrustMaterial(null, (chains, authType) -> true).build();
-        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
-            throw new RuntimeException("Failed to initialize HttpClient", e);
-        }
-
         List<Header> defaultHeaders =
                 List.of(
                         new BasicHeader(HttpHeaders.USER_AGENT, PluginSettings.getInstance().getUserAgent()));
@@ -96,7 +84,14 @@ public class ApiClient {
                         .setConnectionManager(
                                 PoolingAsyncClientConnectionManagerBuilder.create()
                                         .setTlsStrategy(
-                                                ClientTlsStrategyBuilder.create().setSslContext(sslContext).build())
+                                                ClientTlsStrategyBuilder.create()
+                                                        // JDK truststore + DefaultHostnameVerifier. Honours
+                                                        // javax.net.ssl.trustStore* so an operator behind a
+                                                        // TLS-terminating proxy adds a CA instead of disabling
+                                                        // checks.
+                                                        .setSslContext(SSLContexts.createSystemDefault())
+                                                        .setTlsVersions(TLS.V_1_2, TLS.V_1_3)
+                                                        .build())
                                         .build())
                         .build();
 


### PR DESCRIPTION
## Description

The Content Manager plugin's CTI HTTP clients (`com.wazuh.contentmanager.cti.catalog.client.ApiClient` and `com.wazuh.contentmanager.cti.console.client.ApiClient`) built their `SSLContext` with a null `KeyStore` and a `TrustStrategy` that unconditionally returned `true`, disabling TLS certificate validation entirely (CWE-295). This affected the control plane of the whole CTI content sync (catalog contexts, consumer metadata, change offsets, snapshot resource URLs/hashes) and the console token exchange, allowing a network attacker with a MITM position to serve arbitrary content or capture the CTI access token.

Closes wazuh/internal-devel-requests#6044

## Proposed Changes

- Removed the trust-all `TrustStrategy` from both `ApiClient.buildClient()` implementations (catalog and console clients).
- Both clients now build their TLS strategy via `SSLContexts.createSystemDefault()` restricted to `TLS.V_1_2`/`TLS.V_1_3`, honoring the JDK/system truststore and `javax.net.ssl.trustStore*`, and using `DefaultHostnameVerifier` — the same validation behavior `SnapshotClient` already used for the bulk snapshot download.
- No new configuration flag was introduced to re-enable trust-all; the fix is code-only, so an operator cannot disable certificate validation.

### Results and Evidence

- **Static verification:** disassembled the compiled classes (`javap -c -p`) and confirmed no `TrustStrategy`/`isTrusted` lambda remains in `buildClient()` for either client.
- **Unit tests:** existing suite passes unchanged (`ApiClientRetryTests`, `TokenExchangeServiceTests`, `AuthServiceTests`, `PlansServiceTests`, `CtiConsoleTests`), confirming no test relied on the trust-all behavior.
- **Dynamic verification:** deployed the patched plugin to a real `wazuh-indexer` node and pointed `plugins.content_manager.cti.api` at a local self-signed HTTPS stub server. Triggering a sync (`POST /_plugins/_content_manager/update`) now fails with a certificate validation error (untrusted self-signed cert rejected), whereas before the fix the trust-all client would have accepted it silently. Reverting `plugins.content_manager.cti.api` to the real CTI endpoint and re-triggering the sync confirmed normal operation is unaffected by the fix.

 Local self-signed HTTPS stub server:
<img width="1696" height="75" alt="Captura desde 2026-09-08 09-21-54" src="https://github.com/user-attachments/assets/4971cbe1-0c01-4a89-9601-e76dc3ea1d12" />

Real CTI server:
<img width="1766" height="38" alt="Captura desde 2026-09-08 09-46-54" src="https://github.com/user-attachments/assets/4325d717-df43-4ab0-a135-2e75cd1eabfa" />


### Artifacts Affected

- `wazuh-indexer-content-manager` plugin jar — no other packages or executables affected.

### Configuration Changes

- None. No new settings were added or defaults changed.

### Documentation Updates

- None required.

### Tests Introduced

- None added. The fix is covered by the existing `ApiClientRetryTests`/console service test suites, which continue to pass; no new test was added to avoid introducing a test that spins up a local TLS server in the automated suite.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
