### PR TITLE
Fix AMI error logs

### DIFF
--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoader.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchTimeoutException;
-import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -39,6 +38,7 @@ import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.engine.service.EngineService;
 import com.wazuh.contentmanager.utils.Constants;
+import com.wazuh.contentmanager.utils.TransientFailures;
 
 /**
  * Loads the shared, cluster-persisted content spaces into the <em>local</em> node's Engine, keyed
@@ -80,6 +80,16 @@ public class EngineContentLoader {
     private static final TimeValue RELOAD_TIMEOUT = TimeValue.timeValueMinutes(10);
 
     /**
+     * How long the content indices may stay unable to serve reads before the deferral is escalated
+     * from a debug line to a single warning. Startup deferrals clear within seconds; anything past
+     * this is no longer a boot condition, and the node is running with no content in its Engine.
+     */
+    private static final TimeValue NOT_READY_GRACE = TimeValue.timeValueMinutes(5);
+
+    /** {@link #deferringSince} value meaning "the last run got its reads served". */
+    private static final long NOT_DEFERRING = Long.MIN_VALUE;
+
+    /**
      * The shared, cluster-persisted spaces whose Engine representation must be consistent across the
      * cluster. Each node loads all of them into its own Engine.
      */
@@ -97,6 +107,17 @@ public class EngineContentLoader {
      * next trigger.
      */
     private final Map<String, String> loadedHashes = new ConcurrentHashMap<>();
+
+    /**
+     * Relative time of the first deferral of the current not-ready streak, or {@link #NOT_DEFERRING}
+     * when the last run got its reads served. A dedicated sentinel rather than {@code 0}, which is a
+     * legitimate reading of the relative clock early in a node's life. Only ever touched from inside
+     * a run, and runs are single-flighted, so no synchronization beyond visibility is needed.
+     */
+    private volatile long deferringSince = NOT_DEFERRING;
+
+    /** Whether the current not-ready streak has already been escalated to a warning. */
+    private volatile boolean deferralWarned;
 
     /** Guards {@link #current} and each run's waiter list and completion flag. */
     private final Object mutex = new Object();
@@ -247,17 +268,22 @@ public class EngineContentLoader {
      * others from loading. Package-private so tests can drive the chain directly.
      *
      * <p>A node that cannot read the content yet is the one exception: every space reads its hash
-     * from the same {@link Constants#INDEX_POLICIES} index, so a missing index or a cluster block
-     * (usually {@code state not recovered / initialized}) is a precondition of the whole run rather
-     * than a per-space failure. Both are normal while a node starts up and both clear on their own,
-     * so the run ends after a single debug line instead of logging the same error once per tracked
-     * space on every cluster-state update. The next cluster-state event retries.
+     * from the same {@link Constants#INDEX_POLICIES} index, so any failure {@link
+     * TransientFailures#isTransientReadFailure classified as a startup condition} — a missing index,
+     * a cluster block ({@code state not recovered / initialized}), or shards that are not allocated
+     * yet ({@code all shards failed}) — is a precondition of the whole run rather than a per-space
+     * failure. They are all normal while a node starts up and all clear on their own, so the run ends
+     * after a single debug line instead of logging the same error once per tracked space on every
+     * cluster-state update. The next cluster-state event retries.
      *
      * @param index index into {@link #TRACKED_SPACES} of the space to reload next.
      * @param onComplete invoked once, after the last space finishes (successfully or not).
      */
     void reloadFrom(int index, Runnable onComplete) {
         if (index >= TRACKED_SPACES.size()) {
+            // Reaching the end means no space deferred, so the indices are serving reads again.
+            this.deferringSince = NOT_DEFERRING;
+            this.deferralWarned = false;
             onComplete.run();
             return;
         }
@@ -267,14 +293,14 @@ public class EngineContentLoader {
                         v -> this.reloadFrom(index + 1, onComplete),
                         e -> {
                             if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
-                                log.debug(
-                                        Constants.D_LOG_ENGINE_POLICIES_INDEX_NOT_READY, Constants.INDEX_POLICIES);
-                                onComplete.run();
+                                this.deferRun(
+                                        Constants.D_LOG_ENGINE_POLICIES_INDEX_NOT_READY,
+                                        Constants.INDEX_POLICIES,
+                                        onComplete);
                                 return;
                             }
-                            if (ExceptionsHelper.unwrap(e, ClusterBlockException.class) != null) {
-                                log.debug(Constants.D_LOG_ENGINE_CLUSTER_NOT_READY, e.getMessage());
-                                onComplete.run();
+                            if (TransientFailures.isTransientReadFailure(e)) {
+                                this.deferRun(Constants.D_LOG_ENGINE_CLUSTER_NOT_READY, e.getMessage(), onComplete);
                                 return;
                             }
                             log.error(Constants.E_LOG_ENGINE_SPACE_LOAD_FAILED, space, e.getMessage());
@@ -329,6 +355,37 @@ public class EngineContentLoader {
                                             listener::onFailure));
                         },
                         listener::onFailure));
+    }
+
+    /**
+     * Ends the run because the content indices cannot serve reads yet, logging the reason.
+     *
+     * <p>Every tracked space reads from the same {@link Constants#INDEX_POLICIES} index, so the first
+     * such failure decides the whole run: the remaining spaces would fail identically, and the
+     * cluster-state listener retries the run on the next update. This is what keeps a clean boot from
+     * logging one error per tracked space per cluster-state update (issue #38793).
+     *
+     * <p>Because these deferrals are silent, a condition that never clears would otherwise leave the
+     * node running with no content in its Engine and nothing in the log to say so. The first deferral
+     * of a streak starts a clock, and once the streak outlives {@link #NOT_READY_GRACE} it is
+     * escalated to a single warning; the streak resets as soon as a run gets its reads served.
+     *
+     * @param debugMessage the parameterized debug message describing the condition.
+     * @param detail the message's single argument (an index name or a failure message).
+     * @param onComplete the run's completion callback, invoked before returning.
+     */
+    private void deferRun(String debugMessage, String detail, Runnable onComplete) {
+        long now = this.threadPool.relativeTimeInMillis();
+        if (this.deferringSince == NOT_DEFERRING) {
+            this.deferringSince = now;
+        }
+        if (!this.deferralWarned && now - this.deferringSince >= NOT_READY_GRACE.millis()) {
+            this.deferralWarned = true;
+            log.warn(Constants.W_LOG_ENGINE_CONTENT_LOAD_STILL_DEFERRED, NOT_READY_GRACE, detail);
+        } else {
+            log.debug(debugMessage, detail);
+        }
+        onComplete.run();
     }
 
     /**

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/cti/catalog/service/SpaceService.java
@@ -23,27 +23,20 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.DocWriteRequest;
-import org.opensearch.action.NoShardAvailableActionException;
-import org.opensearch.action.UnavailableShardsException;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
-import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
@@ -65,6 +58,7 @@ import com.wazuh.contentmanager.cti.catalog.model.Resource;
 import com.wazuh.contentmanager.cti.catalog.model.Space;
 import com.wazuh.contentmanager.settings.PluginSettings;
 import com.wazuh.contentmanager.utils.Constants;
+import com.wazuh.contentmanager.utils.TransientFailures;
 
 /** Service for retrieving resource information based on their Space. */
 public class SpaceService {
@@ -981,7 +975,7 @@ public class SpaceService {
                             // allocated are expected pre-initialization states, not operational
                             // errors: every node reads policies from startup onwards. Callers still
                             // get the failure and decide.
-                            if (isTransientReadFailure(e)) {
+                            if (TransientFailures.isTransientReadFailure(e)) {
                                 log.debug(Constants.D_LOG_POLICY_INDEX_NOT_READY, space, e.getMessage());
                             } else {
                                 log.error(Constants.E_LOG_GET_POLICY_FAILED, space, e.getMessage());
@@ -989,40 +983,6 @@ public class SpaceService {
                             listener.onFailure(
                                     new IOException("Failed to retrieve policy: " + e.getMessage(), e));
                         }));
-    }
-
-    /**
-     * Classifies a read failure as an expected, self-healing startup condition rather than a real
-     * error.
-     *
-     * <p>During startup (especially on a multi-node cluster) the policies index shards may not be
-     * allocated yet: the index is briefly absent ({@link IndexNotFoundException}), the cluster state
-     * is not recovered ({@link ClusterBlockException}), or a search reaches the coordinating node
-     * before any shard copy is active. The last case surfaces as a {@link
-     * SearchPhaseExecutionException} ("all shards failed") whose shard-level cause is a {@link
-     * NoShardAvailableActionException} or {@link UnavailableShardsException}.
-     *
-     * <p>Only these specific cases are transient. A generic {@link SearchPhaseExecutionException} — a
-     * malformed query, an aggregation error — is a real failure and must not be swallowed, since that
-     * class covers <em>all</em> search failures. The single exception is one whose status is {@code
-     * 503 SERVICE_UNAVAILABLE}: that is "all shards failed" reported without a shard-level cause
-     * attached (empty {@code shardFailures}), still an availability problem and not a query problem.
-     *
-     * @param e the failure to classify.
-     * @return {@code true} if the failure is an expected startup condition that will self-heal once
-     *     the cluster finishes recovering.
-     */
-    private static boolean isTransientReadFailure(Exception e) {
-        if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null
-                || ExceptionsHelper.unwrap(e, ClusterBlockException.class) != null
-                || ExceptionsHelper.unwrap(e, NoShardAvailableActionException.class) != null
-                || ExceptionsHelper.unwrap(e, UnavailableShardsException.class) != null) {
-            return true;
-        }
-        SearchPhaseExecutionException searchFailure =
-                (SearchPhaseExecutionException)
-                        ExceptionsHelper.unwrap(e, SearchPhaseExecutionException.class);
-        return searchFailure != null && searchFailure.status() == RestStatus.SERVICE_UNAVAILABLE;
     }
 
     /**
@@ -1092,7 +1052,7 @@ public class SpaceService {
                             this.calculateAndUpdate(List.of(space), listener);
                         },
                         e -> {
-                            if (!isTransientReadFailure(e)) {
+                            if (!TransientFailures.isTransientReadFailure(e)) {
                                 log.warn(Constants.W_LOG_SPACE_HASH_CHECK_FAILED, space, e.getMessage());
                             }
                             listener.onFailure(e);

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/Constants.java
@@ -312,6 +312,10 @@ public class Constants {
             "Index [{}] does not exist yet; deferring Engine content load until it is created.";
     public static final String D_LOG_ENGINE_CLUSTER_NOT_READY =
             "Cluster cannot serve content reads yet ({}); deferring Engine content load.";
+    public static final String W_LOG_ENGINE_CONTENT_LOAD_STILL_DEFERRED =
+            "Engine content load still deferred after [{}] of retries; the content indices are not "
+                    + "serving reads ({}). The shared content spaces stay unloaded on this node until "
+                    + "this clears.";
     public static final String W_LOG_ENGINE_RELOAD_TIMED_OUT =
             "Engine content reload did not complete within [{}]; releasing the in-flight guard.";
     public static final String D_LOG_ENGINE_SPACE_NO_POLICY =

--- a/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/TransientFailures.java
+++ b/plugins/content-manager/src/main/java/com/wazuh/contentmanager/utils/TransientFailures.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.utils;
+
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.NoShardAvailableActionException;
+import org.opensearch.action.UnavailableShardsException;
+import org.opensearch.action.search.SearchPhaseExecutionException;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.IndexNotFoundException;
+
+/**
+ * Classifies index-read failures that are expected while a node starts up.
+ *
+ * <p>Shared by every startup-sensitive read path so they agree on what counts as noise: the reader
+ * that hits the condition first (e.g. {@code SpaceService.getPolicy}) and the caller that decides
+ * what to do about it (e.g. {@code EngineContentLoader}) must not classify the same failure
+ * differently, or one of them logs an ERROR for a condition the other already knows is transient.
+ */
+public final class TransientFailures {
+
+    private TransientFailures() {}
+
+    /**
+     * Classifies a read failure as an expected, self-healing startup condition rather than a real
+     * error.
+     *
+     * <p>During startup (especially on a multi-node cluster) the index shards may not be allocated
+     * yet: the index is briefly absent ({@link IndexNotFoundException}), the cluster state is not
+     * recovered ({@link ClusterBlockException}), or a search reaches the coordinating node before any
+     * shard copy is active. The last case surfaces as a {@link SearchPhaseExecutionException} ("all
+     * shards failed") whose shard-level cause is a {@link NoShardAvailableActionException} or {@link
+     * UnavailableShardsException}.
+     *
+     * <p>Only these specific cases are transient. A generic {@link SearchPhaseExecutionException} — a
+     * malformed query, an aggregation error — is a real failure and must not be swallowed, since that
+     * class covers <em>all</em> search failures. The single exception is one whose status is {@code
+     * 503 SERVICE_UNAVAILABLE}: that is "all shards failed" reported without a shard-level cause
+     * attached (empty {@code shardFailures}), still an availability problem and not a query problem.
+     *
+     * <p>The whole cause chain is inspected, so a failure already wrapped by an intermediate reader
+     * (as {@code SpaceService.getPolicy} wraps it in an {@link java.io.IOException}) is still
+     * classified on its original cause.
+     *
+     * @param e the failure to classify.
+     * @return {@code true} if the failure is an expected startup condition that will self-heal once
+     *     the cluster finishes recovering.
+     */
+    public static boolean isTransientReadFailure(Exception e) {
+        if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null
+                || ExceptionsHelper.unwrap(e, ClusterBlockException.class) != null
+                || ExceptionsHelper.unwrap(e, NoShardAvailableActionException.class) != null
+                || ExceptionsHelper.unwrap(e, UnavailableShardsException.class) != null) {
+            return true;
+        }
+        SearchPhaseExecutionException searchFailure =
+                (SearchPhaseExecutionException)
+                        ExceptionsHelper.unwrap(e, SearchPhaseExecutionException.class);
+        return searchFailure != null && searchFailure.status() == RestStatus.SERVICE_UNAVAILABLE;
+    }
+}

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/EngineContentLoaderTests.java
@@ -19,7 +19,17 @@ package com.wazuh.contentmanager.cti.catalog.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.opensearch.action.search.SearchPhaseExecutionException;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.common.logging.Loggers;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -30,8 +40,11 @@ import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.wazuh.contentmanager.engine.service.EngineService;
@@ -382,6 +395,87 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
     }
 
     /**
+     * Same for shards that are not allocated yet: the search reaches the coordinating node before any
+     * shard copy is active and fails with {@code all shards failed}. This is the condition seen on a
+     * clean boot (issue #38793) — it used to be logged as an ERROR once per tracked space on every
+     * cluster-state update, because only the two conditions above were recognised as startup noise.
+     */
+    public void testAllShardsFailedEndsTheRunQuietly() {
+        this.stubPolicyFailure(
+                new SearchPhaseExecutionException(
+                        "query", "all shards failed", ShardSearchFailure.EMPTY_ARRAY));
+        this.assertRunDeferredThenRecovers();
+    }
+
+    /**
+     * A genuine search failure — a bad query, reported as 400 — is still a per-space error: it is
+     * logged and the run carries on to the remaining spaces rather than being treated as a
+     * not-ready-yet precondition.
+     */
+    public void testRealSearchFailureIsPerSpaceAndDoesNotEndTheRun() {
+        this.stubPolicyFailure(
+                new SearchPhaseExecutionException(
+                        "query",
+                        "parse error",
+                        new IllegalArgumentException("bad query"),
+                        ShardSearchFailure.EMPTY_ARRAY));
+
+        AtomicReference<Boolean> completed = new AtomicReference<>();
+        this.loader.reloadIfChanged(
+                ActionListener.wrap(v -> completed.set(true), e -> completed.set(false)));
+
+        assertEquals(Boolean.TRUE, completed.get());
+        // Every tracked space was attempted, unlike a startup condition which stops after the first.
+        verify(this.spaceService, times(3)).getPolicy(anyString(), any());
+        verify(this.engine, never()).promoteAsync(any(), any());
+    }
+
+    /**
+     * A not-ready condition that never clears is escalated from debug to a single warning. Silencing
+     * the startup burst must not also silence a node whose Engine never receives any content — that
+     * is a functional outage (no findings in the shared spaces), not boot noise.
+     */
+    public void testPersistentNotReadyIsEscalatedToASingleWarning() throws Exception {
+        AtomicLong clock = new AtomicLong(0L);
+        when(this.threadPool.relativeTimeInMillis()).thenAnswer(inv -> clock.get());
+        this.stubPolicyFailure(
+                new SearchPhaseExecutionException(
+                        "query", "all shards failed", ShardSearchFailure.EMPTY_ARRAY));
+
+        try (CapturingAppender appender = CapturingAppender.attach(EngineContentLoader.class)) {
+            // Inside the grace period every trigger stays at debug, however many arrive.
+            this.loader.reloadIfChanged();
+            clock.set(TimeValue.timeValueMinutes(4).millis());
+            this.loader.reloadIfChanged();
+            assertEquals(
+                    "no warning while the condition may still be a boot state",
+                    0,
+                    appender.count(Level.WARN));
+
+            // Past it, exactly one warning — the escalation must not become a new log flood.
+            clock.set(TimeValue.timeValueMinutes(6).millis());
+            this.loader.reloadIfChanged();
+            this.loader.reloadIfChanged();
+            assertEquals("the escalation is logged once per streak", 1, appender.count(Level.WARN));
+
+            // A run whose reads are served clears the streak, so a later outage warns again.
+            this.stubPolicy(STANDARD, null);
+            this.stubPolicy(TEST, null);
+            this.stubPolicy(CUSTOM, null);
+            this.loader.reloadIfChanged();
+
+            this.stubPolicyFailure(
+                    new SearchPhaseExecutionException(
+                            "query", "all shards failed", ShardSearchFailure.EMPTY_ARRAY));
+            this.loader.reloadIfChanged();
+            assertEquals("a fresh streak starts at debug again", 1, appender.count(Level.WARN));
+            clock.set(TimeValue.timeValueMinutes(12).millis());
+            this.loader.reloadIfChanged();
+            assertEquals("the new streak escalates on its own clock", 2, appender.count(Level.WARN));
+        }
+    }
+
+    /**
      * Stubs every space's policy read to fail with {@code cause}, wrapped as {@code getPolicy} does.
      */
     private void stubPolicyFailure(Exception cause) {
@@ -433,5 +527,47 @@ public class EngineContentLoaderTests extends OpenSearchTestCase {
         AtomicReference<Exception> secondFailure = new AtomicReference<>();
         nullEngineLoader.reloadIfChanged(ActionListener.wrap(v -> {}, secondFailure::set));
         assertNotNull(secondFailure.get());
+    }
+
+    /**
+     * Collects the events a logger emits so a test can assert on the level a message was logged at.
+     * {@code MockLogAppender} from the test framework is not usable here: it rewrites expected logger
+     * names with an {@code org.opensearch.} prefix, so it cannot match this plugin's loggers.
+     */
+    private static final class CapturingAppender extends AbstractAppender implements AutoCloseable {
+
+        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+        private final Logger logger;
+
+        private CapturingAppender(Logger logger) {
+            super("capturing-" + logger.getName(), null, null, true, Property.EMPTY_ARRAY);
+            this.logger = logger;
+        }
+
+        /**
+         * Attaches a new appender to {@code clazz}'s logger. Close it (try-with-resources) to detach:
+         * Log4j configuration is global to the JVM, so a leaked appender would follow later tests.
+         */
+        static CapturingAppender attach(Class<?> clazz) {
+            CapturingAppender appender = new CapturingAppender(LogManager.getLogger(clazz));
+            appender.start();
+            Loggers.addAppender(appender.logger, appender);
+            return appender;
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            this.events.add(event.toImmutable());
+        }
+
+        long count(Level level) {
+            return this.events.stream().filter(event -> event.getLevel() == level).count();
+        }
+
+        @Override
+        public void close() {
+            Loggers.removeAppender(this.logger, this);
+            super.stop();
+        }
     }
 }

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SpaceServiceTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/cti/catalog/service/SpaceServiceTests.java
@@ -17,7 +17,6 @@
 package com.wazuh.contentmanager.cti.catalog.service;
 
 import org.apache.lucene.search.TotalHits;
-import org.opensearch.action.NoShardAvailableActionException;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequestBuilder;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
@@ -25,17 +24,13 @@ import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.search.SearchPhaseExecutionException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.update.UpdateRequest;
-import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
-import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
@@ -45,7 +40,6 @@ import org.opensearch.transport.client.IndicesAdminClient;
 import org.junit.After;
 import org.junit.Before;
 
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -401,52 +395,6 @@ public class SpaceServiceTests extends OpenSearchTestCase {
 
         assertNotNull("Failure should be propagated via onFailure", failure.get());
         assertNull("onResponse should not have been called", changed.get());
-    }
-
-    /**
-     * Verifies the transient-failure classifier: only genuine shard-recovery conditions are treated
-     * as transient. A generic {@link SearchPhaseExecutionException} caused by a bad query (status
-     * 400) must NOT be swallowed, otherwise real search failures would silently disappear.
-     */
-    public void testIsTransientReadFailureClassification() throws Exception {
-        ShardId shardId = new ShardId("wazuh-threatintel-policies", "_na_", 0);
-
-        // "all shards failed" with no shard-level cause attached — reported as 503 → transient.
-        assertTrue(
-                isTransientReadFailure(
-                        new SearchPhaseExecutionException(
-                                "query", "all shards failed", ShardSearchFailure.EMPTY_ARRAY)));
-
-        // "all shards failed" whose shard cause is NoShardAvailable (shards recovering) → transient.
-        assertTrue(
-                isTransientReadFailure(
-                        new SearchPhaseExecutionException(
-                                "query",
-                                "all shards failed",
-                                new NoShardAvailableActionException(shardId),
-                                ShardSearchFailure.EMPTY_ARRAY)));
-
-        // A bare NoShardAvailable → transient.
-        assertTrue(isTransientReadFailure(new NoShardAvailableActionException(shardId)));
-
-        // A real query error (status 400) → NOT transient; must propagate as an error.
-        assertFalse(
-                isTransientReadFailure(
-                        new SearchPhaseExecutionException(
-                                "query",
-                                "parse error",
-                                new IllegalArgumentException("bad query"),
-                                ShardSearchFailure.EMPTY_ARRAY)));
-
-        // An unrelated failure → NOT transient.
-        assertFalse(isTransientReadFailure(new RuntimeException("boom")));
-    }
-
-    @SuppressForbidden(reason = "Unit test reflection on a private classifier")
-    private static boolean isTransientReadFailure(Exception e) throws Exception {
-        Method method = SpaceService.class.getDeclaredMethod("isTransientReadFailure", Exception.class);
-        method.setAccessible(true);
-        return (boolean) method.invoke(null, e);
     }
 
     private SearchHit policyHit(String sourceJson) {

--- a/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/TransientFailuresTests.java
+++ b/plugins/content-manager/src/test/java/com/wazuh/contentmanager/utils/TransientFailuresTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.wazuh.contentmanager.utils;
+
+import org.opensearch.action.NoShardAvailableActionException;
+import org.opensearch.action.UnavailableShardsException;
+import org.opensearch.action.search.SearchPhaseExecutionException;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.gateway.GatewayService;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static com.wazuh.contentmanager.utils.TransientFailures.isTransientReadFailure;
+
+/** Unit tests for {@link TransientFailures}. */
+public class TransientFailuresTests extends OpenSearchTestCase {
+
+    private static final ShardId SHARD_ID = new ShardId(Constants.INDEX_POLICIES, "_na_", 0);
+
+    /**
+     * Verifies the transient-failure classifier: only genuine shard-recovery conditions are treated
+     * as transient. A generic {@link SearchPhaseExecutionException} caused by a bad query (status
+     * 400) must NOT be swallowed, otherwise real search failures would silently disappear.
+     */
+    public void testStartupConditionsAreTransient() {
+        // "all shards failed" with no shard-level cause attached — reported as 503 → transient.
+        assertTrue(
+                isTransientReadFailure(
+                        new SearchPhaseExecutionException(
+                                "query", "all shards failed", ShardSearchFailure.EMPTY_ARRAY)));
+
+        // "all shards failed" whose shard cause is NoShardAvailable (shards recovering) → transient.
+        assertTrue(
+                isTransientReadFailure(
+                        new SearchPhaseExecutionException(
+                                "query",
+                                "all shards failed",
+                                new NoShardAvailableActionException(SHARD_ID),
+                                ShardSearchFailure.EMPTY_ARRAY)));
+
+        // A bare NoShardAvailable → transient.
+        assertTrue(isTransientReadFailure(new NoShardAvailableActionException(SHARD_ID)));
+
+        // Shards known but not yet active → transient.
+        assertTrue(
+                isTransientReadFailure(new UnavailableShardsException(SHARD_ID, "not enough replicas")));
+
+        // The index has not been created yet → transient.
+        assertTrue(isTransientReadFailure(new IndexNotFoundException(Constants.INDEX_POLICIES)));
+
+        // Cluster state not recovered yet → transient.
+        assertTrue(
+                isTransientReadFailure(
+                        new ClusterBlockException(Set.of(GatewayService.STATE_NOT_RECOVERED_BLOCK))));
+    }
+
+    /** A real query error or an unrelated failure must stay an error. */
+    public void testRealFailuresAreNotTransient() {
+        // A real query error (status 400) → NOT transient; must propagate as an error.
+        assertFalse(
+                isTransientReadFailure(
+                        new SearchPhaseExecutionException(
+                                "query",
+                                "parse error",
+                                new IllegalArgumentException("bad query"),
+                                ShardSearchFailure.EMPTY_ARRAY)));
+
+        // An unrelated failure → NOT transient.
+        assertFalse(isTransientReadFailure(new RuntimeException("boom")));
+    }
+
+    /**
+     * A transient failure keeps its classification through the wrapper an intermediate reader adds
+     * ({@code SpaceService.getPolicy} rewraps every failure as an {@link IOException}). Without this,
+     * a caller inspecting the wrapper would log the startup condition as an ERROR.
+     */
+    public void testClassificationSurvivesWrapping() {
+        SearchPhaseExecutionException cause =
+                new SearchPhaseExecutionException(
+                        "query", "all shards failed", ShardSearchFailure.EMPTY_ARRAY);
+
+        assertTrue(
+                isTransientReadFailure(
+                        new IOException("Failed to retrieve policy: " + cause.getMessage(), cause)));
+    }
+}


### PR DESCRIPTION
> **Draft.** Ami validation has not been done yet so the PR is still draft, it has not been done because CTI is with some problems and we cannot generate a package

## Description

On a clean 5.0.0-beta5 AMI, `EngineContentLoader` logs 39 of the log's 43 startup ERRORs, while the policy index shards are still initializing.

The cause is that **two layers disagreed about what counts as a startup condition.**

`SpaceService.getPolicy` already classifies this correctly. Its `isTransientReadFailure` helper, added in #1445, recognises that a policies-index search reaching the coordinating node before any shard copy is active surfaces as a `SearchPhaseExecutionException`, and demotes it to `debug`.

But `getPolicy` then rewraps every failure as `IOException("Failed to retrieve policy: …")` and hands it to its caller, and the caller — `EngineContentLoader.reloadFrom` — had its own, narrower classifier that recognised only `IndexNotFoundException` and `ClusterBlockException`:

Closes https://github.com/wazuh/wazuh-indexer/issues/1881

## Proposed Changes

- **`utils/TransientFailures.java`** — the classifier moved out of `SpaceService` into one shared place, so the reader that hits the condition and the caller that decides what to do about it cannot disagree again. It is unchanged in substance: `IndexNotFoundException`, `ClusterBlockException`, `NoShardAvailableActionException`, `UnavailableShardsException`, and a `SearchPhaseExecutionException` whose status is `503 SERVICE_UNAVAILABLE` (that is "all shards failed" with an empty `shardFailures` array). A generic `SearchPhaseExecutionException` — a malformed query, an aggregation error — is deliberately **not** transient, since that class covers *all* search failures. It inspects the whole cause chain, which is what lets it see through `getPolicy`'s `IOException` wrapper.
- **`EngineContentLoader.reloadFrom`** — uses it. The boot burst collapses to a single `debug` line per cluster-state update, and the run now short-circuits after the first space as it was always meant to.
- **`SpaceService`** — delegates to the shared copy at both of its call sites. Its own logging is unchanged.

### Guarding against the fix hiding a real fault

Demoting these failures to `debug` has a cost: a condition that never clears would leave the node running with an empty Engine and nothing in the log to say so. Per #1445 that is a functional outage, not cosmetic — detectors in the shared spaces stop producing findings.

So `deferRun` starts a clock on the first deferral of a streak and escalates to **exactly one** `warn` once the streak outlives a 5-minute grace period, resetting as soon as a run gets its reads served:

```
[WARN][c.w.c.c.c.s.EngineContentLoader] Engine content load still deferred after [5m] of retries;
  the content indices are not serving reads (Failed to retrieve policy: all shards failed).
  The shared content spaces stay unloaded on this node until this clears.
```

This also covers the pre-existing `IndexNotFoundException` path, which had the same blind spot: a policies index that is never created was already silent before this PR.

This is what the issue's "Expected behaviour" asks for, biased to the quiet end — DEBUG while the condition is still plausibly a boot state, WARN once it is not.

### Results and Evidence

https://github.com/wazuh/wazuh-indexer-plugins/pull/1550#issuecomment-5661767327

### Artifacts Affected

- Content manager plugin

### Configuration Changes

NA

### Documentation Updates

NA 

No user-facing documentation change: the behaviour being fixed is log noise, never documented as intended.

### Tests Introduced

**`EngineContentLoaderTests`** 
- `testAllShardsFailedEndsTheRunQuietly`
- `testRealSearchFailureIsPerSpaceAndDoesNotEndTheRun`
- `testPersistentNotReadyIsEscalatedToASingleWarning`

**`TransientFailuresTests`** (new file)



## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
