### PR TITLE
Document usage findings instead of alerts

### DIFF
--- a/docs/dev/plugins/security-analytics.md
+++ b/docs/dev/plugins/security-analytics.md
@@ -133,6 +133,15 @@ To ensure system stability, `DetectorFactory` implements a fallback mechanism fo
 
 `WTransportIndexDetectorAction` serves as the entry point for detector creation. It extracts the `enabled`, `interval`, and `sources` fields from the `WIndexDetectorRequest` and injects them into the factory method. This ensures that any change in the CTI catalog is reflected in the Security Analytics engine without requiring code changes or restarts.
 
+### Alerts are out of scope for 5.0.0
+
+Detectors are provisioned without triggers and without threat intel matching: `DetectorFactory.createDetector()` passes an empty trigger list and `threatIntelEnabled = false`, and no CTI field feeds either one. That is the scope of 5.0.0 rather than a gap — a detection is delivered as an enriched finding in `wazuh-findings-v5-{category}*`, and the Security Analytics alerting layer is left out of the product.
+
+Three things follow from it:
+
+- **Findings do not need triggers.** A document-level monitor writes a finding for every matching document whether or not it has a trigger; the trigger only decides which of those findings also become alerts. A provisioned detector runs on schedule and keeps writing findings with none.
+- **A detector's alert indices are created and stay unused.** With no condition to evaluate, nothing is alerted on and no action is called. The only documents that reach them are the error alerts Alerting writes when a monitor execution fails.
+
 ## Case management
 
 Case management adds triage capabilities to Security Analytics findings, allowing analysts to track status, classification, a multi-comment discussion thread, tags, and user attribution on individual findings.

--- a/docs/dev/plugins/security-analytics.md
+++ b/docs/dev/plugins/security-analytics.md
@@ -133,15 +133,6 @@ To ensure system stability, `DetectorFactory` implements a fallback mechanism fo
 
 `WTransportIndexDetectorAction` serves as the entry point for detector creation. It extracts the `enabled`, `interval`, and `sources` fields from the `WIndexDetectorRequest` and injects them into the factory method. This ensures that any change in the CTI catalog is reflected in the Security Analytics engine without requiring code changes or restarts.
 
-### Alerts are out of scope for 5.0.0
-
-Detectors are provisioned without triggers and without threat intel matching: `DetectorFactory.createDetector()` passes an empty trigger list and `threatIntelEnabled = false`, and no CTI field feeds either one. That is the scope of 5.0.0 rather than a gap — a detection is delivered as an enriched finding in `wazuh-findings-v5-{category}*`, and the Security Analytics alerting layer is left out of the product.
-
-Three things follow from it:
-
-- **Findings do not need triggers.** A document-level monitor writes a finding for every matching document whether or not it has a trigger; the trigger only decides which of those findings also become alerts. A provisioned detector runs on schedule and keeps writing findings with none.
-- **A detector's alert indices are created and stay unused.** With no condition to evaluate, nothing is alerted on and no action is called. The only documents that reach them are the error alerts Alerting writes when a monitor execution fails.
-
 ## Case management
 
 Case management adds triage capabilities to Security Analytics findings, allowing analysts to track status, classification, a multi-comment discussion thread, tags, and user attribution on individual findings.

--- a/docs/ref/modules/alerting/architecture.md
+++ b/docs/ref/modules/alerting/architecture.md
@@ -10,7 +10,7 @@ The alerting pipeline follows a linear flow:
 2. The query results are evaluated against one or more **Triggers** — boolean conditions that determine whether an alert should fire.
 3. When a trigger condition is met, the monitor executes its configured **Actions** — typically sending a notification through the Notifications plugin.
 4. An **Alert** record is created to track the triggered condition through its lifecycle.
-5. For document-level monitors, **Findings** record which specific documents matched the monitor's queries. Findings are written whether or not the monitor defines a trigger, so a monitor with an empty trigger list still produces them — it just never raises an alert.
+5. For document-level monitors, **Findings** record which specific documents matched the monitor's queries. Findings are written whether or not the monitor defines a trigger, so a monitor with an empty trigger list still produces them.
 
 ## Monitor types
 
@@ -37,7 +37,7 @@ Each monitor type uses a corresponding trigger type:
 
 - **QueryLevelTrigger**: Evaluates a script condition against the full query response. The script has access to the query results, aggregations, and monitor metadata.
 - **BucketLevelTrigger**: Evaluates a condition per aggregation bucket. Supports composite aggregations for paginating through large result sets.
-- **DocumentLevelTrigger**: Selects which of the monitor's per-document queries escalate to an alert, by name, ID, or tag. It decides what is alerted on, not what is recorded as a finding.
+- **DocumentLevelTrigger**: Defines per-document matching conditions using query DSL. Documents that match the trigger's queries generate alerts.
 - **ChainedAlertTrigger**: Evaluates a condition over the alerts produced by the delegate monitors of a composite (workflow) monitor, allowing alerts to fire based on combinations of upstream monitor results.
 
 Cluster metrics monitors reuse `QueryLevelTrigger`, evaluating a script condition against the cluster API response.

--- a/docs/ref/modules/alerting/architecture.md
+++ b/docs/ref/modules/alerting/architecture.md
@@ -10,7 +10,7 @@ The alerting pipeline follows a linear flow:
 2. The query results are evaluated against one or more **Triggers** — boolean conditions that determine whether an alert should fire.
 3. When a trigger condition is met, the monitor executes its configured **Actions** — typically sending a notification through the Notifications plugin.
 4. An **Alert** record is created to track the triggered condition through its lifecycle.
-5. For document-level monitors, **Findings** record which specific documents matched the trigger.
+5. For document-level monitors, **Findings** record which specific documents matched the monitor's queries. Findings are written whether or not the monitor defines a trigger, so a monitor with an empty trigger list still produces them — it just never raises an alert.
 
 ## Monitor types
 
@@ -37,7 +37,7 @@ Each monitor type uses a corresponding trigger type:
 
 - **QueryLevelTrigger**: Evaluates a script condition against the full query response. The script has access to the query results, aggregations, and monitor metadata.
 - **BucketLevelTrigger**: Evaluates a condition per aggregation bucket. Supports composite aggregations for paginating through large result sets.
-- **DocumentLevelTrigger**: Defines per-document matching conditions using query DSL. Documents that match the trigger's queries generate findings.
+- **DocumentLevelTrigger**: Selects which of the monitor's per-document queries escalate to an alert, by name, ID, or tag. It decides what is alerted on, not what is recorded as a finding.
 - **ChainedAlertTrigger**: Evaluates a condition over the alerts produced by the delegate monitors of a composite (workflow) monitor, allowing alerts to fire based on combinations of upstream monitor results.
 
 Cluster metrics monitors reuse `QueryLevelTrigger`, evaluating a script condition against the cluster API response.

--- a/docs/ref/modules/alerting/index.md
+++ b/docs/ref/modules/alerting/index.md
@@ -24,7 +24,7 @@ The plugin is a fork of the [OpenSearch Alerting plugin](https://docs.opensearch
 
 ### Ruleset Management
 
-The [Ruleset Management](../ruleset-management/index.md) plugin uses alerting monitors to evaluate incoming events against Sigma detection rules. When an event matches a rule, Ruleset Management creates a finding and can trigger an alert. The alerting monitor drives the detection loop — periodically querying new events and running them through the configured detectors.
+The [Ruleset Management](../ruleset-management/index.md) plugin uses alerting monitors to evaluate incoming events against Sigma detection rules. The alerting monitor drives the detection loop — periodically querying new events and running them through the configured detectors — and creates a finding for every event that matches a rule.
 
 ### Notifications
 

--- a/docs/ref/modules/alerting/index.md
+++ b/docs/ref/modules/alerting/index.md
@@ -24,7 +24,7 @@ The plugin is a fork of the [OpenSearch Alerting plugin](https://docs.opensearch
 
 ### Ruleset Management
 
-The [Ruleset Management](../ruleset-management/index.md) plugin uses alerting monitors to evaluate incoming events against Sigma detection rules. The alerting monitor drives the detection loop — periodically querying new events and running them through the configured detectors — and creates a finding for every event that matches a rule.
+The [Ruleset Management](../ruleset-management/index.md) plugin uses alerting monitors to evaluate incoming events against Sigma detection rules. The alerting monitor drives the detection loop, periodically querying new events and running them through the configured detectors, and creating a finding for every event that matches a rule 
 
 ### Notifications
 

--- a/docs/ref/modules/ruleset-management/architecture.md
+++ b/docs/ref/modules/ruleset-management/architecture.md
@@ -46,8 +46,9 @@ Threat detectors for Wazuh integrations are created dynamically based on CTI con
 - **Enabled status**: controlled by CTI to activate or deactivate detectors globally.
 - **Scan interval**: customizable per integration (e.g., critical integrations can have shorter intervals).
 - **Source indices**: defines the target indices or index patterns the detector monitors. If no source indices are provided, the detector falls back to the legacy per-category events pattern.
+- **Triggers and threat intelligence matching**: not used. Detectors are created with no triggers and with `threat_intel_enabled` set to `false`, because a finding is the record of a detection — see [Findings, not alerts](index.md#findings-not-alerts).
 
-Any change in the CTI catalog is reflected in detector configuration without requiring code changes or restarts.
+Any change in the CTI catalog is reflected in detector configuration without requiring code changes or restarts. The catalog owns the detectors it creates: each content update rebuilds them, which is why a provisioned detector accepts no user change other than enabling or disabling it.
 
 ## Behavior notes
 
@@ -70,6 +71,7 @@ See [Configuration](configuration.md) for the settings that control batch size, 
 | `.opensearch-sap-log-types-config`          | Integrations                                                 |
 | `.opensearch-sap-detectors-config`          | Threat detector configurations                               |
 | `wazuh-findings-v5-{category}*`             | Enriched findings                                             |
+| `.opensearch-sap-{category}-alerts*`        | Upstream alert indices; unused, since detectors carry no triggers |
 
 ## Access control
 

--- a/docs/ref/modules/ruleset-management/architecture.md
+++ b/docs/ref/modules/ruleset-management/architecture.md
@@ -46,7 +46,7 @@ Threat detectors for Wazuh integrations are created dynamically based on CTI con
 - **Enabled status**: controlled by CTI to activate or deactivate detectors globally.
 - **Scan interval**: customizable per integration (e.g., critical integrations can have shorter intervals).
 - **Source indices**: defines the target indices or index patterns the detector monitors. If no source indices are provided, the detector falls back to the legacy per-category events pattern.
-- **Triggers and threat intelligence matching**: not used. Detectors are created with no triggers and with `threat_intel_enabled` set to `false`, because a finding is the record of a detection — see [Findings, not alerts](index.md#findings-not-alerts).
+- **Triggers and threat intelligence matching**: not used. Detectors are created with no triggers, so a detection is recorded as a finding instead of raising an alert, and with `threat_intel_enabled` set to `false`, because Indicators of Compromise (IoCs) are matched by the Wazuh Engine as it processes events.
 
 Any change in the CTI catalog is reflected in detector configuration without requiring code changes or restarts. The catalog owns the detectors it creates: each content update rebuilds them, which is why a provisioned detector accepts no user change other than enabling or disabling it.
 
@@ -71,13 +71,12 @@ See [Configuration](configuration.md) for the settings that control batch size, 
 | `.opensearch-sap-log-types-config`          | Integrations                                                 |
 | `.opensearch-sap-detectors-config`          | Threat detector configurations                               |
 | `wazuh-findings-v5-{category}*`             | Enriched findings                                             |
-| `.opensearch-sap-{category}-alerts*`        | Upstream alert indices; unused, since detectors carry no triggers |
 
 ## Access control
 
 Access to Ruleset Management is governed by the [default Wazuh roles](../../security/access-control.md). The plugin authorizes requests against two action namespaces: the Wazuh custom actions `cluster:admin/wazuh/securityanalytics/*` and the upstream OpenSearch actions `cluster:admin/opensearch/securityanalytics/*` (see [Permissions](../../security/permissions.md)).
 
-- **`wazuh_admin`** — full access: create/update/delete detectors, rules, log types, and correlations; read findings and alerts.
+- **`wazuh_admin`** — full access: create/update/delete detectors, rules, integrations, and correlations; read findings and alerts.
 - **`wazuh_demo`** — full access, same endpoints as `wazuh_admin`.
 - **`wazuh_readonly`** — read-only: get/search detectors, rules, findings, alerts, mappings, correlations, and threat intel; `rules/evaluate`.
 - **`wazuh_manager`** — no access.

--- a/docs/ref/modules/ruleset-management/index.md
+++ b/docs/ref/modules/ruleset-management/index.md
@@ -1,10 +1,23 @@
 # Ruleset Management
 
-The Ruleset Management plugin is a fork of the [OpenSearch Security Analytics plugin](https://opensearch.org/docs/3.6/security-analytics/) adapted for Wazuh. It evaluates incoming events against Sigma detection rules, creates findings when rules match, and correlates related findings across detectors.
+The Ruleset Management plugin is a fork of the [OpenSearch Security Analytics plugin](https://opensearch.org/docs/3.6/security-analytics/) adapted for Wazuh. It evaluates incoming events against Sigma detection rules and creates a finding for every event that matches.
 
 The Ruleset Management plugin runs inside the Wazuh Indexer and operates as an OpenSearch plugin, using the standard OpenSearch transport layer for all internal communication.
 
 > **A note on naming:** Ruleset Management is the user-facing name of the plugin. Internally the plugin is still called Security Analytics, and that name remains visible in the identifiers it exposes — the `plugins.security_analytics.*` settings prefix, the `/_plugins/_security_analytics/` API base path, the `.opensearch-sap-*` index patterns, and the `cluster:admin/*/securityanalytics/*` action namespaces. The [Development Guide](../../../dev/plugins/security-analytics.md) also refers to it as Security Analytics throughout. Both names describe the same plugin.
+
+## Concepts
+
+- **Integration**: a data source and the content that detects on it, delivered by the Wazuh CTI catalog: `aws`, `windows`, `suricata`, and so on. Each integration has a category, which names the data streams its events and findings are written to. Integrations are what the upstream OpenSearch plugin calls log types.
+- **Detector**: evaluates the events of one integration against a set of Sigma rules on a schedule, and records a finding for every event that matches. Wazuh provides one **standard detector** per integration, provisioned from the CTI catalog; users can also create their own.
+- **Rule**: a Sigma detection rule. Standard rules come from the CTI catalog, custom rules are user-created. See [Sigma rules](rules.md).
+- **Space**: the origin of a piece of content, either **Standard** (CTI-provided) or **Custom** (user-created). A single detector references rules from one space only, see [Detector rule space restriction](#detector-rule-space-restriction).
+- **Finding**: the record that an event matched a rule, carrying the triggering event in full together with the relevant fields of the rule. One is written to `wazuh-findings-v5-{category}*` for every match, and that document is what the Wazuh Dashboard reads and [case management](case-management.md) triages, through status, severity, priority and comments held on it. See [Wazuh enriched findings](#wazuh-enriched-findings) for how it is assembled.
+- **Trigger**: a condition on a detector that decides which findings are escalated, together with the actions that deliver a notification through the [Notifications](../notifications/index.md) plugin.
+- **Alert**: the record created when a trigger condition is met, stored in `.opensearch-sap-{category}-alerts*`.
+- **Correlation**: an upstream mechanism for linking findings from different integrations through correlation rules. It is not used in 5.0.0: no correlation rules are shipped, and `plugins.security_analytics.auto_correlations_enabled` is `false` by default.
+
+> **Note:** the standard threat detectors Wazuh provides do not include alerting triggers. They record detections as findings; no alert is raised, and no notification channel is called. Triggers and alerts are available to detectors that users create.
 
 ## Detector rule space restriction
 
@@ -58,15 +71,9 @@ Enrichment is **fire-and-forget**: it never blocks the Ruleset Management write 
 
 See [Architecture](architecture.md) for the data flow, and the development guide for implementation details.
 
-### Findings, not alerts
-
-An enriched finding carries the triggering event in full together with the metadata of the rule that matched it, and [case management](case-management.md) tracks status, severity, priority and comments on that same document. A finding is the complete record of a detection, and the Wazuh Dashboard works from it.
-
-Wazuh 5.0 does not put the Security Analytics alerting layer on top of that: detectors carry no triggers, `threat_intel_enabled` is `false`, and the `.opensearch-sap-{category}-alerts*` indices go unused. An alert would restate what the finding already holds and split a detection's triage state across two documents.
-
 ## API
 
-Most endpoints (detectors, alerts, findings, correlations, log types) are inherited from the upstream OpenSearch Security Analytics plugin — see the [OpenSearch API reference](https://opensearch.org/docs/3.6/security-analytics/api-tools/) for those. Wazuh-specific additions and modifications:
+Most endpoints (detectors, alerts, findings, correlations, and integrations — `logtype` in the upstream API) are inherited from the upstream OpenSearch Security Analytics plugin — see the [OpenSearch API reference](https://opensearch.org/docs/3.6/security-analytics/api-tools/) for those. Wazuh-specific additions and modifications:
 
 - **Case management update** (`PUT /_plugins/_security_analytics/findings/_update`) — see [Case management](case-management.md).
 - **Detector rule-space restriction** and the **per-detector rule and detector-count limits** — see [Detector rule space restriction](#detector-rule-space-restriction) and [Detector constraints](#detector-constraints) above.

--- a/docs/ref/modules/ruleset-management/index.md
+++ b/docs/ref/modules/ruleset-management/index.md
@@ -58,9 +58,16 @@ Enrichment is **fire-and-forget**: it never blocks the Ruleset Management write 
 
 See [Architecture](architecture.md) for the data flow, and the development guide for implementation details.
 
+### Findings, not alerts
+
+An enriched finding carries the triggering event in full together with the metadata of the rule that matched it, and [case management](case-management.md) tracks status, severity, priority and comments on that same document. A finding is the complete record of a detection, and the Wazuh Dashboard works from it.
+
+Wazuh 5.0 does not put the Security Analytics alerting layer on top of that: detectors carry no triggers, `threat_intel_enabled` is `false`, and the `.opensearch-sap-{category}-alerts*` indices go unused. An alert would restate what the finding already holds and split a detection's triage state across two documents.
+
 ## API
 
 Most endpoints (detectors, alerts, findings, correlations, log types) are inherited from the upstream OpenSearch Security Analytics plugin — see the [OpenSearch API reference](https://opensearch.org/docs/3.6/security-analytics/api-tools/) for those. Wazuh-specific additions and modifications:
 
 - **Case management update** (`PUT /_plugins/_security_analytics/findings/_update`) — see [Case management](case-management.md).
-- **Detector rule-space restriction** and the **100-rule-per-detector limit** — see [Detector rule space restriction](#detector-rule-space-restriction) and [Detector constraints](#detector-constraints) above.
+- **Detector rule-space restriction** and the **per-detector rule and detector-count limits** — see [Detector rule space restriction](#detector-rule-space-restriction) and [Detector constraints](#detector-constraints) above.
+- **Detector updates** (`PUT /_plugins/_security_analytics/detectors/{detector_id}`) — a detector provisioned from the CTI catalog accepts a change to `enabled` and nothing else, since each content update rebuilds it from the catalog.


### PR DESCRIPTION
## Description

This PR documents the usage enriched finding in `wazuh-findings-v5-*` rather than as a Security Analytics alert

Closes #6117

## Proposed Changes

Update the documentation to explain the alerts and findings 

### Results and Evidence

NA

### Artifacts Affected

Documentation

### Configuration Changes

NA

### Documentation Updates

- `docs/ref/modules/ruleset-management/index.md` 
- `docs/ref/modules/ruleset-management/architecture.md`
- `docs/ref/modules/alerting/index.md`
- `docs/ref/modules/alerting/architecture.md`
- `docs/dev/plugins/security-analytics.md`

### Tests Introduced

NA
## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
