### PR TITLE
Document the removal of the OpenSearch demo users

### DIFF
--- a/docs/guide/migration/index.md
+++ b/docs/guide/migration/index.md
@@ -92,6 +92,8 @@ The following 4.x settings have changed in 5.x and must be reviewed before reuse
 
 Authentication and authorization are managed by the OpenSearch Security plugin in both versions, but 5.x ships a new set of default internal users, roles, and role mappings tailored to the Wazuh stack — the 4.x defaults are not carried over. For the full, up-to-date list of 5.x default users, roles, and permissions, see [Access Control](../../ref/security/access-control.md).
 
+5.x also stops shipping the demo entries that the OpenSearch Security plugin installs with itself. Of its demo accounts only `admin` and `kibanaserver` remain, and the `own_index`, `kibana_user`, `readall`, `logstash` and `manage_snapshots` role mappings are removed from `roles_mapping.yml`.
+
 In 5.x, all security plugin configuration lives under `/etc/wazuh-indexer/opensearch-security/`:
 
 | File | Purpose |
@@ -116,6 +118,9 @@ Perform these steps on the new 5.x host.
     - Custom roles → add to `roles.yml`, keeping the 5.x index patterns and permission names.
     - Role mappings → add to `roles_mapping.yml`, referencing the new role names.
     - External authentication backends (LDAP, Active Directory, SAML, OIDC, JWT, Kerberos, client-certificate) → re-create the corresponding `authc` / `authz` blocks in `config.yml` against the 5.x schema.
+
+    > **Warning — backend roles named after the upstream defaults**
+    > The OpenSearch Security demo role mappings are not shipped in 5.x. Those mappings turned the backend roles `kibanauser`, `readall`, `logstash` and `snapshotrestore` into the `kibana_user`, `readall`, `logstash` and `manage_snapshots` roles, keyed on the name alone. If an LDAP or Active Directory group, a JWT claim or a certificate attribute in your deployment is named after one of them and relied on that mapping, it no longer grants anything: its users authenticate exactly as before but lose the privileges, and nothing in the cluster reports why. Map those groups to the role they actually need under `roles_mapping.yml`, choosing from the 5.x roles in [Access Control](../../ref/security/access-control.md).
 
     > **Tip — bulk copy alternative**
     > Reviewing every entry individually is the safest option, but it is tedious and risks silently dropping a custom user or role you set up long ago and no longer remember. As an alternative, copy **all** custom entries from the 4.x files into the corresponding 5.x files at once, then prune afterwards. This guarantees nothing is lost, at the cost of dragging along stale entries. Copied entries may reference 4.x index patterns or permission names that changed in 5.x, and may collide with the new 5.x default users and roles — so still validate the result against [Access Control](../../ref/security/access-control.md) before applying.

--- a/docs/ref/security/defining-users-and-roles.md
+++ b/docs/ref/security/defining-users-and-roles.md
@@ -30,6 +30,18 @@ Follow these steps:
     * Optionally, configure [**Document-level security (DLS)**](https://docs.opensearch.org/3.6/security/access-control/index/) or [**Field-level security (FLS)**](https://docs.opensearch.org/3.6/security/access-control/field-level-security/).
 6. Click **Create** to save the role.
 
+<div class="warning">
+
+**Do not map users to the built-in `kibana_user` role.**
+
+Its name suggests it is what a dashboard user needs, and the upstream OpenSearch documentation recommends it for that purpose. It grants `delete`, `index` and `manage` over the `.kibana*` indices, which is where the Wazuh Dashboard stores its saved objects: the index patterns, visualizations and dashboards Wazuh ships.
+
+Wazuh Indexer disables Dashboard multi-tenancy, so there is no per-user space for those writes to land in. A user holding the role can delete any shipped index pattern — immediately, permanently, and with no undo — or edit its title so that every visualization built on it silently reads from different indices, with nothing in the interface indicating that it changed or who changed it.
+
+No default Wazuh user holds this role: the interactive ones have read-only access to `.kibana*`, and saved objects are managed by `admin`. Custom roles should follow the same rule — grant the permissions the user needs on the Wazuh index patterns and leave `.kibana*` alone.
+
+</div>
+
 ### 2. Create a user
 
 1. In the Wazuh Dashboard, go to **Index Management** -> **Security** -> **Internal users**.


### PR DESCRIPTION
## Description

Companion documentation for wazuh/wazuh-indexer#1899, which stops the packages from shipping the OpenSearch Security demo users and the role mappings that lead to their roles. No page named those accounts, so nothing was factually wrong — what was missing was the new behavior:

- **`docs/guide/migration/index.md`** — the "Security migration" intro now states that 5.x no longer ships the upstream demo entries, and step 2 carries a warning: the removed mappings keyed on backend role *names*, so a deployment with an LDAP/AD group, JWT claim or certificate attribute called `kibanauser`, `readall`, `logstash` or `snapshotrestore` silently loses those privileges — users authenticate as before and nothing reports the cause.
- **`docs/ref/security/defining-users-and-roles.md`** — a warning not to map users to the built-in `kibana_user` role. Its name reads as plain dashboard access, but it grants `delete`/`index`/`manage` over `.kibana*`, and with multi-tenancy disabled a user holding it can permanently delete any shipped index pattern or silently repoint it. The role is static and cannot be removed or weakened from a configuration file, so the warning is the only remaining defense.

Closes wazuh/internal-devel-requests#6113

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
