### PR TITLE
 Adopt `match_only_text` and `wildcard` in the WCS

### DIFF
--- a/plugins/setup/src/main/resources/templates/states/agent-config.json
+++ b/plugins/setup/src/main/resources/templates/states/agent-config.json
@@ -23,8 +23,7 @@
       "dynamic": "true",
       "properties": {
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "state": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/agent-stats.json
+++ b/plugins/setup/src/main/resources/templates/states/agent-stats.json
@@ -21,8 +21,7 @@
       "dynamic": "true",
       "properties": {
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "state": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/fim-files.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-files.json
@@ -127,8 +127,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "state": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-registry-keys.json
@@ -53,8 +53,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "registry": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
+++ b/plugins/setup/src/main/resources/templates/states/fim-registry-values.json
@@ -53,8 +53,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "registry": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-browser-extensions.json
@@ -84,8 +84,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "package": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-groups.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-groups.json
@@ -67,8 +67,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "state": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-hardware.json
@@ -83,8 +83,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "state": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-hotfixes.json
@@ -43,8 +43,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "package": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-interfaces.json
@@ -110,8 +110,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "state": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-networks.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-networks.json
@@ -51,8 +51,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "network": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-packages.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-packages.json
@@ -55,8 +55,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "package": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-ports.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-ports.json
@@ -99,8 +99,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "network": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-processes.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-processes.json
@@ -52,8 +52,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "process": {
           "properties": {
@@ -65,8 +64,7 @@
               "type": "long"
             },
             "command_line": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "name": {
               "ignore_above": 1024,

--- a/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-protocols.json
@@ -52,8 +52,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "network": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-services.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-services.json
@@ -95,8 +95,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "process": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-system.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-system.json
@@ -138,8 +138,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "state": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/inventory-users.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-users.json
@@ -79,8 +79,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "process": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/sca.json
+++ b/plugins/setup/src/main/resources/templates/states/sca.json
@@ -179,8 +179,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "policy": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
+++ b/plugins/setup/src/main/resources/templates/states/vulnerabilities.json
@@ -90,8 +90,7 @@
           }
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "package": {
           "properties": {

--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -1243,8 +1243,7 @@
                                   "type": "keyword"
                                 },
                                 "strings": {
-                                  "ignore_above": 1024,
-                                  "type": "keyword"
+                                  "type": "wildcard"
                                 },
                                 "type": {
                                   "ignore_above": 1024,
@@ -2128,8 +2127,7 @@
                               "type": "keyword"
                             },
                             "strings": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
+                              "type": "wildcard"
                             },
                             "type": {
                               "ignore_above": 1024,

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -2236,8 +2236,7 @@
           "wcs_email_message_id": {
             "path_match": "email.message_id",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -2316,8 +2315,7 @@
           "wcs_error_message": {
             "path_match": "error.message",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "match_only_text"
             }
           }
         },
@@ -2325,8 +2323,7 @@
           "wcs_error_stack_trace": {
             "path_match": "error.stack_trace",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -4590,8 +4587,7 @@
           "wcs_http_request_body_content": {
             "path_match": "http.request.body.content",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -4651,8 +4647,7 @@
           "wcs_http_response_body_content": {
             "path_match": "http.response.body.content",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -6008,8 +6003,7 @@
           "wcs_process_command_line": {
             "path_match": "process.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -6386,8 +6380,7 @@
           "wcs_process_entry_leader_command_line": {
             "path_match": "process.entry_leader.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -6748,8 +6741,7 @@
           "wcs_process_group_leader_command_line": {
             "path_match": "process.group_leader.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -7088,8 +7080,7 @@
           "wcs_process_io_text": {
             "path_match": "process.io.text",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -7367,8 +7358,7 @@
           "wcs_process_parent_command_line": {
             "path_match": "process.parent.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -8590,8 +8580,7 @@
           "wcs_process_previous_command_line": {
             "path_match": "process.previous.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -8731,8 +8720,7 @@
           "wcs_process_session_leader_command_line": {
             "path_match": "process.session_leader.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -9187,8 +9175,7 @@
           "wcs_registry_data_strings": {
             "path_match": "registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -11843,8 +11830,7 @@
           "wcs_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -11985,8 +11971,7 @@
           "wcs_threat_enrichments_indicator_url_full": {
             "path_match": "threat.enrichments.indicator.url.full",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -11994,8 +11979,7 @@
           "wcs_threat_enrichments_indicator_url_original": {
             "path_match": "threat.enrichments.indicator.url.original",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -12012,8 +11996,7 @@
           "wcs_threat_enrichments_indicator_url_path": {
             "path_match": "threat.enrichments.indicator.url.path",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13762,8 +13745,7 @@
           "wcs_threat_indicator_registry_data_strings": {
             "path_match": "threat.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13868,8 +13850,7 @@
           "wcs_threat_indicator_url_full": {
             "path_match": "threat.indicator.url.full",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13877,8 +13858,7 @@
           "wcs_threat_indicator_url_original": {
             "path_match": "threat.indicator.url.original",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13895,8 +13875,7 @@
           "wcs_threat_indicator_url_path": {
             "path_match": "threat.indicator.url.path",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -15043,8 +15022,7 @@
           "wcs_url_full": {
             "path_match": "url.full",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -15052,8 +15030,7 @@
           "wcs_url_original": {
             "path_match": "url.original",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -15070,8 +15047,7 @@
           "wcs_url_path": {
             "path_match": "url.path",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -17919,8 +17895,7 @@
           "wcs_wazuh_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -19713,8 +19688,7 @@
           "wcs_wazuh_threat_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -21634,8 +21608,7 @@
           "type": "object"
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "tags": {
           "ignore_above": 1024,

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -2236,8 +2236,7 @@
           "wcs_email_message_id": {
             "path_match": "email.message_id",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -2316,8 +2315,7 @@
           "wcs_error_message": {
             "path_match": "error.message",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "match_only_text"
             }
           }
         },
@@ -2325,8 +2323,7 @@
           "wcs_error_stack_trace": {
             "path_match": "error.stack_trace",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -4600,8 +4597,7 @@
           "wcs_http_request_body_content": {
             "path_match": "http.request.body.content",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -4661,8 +4657,7 @@
           "wcs_http_response_body_content": {
             "path_match": "http.response.body.content",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -6018,8 +6013,7 @@
           "wcs_process_command_line": {
             "path_match": "process.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -6396,8 +6390,7 @@
           "wcs_process_entry_leader_command_line": {
             "path_match": "process.entry_leader.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -6758,8 +6751,7 @@
           "wcs_process_group_leader_command_line": {
             "path_match": "process.group_leader.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -7098,8 +7090,7 @@
           "wcs_process_io_text": {
             "path_match": "process.io.text",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -7377,8 +7368,7 @@
           "wcs_process_parent_command_line": {
             "path_match": "process.parent.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -8600,8 +8590,7 @@
           "wcs_process_previous_command_line": {
             "path_match": "process.previous.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -8741,8 +8730,7 @@
           "wcs_process_session_leader_command_line": {
             "path_match": "process.session_leader.command_line",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -9197,8 +9185,7 @@
           "wcs_registry_data_strings": {
             "path_match": "registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -11853,8 +11840,7 @@
           "wcs_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -11995,8 +11981,7 @@
           "wcs_threat_enrichments_indicator_url_full": {
             "path_match": "threat.enrichments.indicator.url.full",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -12004,8 +11989,7 @@
           "wcs_threat_enrichments_indicator_url_original": {
             "path_match": "threat.enrichments.indicator.url.original",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -12022,8 +12006,7 @@
           "wcs_threat_enrichments_indicator_url_path": {
             "path_match": "threat.enrichments.indicator.url.path",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13772,8 +13755,7 @@
           "wcs_threat_indicator_registry_data_strings": {
             "path_match": "threat.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13878,8 +13860,7 @@
           "wcs_threat_indicator_url_full": {
             "path_match": "threat.indicator.url.full",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13887,8 +13868,7 @@
           "wcs_threat_indicator_url_original": {
             "path_match": "threat.indicator.url.original",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -13905,8 +13885,7 @@
           "wcs_threat_indicator_url_path": {
             "path_match": "threat.indicator.url.path",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -15053,8 +15032,7 @@
           "wcs_url_full": {
             "path_match": "url.full",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -15062,8 +15040,7 @@
           "wcs_url_original": {
             "path_match": "url.original",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -15080,8 +15057,7 @@
           "wcs_url_path": {
             "path_match": "url.path",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -18327,8 +18303,7 @@
           "wcs_wazuh_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -20121,8 +20096,7 @@
           "wcs_wazuh_threat_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.indicator.registry.data.strings",
             "mapping": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         },
@@ -22072,8 +22046,7 @@
           "type": "object"
         },
         "message": {
-          "ignore_above": 1024,
-          "type": "keyword"
+          "type": "match_only_text"
         },
         "tags": {
           "ignore_above": 1024,

--- a/wcs/generator/images/schema_sanitizer.py
+++ b/wcs/generator/images/schema_sanitizer.py
@@ -25,10 +25,26 @@ SEARCH_PATTERNS = [
 ]
 
 # Type mappings from ECS types to WCS-compatible types
+#
+# The two entries left are not gaps in OpenSearch's type list. They are
+# incompatibilities that break the generated templates:
+#
+#   constant_keyword -> keyword
+#     OpenSearch requires the `value` parameter at mapping time
+#     (ConstantKeywordFieldMapper.TypeParser rejects a mapping without it) and
+#     ECS declares the type with no value, because Elasticsearch infers it from
+#     the first document. In an explicit `properties` block that fails template
+#     creation outright; inside a dynamic_template it is accepted and then
+#     fails at ingest with mapper_parsing_exception, dropping every document
+#     that carries the field. data_stream.{type,dataset,namespace} are the only
+#     constant_keyword fields in ECS and both the events and the findings
+#     subsets include them, so this entry is load-bearing.
+#
+#   flattened -> flat_object
+#     OpenSearch has no `flattened` type ("No handler for type [flattened]");
+#     flat_object is its equivalent.
 TYPES_TO_REMAP = {
     'constant_keyword': 'keyword',
-    'wildcard': 'keyword',
-    'match_only_text': 'keyword',
     'flattened': 'flat_object',
 }
 

--- a/wcs/stateful/agent-config/docs/fields.csv
+++ b/wcs/stateful/agent-config/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,state,state.document_version,integer,custom,,,Version of the document.
 9.1.0,true,state,state.modified_at,date,custom,,,Date/time when the state was last modified.
 9.1.0,true,wazuh,wazuh.agent.configuration.content.agent-info.integrity_interval,long,custom,,,Agent module configuration: agent-info.integrity_interval.

--- a/wcs/stateful/agent-stats/docs/fields.csv
+++ b/wcs/stateful/agent-stats/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,state,state.document_version,integer,custom,,,Version of the document.
 9.1.0,true,state,state.modified_at,date,custom,,,Date/time when the state was last modified.
 9.1.0,true,wazuh,wazuh.agent.id,keyword,custom,,001,Unique identifier of the agent. Used as the document id.

--- a/wcs/stateful/fim/files/docs/fields.csv
+++ b/wcs/stateful/fim/files/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 9.1.0,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.

--- a/wcs/stateful/fim/windows-registry-keys/docs/fields.csv
+++ b/wcs/stateful/fim/windows-registry-keys/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,registry,registry.architecture,keyword,custom,,,Architecture associated with the entity
 9.1.0,true,registry,registry.gid,keyword,custom,,,Group ID associated with the entity

--- a/wcs/stateful/fim/windows-registry-values/docs/fields.csv
+++ b/wcs/stateful/fim/windows-registry-values/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,registry,registry.architecture,keyword,custom,,,Architecture associated with the entity
 9.1.0,true,registry,registry.data.hash.md5,keyword,custom,,,MD5 hash of the file or registry value content

--- a/wcs/stateful/inventory/browser-extensions/docs/fields.csv
+++ b/wcs/stateful/inventory/browser-extensions/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,browser,browser.name,keyword,custom,,chrome,"Name of the browser. Valid values: chrome, chromium, opera, yandex, brave, edge, edge_beta."
 9.1.0,true,browser,browser.profile.name,keyword,custom,,default,Name of the browser profile.
 9.1.0,true,browser,browser.profile.path,keyword,custom,,/home/user/.config/google-chrome/Default,Path to the browser profile.

--- a/wcs/stateful/inventory/groups/docs/fields.csv
+++ b/wcs/stateful/inventory/groups/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,group,group.description,match_only_text,custom,,,Description of the group.
 9.1.0,true,group,group.id,unsigned_long,custom,,,Unsigned int64 group ID.

--- a/wcs/stateful/inventory/hardware/docs/fields.csv
+++ b/wcs/stateful/inventory/hardware/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,host,host.cpu.cores,short,custom,,8,Number of CPU cores.
 9.1.0,true,host,host.cpu.name,keyword,custom,,Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz,Name/model of the CPU.

--- a/wcs/stateful/inventory/hotfixes/docs/fields.csv
+++ b/wcs/stateful/inventory/hotfixes/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,package,package.hotfix,object,custom,,,Hotfix related data.
 9.1.0,true,package,package.hotfix.name,keyword,custom,,,Name of the Hotfix.

--- a/wcs/stateful/inventory/interfaces/docs/fields.csv
+++ b/wcs/stateful/inventory/interfaces/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,host,host.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",Host MAC addresses.
 9.1.0,true,host,host.network.egress.bytes,long,extended,,,The number of bytes sent on all network interfaces.

--- a/wcs/stateful/inventory/networks/docs/fields.csv
+++ b/wcs/stateful/inventory/networks/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,interface,interface.name,keyword,extended,,eth0,Interface name
 9.1.0,true,network,network.broadcast,ip,custom,,,Broadcast address

--- a/wcs/stateful/inventory/packages/docs/fields.csv
+++ b/wcs/stateful/inventory/packages/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,package,package.architecture,keyword,extended,,x86_64,Package architecture.
 9.1.0,true,package,package.category,keyword,custom,,,Package category or group

--- a/wcs/stateful/inventory/ports/docs/fields.csv
+++ b/wcs/stateful/inventory/ports/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,destination,destination.ip,ip,core,,,IP address of the destination.
 9.1.0,true,destination,destination.port,long,core,,,Port of the destination.

--- a/wcs/stateful/inventory/processes/docs/fields.csv
+++ b/wcs/stateful/inventory/processes/docs/fields.csv
@@ -1,9 +1,9 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.name,keyword,extended,,ssh,Process name.
 9.1.0,true,process,process.parent.pid,long,core,,4242,Process id.
 9.1.0,true,process,process.pid,long,core,,4242,Process id.

--- a/wcs/stateful/inventory/protocols/docs/fields.csv
+++ b/wcs/stateful/inventory/protocols/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,interface,interface.name,keyword,extended,,eth0,Interface name
 9.1.0,true,network,network.dhcp,boolean,custom,,,DHCP enabled

--- a/wcs/stateful/inventory/services/docs/fields.csv
+++ b/wcs/stateful/inventory/services/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,error,error.log.file.path,keyword,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
 9.1.0,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."

--- a/wcs/stateful/inventory/system/docs/fields.csv
+++ b/wcs/stateful/inventory/system/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,host,host.architecture,keyword,core,,x86_64,Operating system architecture.
 9.1.0,true,host,host.hostname,keyword,core,,,Hostname of the host.

--- a/wcs/stateful/inventory/users/docs/fields.csv
+++ b/wcs/stateful/inventory/users/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,host,host.ip,ip,core,array,,Host ip addresses.
 9.1.0,true,login,login.status,boolean,custom,,,Whether the login was successful or the user is currently logged in.

--- a/wcs/stateful/sca/docs/fields.csv
+++ b/wcs/stateful/sca/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,check,check.compliance.cmmc,keyword,custom,array,"[""AC.1.001"", ""AU.L2-3.3.1""]",CMMC requirements.
 9.1.0,true,check,check.compliance.fedramp,keyword,custom,array,"[""AC-2"", ""SC-7""]",FedRAMP requirements.
 9.1.0,true,check,check.compliance.gdpr,keyword,custom,array,"[""Art. 32"", ""Art. 25""]",GDPR requirements.

--- a/wcs/stateful/vulnerabilities/docs/fields.csv
+++ b/wcs/stateful/vulnerabilities/docs/fields.csv
@@ -1,5 +1,5 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 9.1.0,true,host,host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.

--- a/wcs/stateless/active-responses/docs/fields.csv
+++ b/wcs/stateless/active-responses/docs/fields.csv
@@ -278,7 +278,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -487,7 +487,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.

--- a/wcs/stateless/active-responses/docs/wcs_flat.yml
+++ b/wcs/stateless/active-responses/docs/wcs_flat.yml
@@ -3518,14 +3518,13 @@ wazuh.threat.enrichments.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: wazuh.threat.enrichments.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 wazuh.threat.enrichments.indicator.registry.data.type:
   dashed_name: wazuh-threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -6174,14 +6173,13 @@ wazuh.threat.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: wazuh.threat.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 wazuh.threat.indicator.registry.data.type:
   dashed_name: wazuh-threat-indicator-registry-data-type
   description: Standard registry type for encoding contents

--- a/wcs/stateless/events/findings/docs/fields.csv
+++ b/wcs/stateless/events/findings/docs/fields.csv
@@ -1,7 +1,7 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 9.1.0,true,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 9.1.0,true,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 9.1.0,true,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
@@ -258,7 +258,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.direction,keyword,extended,,inbound,Direction of the message.
 9.1.0,true,email,email.from.address,keyword,extended,array,sender@example.com,The sender's email address.
 9.1.0,true,email,email.local_id,keyword,extended,,c26dbea0-80d5-463b-b93c-4e8b708219ce,Unique identifier given by the source.
-9.1.0,true,email,email.message_id,keyword,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
+9.1.0,true,email,email.message_id,wildcard,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
 9.1.0,true,email,email.origination_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time the email was composed.
 9.1.0,true,email,email.reply_to.address,keyword,extended,array,reply.here@example.com,Address replies should be delivered to.
 9.1.0,true,email,email.sender.address,keyword,extended,,,Address of the message sender.
@@ -267,8 +267,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.x_mailer,keyword,extended,,Spambot v2.5,Application that drafted email.
 9.1.0,true,error,error.code,keyword,core,,,Error code describing the error.
 9.1.0,true,error,error.id,keyword,core,,,Unique identifier for the error.
-9.1.0,true,error,error.message,keyword,core,,,Error message.
-9.1.0,true,error,error.stack_trace,keyword,extended,,,The stack trace of this error in plain text.
+9.1.0,true,error,error.message,match_only_text,core,,,Error message.
+9.1.0,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
 9.1.0,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 9.1.0,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 9.1.0,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -538,14 +538,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,host,host.type,keyword,core,,,Type of host.
 9.1.0,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 9.1.0,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
-9.1.0,true,http,http.request.body.content,keyword,extended,,Hello world,The full HTTP request body.
+9.1.0,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
 9.1.0,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 9.1.0,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 9.1.0,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
 9.1.0,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 9.1.0,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 9.1.0,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
-9.1.0,true,http,http.response.body.content,keyword,extended,,Hello world,The full HTTP response body.
+9.1.0,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
 9.1.0,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 9.1.0,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 9.1.0,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -706,7 +706,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -752,7 +752,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.entry_leader.attested_groups.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.entry_leader.attested_user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 9.1.0,true,process,process.entry_leader.attested_user.name,keyword,core,,a.einstein,Short name or login of the user.
-9.1.0,true,process,process.entry_leader.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.entry_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.entry_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 9.1.0,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
@@ -796,7 +796,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.group.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.group_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.group_leader.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.group_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -837,7 +837,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
 9.1.0,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 9.1.0,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
-9.1.0,true,process,process.io.text,keyword,extended,,,A chunk of output or input sanitized to UTF-8.
+9.1.0,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
 9.1.0,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
 9.1.0,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 9.1.0,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
@@ -871,7 +871,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.parent.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -1020,7 +1020,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.pid,long,core,,4242,Process id.
 9.1.0,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.previous.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.previous.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.previous.name,keyword,extended,,ssh,Process name.
 9.1.0,true,process,process.previous.parent.pid,long,custom,,1,PID of the parent process.
@@ -1036,7 +1036,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.saved_user.name,keyword,core,,a.einstein,Short name or login of the user.
 9.1.0,true,process,process.session_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.session_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.session_leader.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.session_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -1091,7 +1091,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.vpid,long,core,,4242,Virtual process id.
 9.1.0,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 9.1.0,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,registry,registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,registry,registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,registry,registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1401,7 +1401,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1418,10 +1418,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.enrichments.indicator.url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.enrichments.indicator.url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.enrichments.indicator.url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.enrichments.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.enrichments.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1624,7 +1624,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1636,10 +1636,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.indicator.url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.indicator.url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.indicator.url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1768,10 +1768,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,url,url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,url,url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,url,url.password,keyword,extended,,,Password of the request.
-9.1.0,true,url,url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,url,url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,url,url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -2154,7 +2154,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -2363,7 +2363,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.

--- a/wcs/stateless/events/findings/docs/wcs_flat.yml
+++ b/wcs/stateless/events/findings/docs/wcs_flat.yml
@@ -3361,12 +3361,11 @@ email.message_id:
     to a particular email message.
   example: 81ce15$8r2j59@mail01.example.com
   flat_name: email.message_id
-  ignore_above: 1024
   level: extended
   name: message_id
   normalize: []
   short: Value from the Message-ID header.
-  type: keyword
+  type: wildcard
 email.origination_timestamp:
   dashed_name: email-origination-timestamp
   description: The date and time the email message was composed. Many email clients
@@ -3461,7 +3460,6 @@ error.message:
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
-  ignore_above: 1024
   level: core
   name: message
   normalize: []
@@ -3470,12 +3468,11 @@ error.message:
     relation: equivalent
     stability: stable
   short: Error message.
-  type: keyword
+  type: match_only_text
 error.stack_trace:
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
-  ignore_above: 1024
   level: extended
   name: stack_trace
   normalize: []
@@ -3484,7 +3481,7 @@ error.stack_trace:
     relation: equivalent
     stability: stable
   short: The stack trace of this error in plain text.
-  type: keyword
+  type: wildcard
 error.type:
   dashed_name: error-type
   description: The type of the error, for example the class name of the exception.
@@ -7494,12 +7491,11 @@ http.request.body.content:
   description: The full HTTP request body.
   example: Hello world
   flat_name: http.request.body.content
-  ignore_above: 1024
   level: extended
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
-  type: keyword
+  type: wildcard
 http.request.bytes:
   dashed_name: http-request-bytes
   description: Total size in bytes of the request (body and headers).
@@ -7602,12 +7598,11 @@ http.response.body.content:
   description: The full HTTP response body.
   example: Hello world
   flat_name: http.response.body.content
-  ignore_above: 1024
   level: extended
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
-  type: keyword
+  type: wildcard
 http.response.bytes:
   dashed_name: http-response-bytes
   description: Total size in bytes of the response (body and headers).
@@ -8012,7 +8007,6 @@ message:
     If multiple messages exist, they can be combined into one message.'
   example: Hello World
   flat_name: message
-  ignore_above: 1024
   level: core
   name: message
   normalize: []
@@ -8023,7 +8017,7 @@ message:
     relation: otlp
     stability: stable
   short: Log message optimized for viewing in a log viewer.
-  type: keyword
+  type: match_only_text
 mitre.subtechnique:
   dashed_name: mitre-subtechnique
   description: MITRE ATT&CK subtechniques.
@@ -9672,7 +9666,6 @@ process.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
@@ -9680,7 +9673,7 @@ process.command_line:
   - relation: match
     stability: development
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.elf.architecture:
   dashed_name: process-elf-architecture
   description: Machine architecture of the ELF file.
@@ -10226,13 +10219,12 @@ process.entry_leader.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.entry_leader.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.entry_leader.entity_id:
   dashed_name: process-entry-leader-entity-id
   description: 'Unique identifier for the process.
@@ -10826,13 +10818,12 @@ process.group_leader.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.group_leader.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.group_leader.entity_id:
   dashed_name: process-group-leader-entity-id
   description: 'Unique identifier for the process.
@@ -11360,12 +11351,11 @@ process.io.text:
     may contain terminal control codes such as for cursor movement, so some string
     queries may not match due to terminal codes inserted between characters of a word.'
   flat_name: process.io.text
-  ignore_above: 1024
   level: extended
   name: io.text
   normalize: []
   short: A chunk of output or input sanitized to UTF-8.
-  type: keyword
+  type: wildcard
 process.io.total_bytes_captured:
   dashed_name: process-io-total-bytes-captured
   description: The total number of bytes captured in this event.
@@ -11801,13 +11791,12 @@ process.parent.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.parent.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.parent.elf.architecture:
   dashed_name: process-parent-elf-architecture
   description: Machine architecture of the ELF file.
@@ -13644,13 +13633,12 @@ process.previous.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.previous.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.previous.executable:
   dashed_name: process-previous-executable
   description: Absolute path to the process executable.
@@ -13855,13 +13843,12 @@ process.session_leader.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.session_leader.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.session_leader.entity_id:
   dashed_name: process-session-leader-entity-id
   description: 'Unique identifier for the process.
@@ -14603,13 +14590,12 @@ registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 registry.data.type:
   dashed_name: registry-data-type
   description: Standard registry type for encoding contents
@@ -18696,14 +18682,13 @@ threat.enrichments.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: threat.enrichments.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.registry.data.type:
   dashed_name: threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -18928,13 +18913,12 @@ threat.enrichments.indicator.url.full:
     in `url.full`, whether this field is reconstructed or present in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top
   flat_name: threat.enrichments.indicator.url.full
-  ignore_above: 1024
   level: extended
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.url.original:
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -18945,13 +18929,12 @@ threat.enrichments.indicator.url.original:
     This field is meant to represent the URL as it was observed, complete or not.'
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   flat_name: threat.enrichments.indicator.url.original
-  ignore_above: 1024
   level: extended
   name: original
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.url.password:
   dashed_name: threat-enrichments-indicator-url-password
   description: Password of the request.
@@ -18967,13 +18950,12 @@ threat.enrichments.indicator.url.path:
   dashed_name: threat-enrichments-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.enrichments.indicator.url.path
-  ignore_above: 1024
   level: extended
   name: path
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.url.port:
   dashed_name: threat-enrichments-indicator-url-port
   description: Port of the request, such as 443.
@@ -21528,14 +21510,13 @@ threat.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: threat.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 threat.indicator.registry.data.type:
   dashed_name: threat-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -21705,13 +21686,12 @@ threat.indicator.url.full:
     in `url.full`, whether this field is reconstructed or present in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top
   flat_name: threat.indicator.url.full
-  ignore_above: 1024
   level: extended
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: keyword
+  type: wildcard
 threat.indicator.url.original:
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -21722,13 +21702,12 @@ threat.indicator.url.original:
     This field is meant to represent the URL as it was observed, complete or not.'
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   flat_name: threat.indicator.url.original
-  ignore_above: 1024
   level: extended
   name: original
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: keyword
+  type: wildcard
 threat.indicator.url.password:
   dashed_name: threat-indicator-url-password
   description: Password of the request.
@@ -21744,13 +21723,12 @@ threat.indicator.url.path:
   dashed_name: threat-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.indicator.url.path
-  ignore_above: 1024
   level: extended
   name: path
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: keyword
+  type: wildcard
 threat.indicator.url.port:
   dashed_name: threat-indicator-url-port
   description: Port of the request, such as 443.
@@ -23526,7 +23504,6 @@ url.full:
     in `url.full`, whether this field is reconstructed or present in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top
   flat_name: url.full
-  ignore_above: 1024
   level: extended
   name: full
   normalize: []
@@ -23534,7 +23511,7 @@ url.full:
   - relation: match
     stability: stable
   short: Full unparsed URL.
-  type: keyword
+  type: wildcard
 url.original:
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
@@ -23545,7 +23522,6 @@ url.original:
     This field is meant to represent the URL as it was observed, complete or not.'
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   flat_name: url.original
-  ignore_above: 1024
   level: extended
   name: original
   normalize: []
@@ -23553,7 +23529,7 @@ url.original:
   - relation: match
     stability: development
   short: Unmodified original url as seen in the event source.
-  type: keyword
+  type: wildcard
 url.password:
   dashed_name: url-password
   description: Password of the request.
@@ -23568,7 +23544,6 @@ url.path:
   dashed_name: url-path
   description: Path of the request, such as "/search".
   flat_name: url.path
-  ignore_above: 1024
   level: extended
   name: path
   normalize: []
@@ -23576,7 +23551,7 @@ url.path:
   - relation: match
     stability: stable
   short: Path of the request, such as "/search".
-  type: keyword
+  type: wildcard
 url.port:
   dashed_name: url-port
   description: Port of the request, such as 443.
@@ -28384,14 +28359,13 @@ wazuh.threat.enrichments.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: wazuh.threat.enrichments.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 wazuh.threat.enrichments.indicator.registry.data.type:
   dashed_name: wazuh-threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -31040,14 +31014,13 @@ wazuh.threat.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: wazuh.threat.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 wazuh.threat.indicator.registry.data.type:
   dashed_name: wazuh-threat-indicator-registry-data-type
   description: Standard registry type for encoding contents

--- a/wcs/stateless/events/main/docs/fields.csv
+++ b/wcs/stateless/events/main/docs/fields.csv
@@ -1,7 +1,7 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 9.1.0,true,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
-9.1.0,true,base,message,keyword,core,,Hello World,Log message optimized for viewing in a log viewer.
+9.1.0,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 9.1.0,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 9.1.0,true,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 9.1.0,true,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
@@ -258,7 +258,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.direction,keyword,extended,,inbound,Direction of the message.
 9.1.0,true,email,email.from.address,keyword,extended,array,sender@example.com,The sender's email address.
 9.1.0,true,email,email.local_id,keyword,extended,,c26dbea0-80d5-463b-b93c-4e8b708219ce,Unique identifier given by the source.
-9.1.0,true,email,email.message_id,keyword,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
+9.1.0,true,email,email.message_id,wildcard,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
 9.1.0,true,email,email.origination_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time the email was composed.
 9.1.0,true,email,email.reply_to.address,keyword,extended,array,reply.here@example.com,Address replies should be delivered to.
 9.1.0,true,email,email.sender.address,keyword,extended,,,Address of the message sender.
@@ -267,8 +267,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.x_mailer,keyword,extended,,Spambot v2.5,Application that drafted email.
 9.1.0,true,error,error.code,keyword,core,,,Error code describing the error.
 9.1.0,true,error,error.id,keyword,core,,,Unique identifier for the error.
-9.1.0,true,error,error.message,keyword,core,,,Error message.
-9.1.0,true,error,error.stack_trace,keyword,extended,,,The stack trace of this error in plain text.
+9.1.0,true,error,error.message,match_only_text,core,,,Error message.
+9.1.0,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
 9.1.0,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 9.1.0,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 9.1.0,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -537,14 +537,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,host,host.type,keyword,core,,,Type of host.
 9.1.0,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 9.1.0,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
-9.1.0,true,http,http.request.body.content,keyword,extended,,Hello world,The full HTTP request body.
+9.1.0,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
 9.1.0,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 9.1.0,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 9.1.0,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
 9.1.0,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 9.1.0,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 9.1.0,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
-9.1.0,true,http,http.response.body.content,keyword,extended,,Hello world,The full HTTP response body.
+9.1.0,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
 9.1.0,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 9.1.0,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 9.1.0,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -705,7 +705,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -751,7 +751,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.entry_leader.attested_groups.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.entry_leader.attested_user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 9.1.0,true,process,process.entry_leader.attested_user.name,keyword,core,,a.einstein,Short name or login of the user.
-9.1.0,true,process,process.entry_leader.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.entry_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.entry_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 9.1.0,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
@@ -795,7 +795,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.group.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.group_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.group_leader.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.group_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -836,7 +836,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
 9.1.0,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 9.1.0,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
-9.1.0,true,process,process.io.text,keyword,extended,,,A chunk of output or input sanitized to UTF-8.
+9.1.0,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
 9.1.0,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
 9.1.0,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 9.1.0,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
@@ -870,7 +870,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.parent.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -1019,7 +1019,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.pid,long,core,,4242,Process id.
 9.1.0,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.previous.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.previous.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.previous.name,keyword,extended,,ssh,Process name.
 9.1.0,true,process,process.previous.parent.pid,long,custom,,1,PID of the parent process.
@@ -1035,7 +1035,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.saved_user.name,keyword,core,,a.einstein,Short name or login of the user.
 9.1.0,true,process,process.session_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.session_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.session_leader.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.session_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -1090,7 +1090,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.vpid,long,core,,4242,Virtual process id.
 9.1.0,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 9.1.0,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,registry,registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,registry,registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,registry,registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1400,7 +1400,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1417,10 +1417,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.enrichments.indicator.url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.enrichments.indicator.url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.enrichments.indicator.url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.enrichments.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.enrichments.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1623,7 +1623,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1635,10 +1635,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.indicator.url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.indicator.url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.indicator.url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1767,10 +1767,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,url,url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,url,url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,url,url.password,keyword,extended,,,Password of the request.
-9.1.0,true,url,url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,url,url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,url,url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -2104,7 +2104,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -2313,7 +2313,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.

--- a/wcs/stateless/events/main/docs/wcs_flat.yml
+++ b/wcs/stateless/events/main/docs/wcs_flat.yml
@@ -3361,12 +3361,11 @@ email.message_id:
     to a particular email message.
   example: 81ce15$8r2j59@mail01.example.com
   flat_name: email.message_id
-  ignore_above: 1024
   level: extended
   name: message_id
   normalize: []
   short: Value from the Message-ID header.
-  type: keyword
+  type: wildcard
 email.origination_timestamp:
   dashed_name: email-origination-timestamp
   description: The date and time the email message was composed. Many email clients
@@ -3461,7 +3460,6 @@ error.message:
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
-  ignore_above: 1024
   level: core
   name: message
   normalize: []
@@ -3470,12 +3468,11 @@ error.message:
     relation: equivalent
     stability: stable
   short: Error message.
-  type: keyword
+  type: match_only_text
 error.stack_trace:
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
-  ignore_above: 1024
   level: extended
   name: stack_trace
   normalize: []
@@ -3484,7 +3481,7 @@ error.stack_trace:
     relation: equivalent
     stability: stable
   short: The stack trace of this error in plain text.
-  type: keyword
+  type: wildcard
 error.type:
   dashed_name: error-type
   description: The type of the error, for example the class name of the exception.
@@ -7489,12 +7486,11 @@ http.request.body.content:
   description: The full HTTP request body.
   example: Hello world
   flat_name: http.request.body.content
-  ignore_above: 1024
   level: extended
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
-  type: keyword
+  type: wildcard
 http.request.bytes:
   dashed_name: http-request-bytes
   description: Total size in bytes of the request (body and headers).
@@ -7597,12 +7593,11 @@ http.response.body.content:
   description: The full HTTP response body.
   example: Hello world
   flat_name: http.response.body.content
-  ignore_above: 1024
   level: extended
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
-  type: keyword
+  type: wildcard
 http.response.bytes:
   dashed_name: http-response-bytes
   description: Total size in bytes of the response (body and headers).
@@ -8007,7 +8002,6 @@ message:
     If multiple messages exist, they can be combined into one message.'
   example: Hello World
   flat_name: message
-  ignore_above: 1024
   level: core
   name: message
   normalize: []
@@ -8018,7 +8012,7 @@ message:
     relation: otlp
     stability: stable
   short: Log message optimized for viewing in a log viewer.
-  type: keyword
+  type: match_only_text
 mitre.subtechnique:
   dashed_name: mitre-subtechnique
   description: MITRE ATT&CK subtechniques.
@@ -9667,7 +9661,6 @@ process.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
@@ -9675,7 +9668,7 @@ process.command_line:
   - relation: match
     stability: development
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.elf.architecture:
   dashed_name: process-elf-architecture
   description: Machine architecture of the ELF file.
@@ -10221,13 +10214,12 @@ process.entry_leader.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.entry_leader.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.entry_leader.entity_id:
   dashed_name: process-entry-leader-entity-id
   description: 'Unique identifier for the process.
@@ -10821,13 +10813,12 @@ process.group_leader.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.group_leader.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.group_leader.entity_id:
   dashed_name: process-group-leader-entity-id
   description: 'Unique identifier for the process.
@@ -11355,12 +11346,11 @@ process.io.text:
     may contain terminal control codes such as for cursor movement, so some string
     queries may not match due to terminal codes inserted between characters of a word.'
   flat_name: process.io.text
-  ignore_above: 1024
   level: extended
   name: io.text
   normalize: []
   short: A chunk of output or input sanitized to UTF-8.
-  type: keyword
+  type: wildcard
 process.io.total_bytes_captured:
   dashed_name: process-io-total-bytes-captured
   description: The total number of bytes captured in this event.
@@ -11796,13 +11786,12 @@ process.parent.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.parent.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.parent.elf.architecture:
   dashed_name: process-parent-elf-architecture
   description: Machine architecture of the ELF file.
@@ -13639,13 +13628,12 @@ process.previous.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.previous.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.previous.executable:
   dashed_name: process-previous-executable
   description: Absolute path to the process executable.
@@ -13850,13 +13838,12 @@ process.session_leader.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.session_leader.command_line
-  ignore_above: 1024
   level: extended
   name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: keyword
+  type: wildcard
 process.session_leader.entity_id:
   dashed_name: process-session-leader-entity-id
   description: 'Unique identifier for the process.
@@ -14598,13 +14585,12 @@ registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 registry.data.type:
   dashed_name: registry-data-type
   description: Standard registry type for encoding contents
@@ -18691,14 +18677,13 @@ threat.enrichments.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: threat.enrichments.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.registry.data.type:
   dashed_name: threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -18923,13 +18908,12 @@ threat.enrichments.indicator.url.full:
     in `url.full`, whether this field is reconstructed or present in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top
   flat_name: threat.enrichments.indicator.url.full
-  ignore_above: 1024
   level: extended
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.url.original:
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -18940,13 +18924,12 @@ threat.enrichments.indicator.url.original:
     This field is meant to represent the URL as it was observed, complete or not.'
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   flat_name: threat.enrichments.indicator.url.original
-  ignore_above: 1024
   level: extended
   name: original
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.url.password:
   dashed_name: threat-enrichments-indicator-url-password
   description: Password of the request.
@@ -18962,13 +18945,12 @@ threat.enrichments.indicator.url.path:
   dashed_name: threat-enrichments-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.enrichments.indicator.url.path
-  ignore_above: 1024
   level: extended
   name: path
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: keyword
+  type: wildcard
 threat.enrichments.indicator.url.port:
   dashed_name: threat-enrichments-indicator-url-port
   description: Port of the request, such as 443.
@@ -21523,14 +21505,13 @@ threat.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: threat.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 threat.indicator.registry.data.type:
   dashed_name: threat-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -21700,13 +21681,12 @@ threat.indicator.url.full:
     in `url.full`, whether this field is reconstructed or present in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top
   flat_name: threat.indicator.url.full
-  ignore_above: 1024
   level: extended
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: keyword
+  type: wildcard
 threat.indicator.url.original:
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -21717,13 +21697,12 @@ threat.indicator.url.original:
     This field is meant to represent the URL as it was observed, complete or not.'
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   flat_name: threat.indicator.url.original
-  ignore_above: 1024
   level: extended
   name: original
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: keyword
+  type: wildcard
 threat.indicator.url.password:
   dashed_name: threat-indicator-url-password
   description: Password of the request.
@@ -21739,13 +21718,12 @@ threat.indicator.url.path:
   dashed_name: threat-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.indicator.url.path
-  ignore_above: 1024
   level: extended
   name: path
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: keyword
+  type: wildcard
 threat.indicator.url.port:
   dashed_name: threat-indicator-url-port
   description: Port of the request, such as 443.
@@ -23521,7 +23499,6 @@ url.full:
     in `url.full`, whether this field is reconstructed or present in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top
   flat_name: url.full
-  ignore_above: 1024
   level: extended
   name: full
   normalize: []
@@ -23529,7 +23506,7 @@ url.full:
   - relation: match
     stability: stable
   short: Full unparsed URL.
-  type: keyword
+  type: wildcard
 url.original:
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
@@ -23540,7 +23517,6 @@ url.original:
     This field is meant to represent the URL as it was observed, complete or not.'
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   flat_name: url.original
-  ignore_above: 1024
   level: extended
   name: original
   normalize: []
@@ -23548,7 +23524,7 @@ url.original:
   - relation: match
     stability: development
   short: Unmodified original url as seen in the event source.
-  type: keyword
+  type: wildcard
 url.password:
   dashed_name: url-password
   description: Password of the request.
@@ -23563,7 +23539,6 @@ url.path:
   dashed_name: url-path
   description: Path of the request, such as "/search".
   flat_name: url.path
-  ignore_above: 1024
   level: extended
   name: path
   normalize: []
@@ -23571,7 +23546,7 @@ url.path:
   - relation: match
     stability: stable
   short: Path of the request, such as "/search".
-  type: keyword
+  type: wildcard
 url.port:
   dashed_name: url-port
   description: Port of the request, such as 443.
@@ -27784,14 +27759,13 @@ wazuh.threat.enrichments.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: wazuh.threat.enrichments.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 wazuh.threat.enrichments.indicator.registry.data.type:
   dashed_name: wazuh-threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -30440,14 +30414,13 @@ wazuh.threat.indicator.registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: wazuh.threat.indicator.registry.data.strings
-  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: keyword
+  type: wildcard
 wazuh.threat.indicator.registry.data.type:
   dashed_name: wazuh-threat-indicator-registry-data-type
   description: Standard registry type for encoding contents


### PR DESCRIPTION
## Description

The WCS sanitizer rewrote four ECS field types to equivalents because the Initial release of the WCS had no support for those type of fields

| ECS type | live 5.0.0 verdict | decision |
|---|---|---|
| `match_only_text` | **ACCEPTED** | **adopt** |
| `wildcard` | **ACCEPTED** | **adopt** |
| `constant_keyword` | **REJECTED** — `mapper_parsing_exception: Field [type] is missing required parameter [value]` | keep remapping to `keyword` |
| `flattened` | **REJECTED** — `No handler for type [flattened]` | keep remapping to `flat_object` |

Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1529

## Proposed Changes

Modify the list of fields to remap in `wcs/generator/images/schema_sanitizer.py`:

```diff
 TYPES_TO_REMAP = {
     'constant_keyword': 'keyword',
-    'wildcard': 'keyword',
-    'match_only_text': 'keyword',
     'flattened': 'flat_object',
 }
```

Generate again the files using the generator

### Results and Evidence

Every type transition across all 23 templates:
``` console
   keyword -> wildcard              53
   keyword -> match_only_text       24
   TOTAL field mappings changed     77
```


All 40 templates install and work on a live 5.0.0 node.

### Artifacts Affected

Index templates

### Configuration Changes

NA

### Documentation Updates

NA

### Tests Introduced

NA


## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
