### PR TITLE
Remove unused fields in wazuh-metrics-agents WCS module

### DIFF
--- a/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
+++ b/plugins/setup/src/main/resources/templates/streams/metrics-agents.json
@@ -40,33 +40,6 @@
           "properties": {
             "agent": {
               "properties": {
-                "config": {
-                  "properties": {
-                    "group": {
-                      "properties": {
-                        "hash": {
-                          "properties": {
-                            "md5": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
-                        },
-                        "synced": {
-                          "type": "boolean"
-                        }
-                      }
-                    },
-                    "hash": {
-                      "properties": {
-                        "md5": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
-                    }
-                  }
-                },
                 "disconnected_at": {
                   "type": "date"
                 },
@@ -85,10 +58,6 @@
                     },
                     "os": {
                       "properties": {
-                        "full": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        },
                         "name": {
                           "ignore_above": 1024,
                           "type": "keyword"

--- a/wcs/stateless/metrics/agents/docs/README.md
+++ b/wcs/stateless/metrics/agents/docs/README.md
@@ -30,16 +30,12 @@ The detail of the fields can be found in the csv file [Fields](fields.csv).
 | `wazuh.agent.host.os.name` | keyword | extended | Operating system name, without the version. |
 | `wazuh.agent.host.os.version` | keyword | extended | Operating system version as a raw string. |
 | `wazuh.agent.host.os.platform` | keyword | extended | Operating system platform. |
-| `wazuh.agent.host.os.full` | keyword | extended | Operating system name, including the version or code name. |
 | `wazuh.agent.register.ip` | ip | custom | Registration IP value from `client.keys`. |
 | `wazuh.agent.status` | keyword | custom | Current connection status of the agent. |
 | `wazuh.agent.status_code` | integer | custom | Internal numeric status code for the connection state. |
 | `wazuh.agent.registered_at` | date | custom | Date/time when the agent was registered. |
 | `wazuh.agent.last_seen` | date | custom | Date/time of the last keepalive received. |
 | `wazuh.agent.disconnected_at` | date | custom | Date/time when the agent was considered disconnected. |
-| `wazuh.agent.config.hash.md5` | keyword | custom | MD5 hash of the agent configuration. |
-| `wazuh.agent.config.group.synced` | boolean | custom | Status of the group configuration assigned to the agent. |
-| `wazuh.agent.config.group.hash.md5` | keyword | custom | MD5 hash of the merged group configuration. |
 | `wazuh.cluster.name` | keyword | custom | Wazuh cluster name. |
 | `wazuh.cluster.node` | keyword | custom | Wazuh cluster node name. |
 | `wazuh.schema.version` | keyword | custom | Wazuh schema version. |

--- a/wcs/stateless/metrics/agents/docs/fields.csv
+++ b/wcs/stateless/metrics/agents/docs/fields.csv
@@ -1,13 +1,9 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-9.1.0,true,wazuh,wazuh.agent.config.group.hash.md5,keyword,custom,,16728192a0e2b5ca79e3d1385c32096e,MD5 hash of the merged group configuration currently applied to the agent.
-9.1.0,true,wazuh,wazuh.agent.config.group.synced,boolean,custom,,True,Status of the group configuration assigned to the agent.
-9.1.0,true,wazuh,wazuh.agent.config.hash.md5,keyword,custom,,7fdd9b4cf9a06dbe937f7de73dcbe9e4,MD5 hash of the agent configuration used for integrity verification and change detection.
 9.1.0,true,wazuh,wazuh.agent.disconnected_at,date,custom,,,Date/time when the agent was considered disconnected.
 9.1.0,true,wazuh,wazuh.agent.groups,keyword,custom,array,"[""group1"", ""group2""]",List of groups the agent belongs to.
 9.1.0,true,wazuh,wazuh.agent.host.architecture,keyword,core,,x86_64,Operating system architecture.
 9.1.0,true,wazuh,wazuh.agent.host.ip,ip,core,array,,Host ip addresses.
-9.1.0,true,wazuh,wazuh.agent.host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 9.1.0,true,wazuh,wazuh.agent.host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 9.1.0,true,wazuh,wazuh.agent.host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 9.1.0,true,wazuh,wazuh.agent.host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.

--- a/wcs/stateless/metrics/agents/docs/wcs_flat.yml
+++ b/wcs/stateless/metrics/agents/docs/wcs_flat.yml
@@ -33,44 +33,6 @@
   required: true
   short: Date/time when the event originated.
   type: date
-wazuh.agent.config.group.hash.md5:
-  dashed_name: wazuh-agent-config-group-hash-md5
-  description: MD5 hash of the merged group configuration currently applied to the
-    agent.
-  example: 16728192a0e2b5ca79e3d1385c32096e
-  flat_name: wazuh.agent.config.group.hash.md5
-  ignore_above: 1024
-  level: custom
-  name: config.group.hash.md5
-  normalize: []
-  original_fieldset: agent
-  short: MD5 hash of the merged group configuration currently applied to the agent.
-  type: keyword
-wazuh.agent.config.group.synced:
-  dashed_name: wazuh-agent-config-group-synced
-  description: Status of the group configuration assigned to the agent.
-  example: true
-  flat_name: wazuh.agent.config.group.synced
-  level: custom
-  name: config.group.synced
-  normalize: []
-  original_fieldset: agent
-  short: Status of the group configuration assigned to the agent.
-  type: boolean
-wazuh.agent.config.hash.md5:
-  dashed_name: wazuh-agent-config-hash-md5
-  description: MD5 hash of the agent configuration used for integrity verification
-    and change detection.
-  example: 7fdd9b4cf9a06dbe937f7de73dcbe9e4
-  flat_name: wazuh.agent.config.hash.md5
-  ignore_above: 1024
-  level: custom
-  name: config.hash.md5
-  normalize: []
-  original_fieldset: agent
-  short: MD5 hash of the agent configuration used for integrity verification and change
-    detection.
-  type: keyword
 wazuh.agent.disconnected_at:
   dashed_name: wazuh-agent-disconnected-at
   description: Date/time when the agent was considered disconnected.
@@ -117,18 +79,6 @@ wazuh.agent.host.ip:
   original_fieldset: host
   short: Host ip addresses.
   type: ip
-wazuh.agent.host.os.full:
-  dashed_name: wazuh-agent-host-os-full
-  description: Operating system name, including the version or code name.
-  example: Mac OS Mojave
-  flat_name: wazuh.agent.host.os.full
-  ignore_above: 1024
-  level: extended
-  name: full
-  normalize: []
-  original_fieldset: os
-  short: Operating system name, including the version or code name.
-  type: keyword
 wazuh.agent.host.os.name:
   dashed_name: wazuh-agent-host-os-name
   description: Operating system name, without the version.

--- a/wcs/stateless/metrics/agents/fields/custom/agent.yml
+++ b/wcs/stateless/metrics/agents/fields/custom/agent.yml
@@ -53,25 +53,6 @@
       level: custom
       description: >
         Date/time when the agent was considered disconnected.
-    - name: config.hash.md5
-      type: keyword
-      level: custom
-      description: >
-        MD5 hash of the agent configuration used for integrity verification and
-        change detection.
-      example: "7fdd9b4cf9a06dbe937f7de73dcbe9e4"
-    - name: config.group.synced
-      type: boolean
-      level: custom
-      description: >
-        Status of the group configuration assigned to the agent.
-      example: true
-    - name: config.group.hash.md5
-      type: keyword
-      level: custom
-      description: >
-        MD5 hash of the merged group configuration currently applied to the agent.
-      example: "16728192a0e2b5ca79e3d1385c32096e"
 
 - name: host
   reusable:

--- a/wcs/stateless/metrics/agents/fields/subset.yml
+++ b/wcs/stateless/metrics/agents/fields/subset.yml
@@ -20,17 +20,6 @@ fields:
           registered_at: {}
           last_seen: {}
           disconnected_at: {}
-          config:
-            fields:
-              hash:
-                fields:
-                  md5: {}
-              group:
-                fields:
-                  synced: {}
-                  hash:
-                    fields:
-                      md5: {}
           host:
             fields:
               ip: {}
@@ -40,7 +29,6 @@ fields:
                   name: {}
                   version: {}
                   platform: {}
-                  full: {}
       cluster:
         fields: "*"
       schema:


### PR DESCRIPTION
## Description

This pull request removes 4 unused fields from the `wazuh-metrics-agents` data stream.

Closes #1558 

## Proposed Changes

- `fields/subset.yml` — dropped the whole `config`: block (its only leaves were the three removed fields) and `full: {}` under `wazuh.agent.host.os`.
- `fields/custom/agent.yml` — dropped the `config.hash.md5`, `config.group.synced`, and `config.group.hash.md5` entries. `os.full` needed no change here; it came from the ECS `os` fieldset, so removing it from the subset was enough.
- `docs/README.md` — removed the four rows from the hand-written field table.

### Results and Evidence

See the diff.

### Artifacts Affected

- `templates/streams/metrics-agents.json` — the four mapping leaves are gone, nothing else changed.
- `docs/fields.csv`, `docs/wcs_flat.yml` — 4 and 50 lines removed respectively.
- `count_and_update_total_fields.sh` --apply ran: field count 26, limits unchanged (total_fields: 1000, max_docvalue_fields_search: 100), so the two `template-settings*.json` files ended up byte-identical and stay out of the diff.

### Configuration Changes

None.

### Documentation Updates

WCS documentation.

### Tests Introduced

None.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
