### PR TITLE
Document the threat detector detection gap and detector permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@
 - [BUG] Resource creation requires `indices:admin/create` on `.wazuh-content-manager-resource-locks` for the calling user [(#1520)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1520)
 - [BUG] `index.query.default_field` lists name fields the index does not have, fields no text term can match and entries with trailing spaces [(#1536)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1536)
 - [BUG] `logtest` reports `contains` matches that never fire in the real ingestion pipeline (case sensitivity) [(#321)](https://github.com/wazuh/wazuh-indexer-security-analytics/issues/321)
+- [BUG] Document that a disabled threat detector produces no findings and that the missed interval is never re-evaluated [(#1531)](https://github.com/wazuh/wazuh-indexer-plugins/issues/1531)
 
 ## Prior versions
 - []()

--- a/docs/ref/modules/ruleset-management/index.md
+++ b/docs/ref/modules/ruleset-management/index.md
@@ -32,6 +32,47 @@ When the restriction is violated, the API returns `400 Bad Request`.
 
 Both limits are dynamic and enforced at the transport layer, applying to all detector creation and update paths, including inter-plugin calls from the Content Manager. Both accept any value from `0` upwards; there is no hard-coded ceiling. See [Configuration](configuration.md) for details.
 
+## Enabling and disabling detectors
+
+A standard detector accepts one user change and one only: switching `enabled` on or off. Every other field is owned by the CTI catalog and is rejected with `400 Bad Request` and `Standard detectors cannot be modified by users. Only enabling or disabling is allowed.` A standard detector also cannot be deleted; the API answers `400 Bad Request` with `Standard detectors cannot be deleted by users.`
+
+```bash
+# Disable a detector (as an administrator)
+curl -sk -u wazuh-admin:<password> -X PUT \
+  -H 'Content-Type: application/json' \
+  "https://localhost:9200/_plugins/_security_analytics/detectors/<detector_id>" \
+  --data-binary @detector-with-enabled-false.json
+```
+
+> **Note:** the detector API returns `last_update_time` and `enabled_time` as ISO-8601 strings but expects epoch milliseconds on write. Sending back an unmodified response body fails with `illegal_argument_exception: For input string: "..."`, which is a parse error, not a permission one.
+
+### Who can switch a detector off
+
+Switching a detector on or off requires `cluster:admin/opensearch/securityanalytics/detector/write`, which among the [default roles](../../security/access-control.md) only `wazuh_admin` holds. `wazuh_demo` and `wazuh_readonly` can read detectors (`detector/get`, `detector/search`) but cannot change their state.
+
+### The detection gap
+
+**A disabled detector produces no findings, and the events missed while it was off are never recovered.** A detector analyses the events of each scheduled run, and a disabled detector is not run at all. Events indexed while it was off therefore fall outside every run, before and after, so re-enabling it resumes detection from that moment forward — it does not go back over the interval that was skipped.
+
+The consequences are worth stating plainly:
+
+- The events themselves are not lost; they are indexed as usual and remain searchable in `wazuh-events-v5-*`.
+- No finding exists for them and none will be created later, so anything that reads findings — the Dashboard, [case management](case-management.md), triggers and alerts on user-created detectors, correlations — behaves as if nothing matched.
+- There is no re-scan or backfill API. The only way to evaluate an event against rules after the fact is [logtest](../content-manager/rule-testing.md), one event at a time.
+
+Plan a maintenance window that disables a detector accordingly, and re-ingest the source data if the interval matters.
+
+### Auditing state changes
+
+Every transition is recorded in the Wazuh Indexer log at `INFO`, together with the account that requested it:
+
+```
+[2026-09-10T13:54:15,906][INFO ][o.o.s.t.TransportIndexDetectorAction] [indexer] Detector [h1BSbaABJb1ilIZ5JvzP] (windows, standard) was disabled by [wazuh-admin]. No findings will be generated for its integration until it is enabled again.
+[2026-09-10T13:54:20,282][INFO ][o.o.s.t.TransportIndexDetectorAction] [indexer] Detector [h1BSbaABJb1ilIZ5JvzP] (windows, standard) was enabled by [wazuh-admin]. Events indexed while it was disabled are not re-evaluated.
+```
+
+A change carried with no authenticated user attached to the request — the Content Manager switching a detector off because its integration was disabled in the CTI catalog, or any cluster running without the security plugin — is logged the same way, with `internal` in place of the account name. Nothing is written when a request leaves the state unchanged, and nothing is written until the change is persisted.
+
 ## Wazuh enriched findings
 
 ### What is a finding?
@@ -77,4 +118,4 @@ Most endpoints (detectors, alerts, findings, correlations, and integrations — 
 
 - **Case management update** (`PUT /_plugins/_security_analytics/findings/_update`) — see [Case management](case-management.md).
 - **Detector rule-space restriction** and the **per-detector rule and detector-count limits** — see [Detector rule space restriction](#detector-rule-space-restriction) and [Detector constraints](#detector-constraints) above.
-- **Detector updates** (`PUT /_plugins/_security_analytics/detectors/{detector_id}`) — a detector provisioned from the CTI catalog accepts a change to `enabled` and nothing else, since each content update rebuilds it from the catalog.
+- **Detector updates** (`PUT /_plugins/_security_analytics/detectors/{detector_id}`) — a detector provisioned from the CTI catalog accepts a change to `enabled` and nothing else, since each content update rebuilds it from the catalog. See [Enabling and disabling detectors](#enabling-and-disabling-detectors) for who may do it and what a disabled detector costs.

--- a/docs/ref/security/access-control.md
+++ b/docs/ref/security/access-control.md
@@ -17,7 +17,7 @@ Each default user is mapped 1:1 to the role of the matching name in `roles_mappi
 
 - **`wazuh-manager`** → `wazuh_manager` — service account for the Wazuh Manager: read/write on stateless (events, metrics) indices, read/write/delete on stateful (states) indices, read/write on the agent statistics and configuration indexes, and read on consumers, threat intelligence and active-responses.
 - **`wazuh-admin`** → `wazuh_admin` — administrator: read access to all Wazuh indices, write access to Wazuh settings, full Content Manager and Ruleset Management access, and management of alerting, notifications, reporting and index management. Excludes super-admin (security configuration).
-- **`wazuh-demo`** → `wazuh_demo` — default interactive user: read data, manage threat intelligence content, full Content Manager content operations and Ruleset Management, and read-only alerting, notifications, reporting and index management.
+- **`wazuh-demo`** → `wazuh_demo` — default interactive user: read data, manage threat intelligence content, full Content Manager content operations and Ruleset Management except detectors (read-only), and read-only alerting, notifications, reporting and index management.
 - **`wazuh-readonly`** → `wazuh_readonly` — read-only access to indices, settings, subscriptions and Ruleset Management (detectors, findings, alerts).
 
 > **Security note:** The bundled password hashes decode to the username, and nothing rotates them during installation. Change every default password immediately after installation, as described in [Changing the default passwords](../getting-started/installation.md#4-changing-the-default-passwords).
@@ -80,7 +80,7 @@ Default interactive user: can visualize data and manage threat intelligence / Co
   - Base: `cluster_composite_ops`, `indices:data/read/scroll/clear`, `cluster_monitor`.
   - AI assistant settings (setup plugin): `plugin:wazuh/ai_assistant/settings/read`.
   - Content Manager: full content operations (no subscription create/delete, no policy update).
-  - Ruleset Management: full (both the Wazuh custom actions and the upstream OpenSearch Security Analytics actions).
+  - Ruleset Management: full (both the Wazuh custom actions and the upstream OpenSearch Security Analytics actions), **except detectors**, which are read-only (`detector/get`, `detector/search`). Creating, deleting and enabling or disabling a detector is reserved to `wazuh_admin`, because switching a detector off silently stops detection for its integration — see [Enabling and disabling detectors](../modules/ruleset-management/index.md#enabling-and-disabling-detectors).
   - Alerting, Anomaly detection, Notifications, Reporting, Index management: **read-only**.
 - **Index permissions:**
   - `get`, `read`, `indices:admin/aliases/get`, `indices:monitor/*` on `*`, `.kibana*`.

--- a/docs/ref/security/permissions.md
+++ b/docs/ref/security/permissions.md
@@ -35,6 +35,7 @@ Wazuh custom actions:
 
 - `cluster:admin/wazuh/securityanalytics/detector/write`
 - `cluster:admin/wazuh/securityanalytics/detector/delete`
+- `cluster:admin/wazuh/securityanalytics/detector/set_enabled` — switch an existing detector on or off without changing anything else (used by the Content Manager when an integration is enabled or disabled)
 - `cluster:admin/wazuh/securityanalytics/logtype/write`
 - `cluster:admin/wazuh/securityanalytics/logtype/delete`
 - `cluster:admin/wazuh/securityanalytics/rule/write`
@@ -44,4 +45,6 @@ Wazuh custom actions:
 - `cluster:admin/wazuh/securityanalytics/rules/evaluate`
 - `cluster:admin/wazuh/securityanalytics/space/delete`
 
-The default roles also grant the upstream OpenSearch Security Analytics actions (`cluster:admin/opensearch/securityanalytics/*`) — the full `/*` set for `wazuh_admin` and `wazuh_demo`, and the read-only (`/get`, `/search`) subset for `wazuh_readonly`.
+The default roles also grant the upstream OpenSearch Security Analytics actions (`cluster:admin/opensearch/securityanalytics/*`) — the full `/*` set for `wazuh_admin`, and the read-only (`/get`, `/search`) subset for `wazuh_readonly`. `wazuh_demo` holds the full set except on detectors, where it is limited to `cluster:admin/opensearch/securityanalytics/detector/get` and `.../detector/search`.
+
+> **Note:** `cluster:admin/opensearch/securityanalytics/detector/write` is the permission that switches a detector on or off, and only `wazuh_admin` holds it. Disabling a detector stops detection for its integration and the interval missed is never re-evaluated — see [Enabling and disabling detectors](../modules/ruleset-management/index.md#enabling-and-disabling-detectors).


### PR DESCRIPTION
## Description

Standard detectors are protected from deletion but can be switched off, which stops detection for their integration just as effectively. Nothing in the reference said so, nor that the detections missed while a detector is off are never recovered.

Closes #1531, which needs all three of:

| | |
|---|---|
| this PR | documents the detection gap and the permissions |
| wazuh/wazuh-indexer-security-analytics#332 | logs each transition with the account that requested it |
| wazuh/wazuh-indexer#1903 | restricts `wazuh_demo` to read-only access on detectors |

## Proposed Changes

A new **Enabling and disabling detectors** section in the Ruleset Management reference, plus the security pages that follow from the role change.

| Documented | Where |
|---|---|
| A standard detector accepts a change to `enabled` and nothing else, and cannot be deleted — both rejection messages verbatim | `ruleset-management/index.md` |
| The API returns `last_update_time` / `enabled_time` as ISO-8601 but expects epoch milliseconds on write; an unconverted payload fails with `illegal_argument_exception`, a parse error and not an authorisation one | same |
| Who may switch a detector off | same |
| **The detection gap** — no findings while off, the missed interval is never re-evaluated, the events stay searchable, and there is no re-scan or backfill API | same |
| The INFO log entry each transition leaves | same |
| `wazuh_demo` is read-only on detectors; `detector/write` is what switches one on or off | `security/access-control.md`, `security/permissions.md` |
| `cluster:admin/wazuh/securityanalytics/detector/set_enabled`, missing from the permission list | `security/permissions.md` |

The gap claim is what the code does, not a repetition of the issue thread: a detector's `enabled` becomes its composite workflow's `enabled` (`WorkflowService`), and re-enabling a workflow sets `isWorkflowRestarted`, which passes `forceCreateLastRunContext = true` to `MonitorMetadataService.getOrCreateMetadata` (`TransportIndexWorkflowAction`; same logic for standalone doc-level monitors in `TransportIndexMonitorAction`). That rebuilds `lastRunContext` at the shards' current sequence numbers, so the skipped interval is dropped deliberately.

**What this does not do:** it does not make the missed window recoverable, and it changes no behaviour.

### Results and Evidence

Every documented claim was checked against a real cluster or against the source. `mdbook build` renders and the cross-page anchors resolve.

<details><summary>Verified on a cluster</summary>

A `vagrant/5.0` VM (OpenSearch 3.6.0, security plugin enabled) with all three branches deployed via `push.sh --build --install`, against `apache-http`, a real **standard** detector:

| Documented claim | Result |
|---|---|
| standard detectors cannot be deleted | 400 `Standard detectors cannot be deleted by users.` (403 first for a role without `detector/delete`) |
| no update but the `enabled` toggle | 400 `Standard detectors cannot be modified by users. Only enabling or disabling is allowed.` |
| `wazuh_demo` cannot switch one off | 403 on `detector/write`; detector unchanged |
| an administrator still can | 200 |
| each transition is logged | `Detector [7afa379b-…] (apache-http, standard) was disabled by [wazuh-admin]. …` |
| epoch milliseconds on write | `400 illegal_argument_exception: For input string: "2026-09-04T16:03:04.772Z"` |

</details>

<details><summary>Verified by reading the source</summary>

| Claim | Source |
|---|---|
| the toggle requires `detector/write` | `IndexDetectorAction.NAME` |
| `detector/set_enabled` is the Content Manager's path | `WSetDetectorEnabledAction.NAME`, from `TransportUpdateIntegrationAction.syncDetectorEnabledState` |
| times are epoch millis on write | `Detector.parse` → `Instant.ofEpochMilli(xcp.longValue())` |
| re-enabling resets the run context | `TransportIndexWorkflowAction` / `TransportIndexMonitorAction` → `forceCreateLastRunContext` |

**Not empirically tested:** the gap itself — indexing an event while a detector is off and showing no finding is produced for it afterwards. The mechanism is proven in code and stated by the maintainer in #1531, but no event was pushed through the pipeline.

</details>

### Artifacts Affected

None. Documentation only — no plugin, packaging, default configuration, index template or security configuration. `docs/book/` is build output and is not committed.

### Configuration Changes

None in this PR. The `wazuh_demo` change it documents lives in wazuh/wazuh-indexer#1903; existing deployments keep the roles they have until the new `roles.yml` is applied.

### Documentation Updates

- `docs/ref/modules/ruleset-management/index.md` — the new section; the API bullet on detector updates links to it.
- `docs/ref/security/access-control.md` — `wazuh_demo` in the user list and the role breakdown.
- `docs/ref/security/permissions.md` — the role summary, `detector/set_enabled`, and a note on `detector/write`.

No endpoint changed, so `openapi.yml` needs no update. No new page, so `docs/SUMMARY.md` is untouched.

### Tests Introduced

None — no code to test. Verification is the cluster evidence above plus `mdbook build`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — not applicable, documentation only
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues — describes behaviour that exists once wazuh/wazuh-indexer-security-analytics#332 and wazuh/wazuh-indexer#1903 merge
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`) — CHANGELOG entry added
