### PR TITLE
Change `wildcard` for `match_only_text` to fix detection error

### DIFF
--- a/plugins/setup/src/main/resources/templates/states/inventory-processes.json
+++ b/plugins/setup/src/main/resources/templates/states/inventory-processes.json
@@ -64,7 +64,7 @@
               "type": "long"
             },
             "command_line": {
-              "type": "wildcard"
+              "type": "match_only_text"
             },
             "name": {
               "ignore_above": 1024,

--- a/plugins/setup/src/main/resources/templates/streams/active-responses.json
+++ b/plugins/setup/src/main/resources/templates/streams/active-responses.json
@@ -1621,7 +1621,7 @@
                                   "type": "keyword"
                                 },
                                 "strings": {
-                                  "type": "wildcard"
+                                  "type": "match_only_text"
                                 },
                                 "type": {
                                   "ignore_above": 1024,
@@ -2505,7 +2505,7 @@
                               "type": "keyword"
                             },
                             "strings": {
-                              "type": "wildcard"
+                              "type": "match_only_text"
                             },
                             "type": {
                               "ignore_above": 1024,

--- a/plugins/setup/src/main/resources/templates/streams/events.json
+++ b/plugins/setup/src/main/resources/templates/streams/events.json
@@ -2235,7 +2235,7 @@
           "wcs_email_message_id": {
             "path_match": "email.message_id",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -2322,7 +2322,7 @@
           "wcs_error_stack_trace": {
             "path_match": "error.stack_trace",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -4586,7 +4586,7 @@
           "wcs_http_request_body_content": {
             "path_match": "http.request.body.content",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -4646,7 +4646,7 @@
           "wcs_http_response_body_content": {
             "path_match": "http.response.body.content",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -6002,7 +6002,7 @@
           "wcs_process_command_line": {
             "path_match": "process.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -6379,7 +6379,7 @@
           "wcs_process_entry_leader_command_line": {
             "path_match": "process.entry_leader.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -6740,7 +6740,7 @@
           "wcs_process_group_leader_command_line": {
             "path_match": "process.group_leader.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -7079,7 +7079,7 @@
           "wcs_process_io_text": {
             "path_match": "process.io.text",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -7357,7 +7357,7 @@
           "wcs_process_parent_command_line": {
             "path_match": "process.parent.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -8579,7 +8579,7 @@
           "wcs_process_previous_command_line": {
             "path_match": "process.previous.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -8719,7 +8719,7 @@
           "wcs_process_session_leader_command_line": {
             "path_match": "process.session_leader.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -9174,7 +9174,7 @@
           "wcs_registry_data_strings": {
             "path_match": "registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -11829,7 +11829,7 @@
           "wcs_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -11970,7 +11970,7 @@
           "wcs_threat_enrichments_indicator_url_full": {
             "path_match": "threat.enrichments.indicator.url.full",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -11978,7 +11978,7 @@
           "wcs_threat_enrichments_indicator_url_original": {
             "path_match": "threat.enrichments.indicator.url.original",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -11995,7 +11995,7 @@
           "wcs_threat_enrichments_indicator_url_path": {
             "path_match": "threat.enrichments.indicator.url.path",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13744,7 +13744,7 @@
           "wcs_threat_indicator_registry_data_strings": {
             "path_match": "threat.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13849,7 +13849,7 @@
           "wcs_threat_indicator_url_full": {
             "path_match": "threat.indicator.url.full",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13857,7 +13857,7 @@
           "wcs_threat_indicator_url_original": {
             "path_match": "threat.indicator.url.original",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13874,7 +13874,7 @@
           "wcs_threat_indicator_url_path": {
             "path_match": "threat.indicator.url.path",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -15021,7 +15021,7 @@
           "wcs_url_full": {
             "path_match": "url.full",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -15029,7 +15029,7 @@
           "wcs_url_original": {
             "path_match": "url.original",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -15046,7 +15046,7 @@
           "wcs_url_path": {
             "path_match": "url.path",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -17894,7 +17894,7 @@
           "wcs_wazuh_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -19687,7 +19687,7 @@
           "wcs_wazuh_threat_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },

--- a/plugins/setup/src/main/resources/templates/streams/findings.json
+++ b/plugins/setup/src/main/resources/templates/streams/findings.json
@@ -2235,7 +2235,7 @@
           "wcs_email_message_id": {
             "path_match": "email.message_id",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -2322,7 +2322,7 @@
           "wcs_error_stack_trace": {
             "path_match": "error.stack_trace",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -4596,7 +4596,7 @@
           "wcs_http_request_body_content": {
             "path_match": "http.request.body.content",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -4656,7 +4656,7 @@
           "wcs_http_response_body_content": {
             "path_match": "http.response.body.content",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -6012,7 +6012,7 @@
           "wcs_process_command_line": {
             "path_match": "process.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -6389,7 +6389,7 @@
           "wcs_process_entry_leader_command_line": {
             "path_match": "process.entry_leader.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -6750,7 +6750,7 @@
           "wcs_process_group_leader_command_line": {
             "path_match": "process.group_leader.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -7089,7 +7089,7 @@
           "wcs_process_io_text": {
             "path_match": "process.io.text",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -7367,7 +7367,7 @@
           "wcs_process_parent_command_line": {
             "path_match": "process.parent.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -8589,7 +8589,7 @@
           "wcs_process_previous_command_line": {
             "path_match": "process.previous.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -8729,7 +8729,7 @@
           "wcs_process_session_leader_command_line": {
             "path_match": "process.session_leader.command_line",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -9184,7 +9184,7 @@
           "wcs_registry_data_strings": {
             "path_match": "registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -11839,7 +11839,7 @@
           "wcs_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -11980,7 +11980,7 @@
           "wcs_threat_enrichments_indicator_url_full": {
             "path_match": "threat.enrichments.indicator.url.full",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -11988,7 +11988,7 @@
           "wcs_threat_enrichments_indicator_url_original": {
             "path_match": "threat.enrichments.indicator.url.original",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -12005,7 +12005,7 @@
           "wcs_threat_enrichments_indicator_url_path": {
             "path_match": "threat.enrichments.indicator.url.path",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13754,7 +13754,7 @@
           "wcs_threat_indicator_registry_data_strings": {
             "path_match": "threat.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13859,7 +13859,7 @@
           "wcs_threat_indicator_url_full": {
             "path_match": "threat.indicator.url.full",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13867,7 +13867,7 @@
           "wcs_threat_indicator_url_original": {
             "path_match": "threat.indicator.url.original",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -13884,7 +13884,7 @@
           "wcs_threat_indicator_url_path": {
             "path_match": "threat.indicator.url.path",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -15031,7 +15031,7 @@
           "wcs_url_full": {
             "path_match": "url.full",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -15039,7 +15039,7 @@
           "wcs_url_original": {
             "path_match": "url.original",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -15056,7 +15056,7 @@
           "wcs_url_path": {
             "path_match": "url.path",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -18302,7 +18302,7 @@
           "wcs_wazuh_threat_enrichments_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.enrichments.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },
@@ -20095,7 +20095,7 @@
           "wcs_wazuh_threat_indicator_registry_data_strings": {
             "path_match": "wazuh.threat.indicator.registry.data.strings",
             "mapping": {
-              "type": "wildcard"
+              "type": "match_only_text"
             }
           }
         },

--- a/wcs/generator/images/schema_sanitizer.py
+++ b/wcs/generator/images/schema_sanitizer.py
@@ -26,8 +26,8 @@ SEARCH_PATTERNS = [
 
 # Type mappings from ECS types to WCS-compatible types
 #
-# The two entries left are not gaps in OpenSearch's type list. They are
-# incompatibilities that break the generated templates:
+# The entries here handle incompatibilities that break generated templates
+# or detection querying in OpenSearch:
 #
 #   constant_keyword -> keyword
 #     OpenSearch requires the `value` parameter at mapping time
@@ -43,9 +43,19 @@ SEARCH_PATTERNS = [
 #   flattened -> flat_object
 #     OpenSearch has no `flattened` type ("No handler for type [flattened]");
 #     flat_object is its equivalent.
+#
+#   wildcard -> match_only_text
+#     Security Analytics compiles Sigma rules to `query_string` queries, which
+#     cannot query OpenSearch `wildcard` fields (upstream WildcardFieldMapper
+#     overrides only the 4-arg wildcardQuery method; StringFieldType delegates
+#     the 5-arg normalizedWildcardQuery from query_string to base Lucene over
+#     n-grams, producing zero hits without error). Remapping to `match_only_text`
+#     keeps fields (e.g. process.command_line, url.*) reachable from the
+#     detection query path without the 1024-char ceiling of `keyword`.
 TYPES_TO_REMAP = {
     'constant_keyword': 'keyword',
     'flattened': 'flat_object',
+    'wildcard': 'match_only_text',
 }
 
 # Specific field type remappings

--- a/wcs/stateful/inventory/processes/docs/fields.csv
+++ b/wcs/stateful/inventory/processes/docs/fields.csv
@@ -3,7 +3,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,checksum,checksum.hash.sha1,keyword,custom,,,SHA1 hash used as checksum of the data collected by the agent.
 9.1.0,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.name,keyword,extended,,ssh,Process name.
 9.1.0,true,process,process.parent.pid,long,core,,4242,Process id.
 9.1.0,true,process,process.pid,long,core,,4242,Process id.

--- a/wcs/stateless/active-responses/docs/fields.csv
+++ b/wcs/stateless/active-responses/docs/fields.csv
@@ -278,7 +278,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -487,7 +487,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.

--- a/wcs/stateless/active-responses/docs/wcs_flat.yml
+++ b/wcs/stateless/active-responses/docs/wcs_flat.yml
@@ -3524,7 +3524,7 @@ wazuh.threat.enrichments.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 wazuh.threat.enrichments.indicator.registry.data.type:
   dashed_name: wazuh-threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -6179,7 +6179,7 @@ wazuh.threat.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 wazuh.threat.indicator.registry.data.type:
   dashed_name: wazuh-threat-indicator-registry-data-type
   description: Standard registry type for encoding contents

--- a/wcs/stateless/events/findings/docs/fields.csv
+++ b/wcs/stateless/events/findings/docs/fields.csv
@@ -258,7 +258,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.direction,keyword,extended,,inbound,Direction of the message.
 9.1.0,true,email,email.from.address,keyword,extended,array,sender@example.com,The sender's email address.
 9.1.0,true,email,email.local_id,keyword,extended,,c26dbea0-80d5-463b-b93c-4e8b708219ce,Unique identifier given by the source.
-9.1.0,true,email,email.message_id,wildcard,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
+9.1.0,true,email,email.message_id,match_only_text,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
 9.1.0,true,email,email.origination_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time the email was composed.
 9.1.0,true,email,email.reply_to.address,keyword,extended,array,reply.here@example.com,Address replies should be delivered to.
 9.1.0,true,email,email.sender.address,keyword,extended,,,Address of the message sender.
@@ -268,7 +268,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,error,error.code,keyword,core,,,Error code describing the error.
 9.1.0,true,error,error.id,keyword,core,,,Unique identifier for the error.
 9.1.0,true,error,error.message,match_only_text,core,,,Error message.
-9.1.0,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
+9.1.0,true,error,error.stack_trace,match_only_text,extended,,,The stack trace of this error in plain text.
 9.1.0,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 9.1.0,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 9.1.0,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -538,14 +538,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,host,host.type,keyword,core,,,Type of host.
 9.1.0,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 9.1.0,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
-9.1.0,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
+9.1.0,true,http,http.request.body.content,match_only_text,extended,,Hello world,The full HTTP request body.
 9.1.0,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 9.1.0,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 9.1.0,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
 9.1.0,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 9.1.0,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 9.1.0,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
-9.1.0,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
+9.1.0,true,http,http.response.body.content,match_only_text,extended,,Hello world,The full HTTP response body.
 9.1.0,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 9.1.0,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 9.1.0,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -706,7 +706,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -752,7 +752,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.entry_leader.attested_groups.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.entry_leader.attested_user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 9.1.0,true,process,process.entry_leader.attested_user.name,keyword,core,,a.einstein,Short name or login of the user.
-9.1.0,true,process,process.entry_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.entry_leader.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.entry_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 9.1.0,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
@@ -796,7 +796,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.group.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.group_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.group_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.group_leader.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -837,7 +837,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
 9.1.0,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 9.1.0,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
-9.1.0,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
+9.1.0,true,process,process.io.text,match_only_text,extended,,,A chunk of output or input sanitized to UTF-8.
 9.1.0,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
 9.1.0,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 9.1.0,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
@@ -871,7 +871,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.parent.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -1020,7 +1020,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.pid,long,core,,4242,Process id.
 9.1.0,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.previous.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.previous.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.previous.name,keyword,extended,,ssh,Process name.
 9.1.0,true,process,process.previous.parent.pid,long,custom,,1,PID of the parent process.
@@ -1036,7 +1036,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.saved_user.name,keyword,core,,a.einstein,Short name or login of the user.
 9.1.0,true,process,process.session_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.session_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.session_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.session_leader.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -1091,7 +1091,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.vpid,long,core,,4242,Virtual process id.
 9.1.0,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 9.1.0,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,registry,registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,registry,registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,registry,registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1401,7 +1401,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1418,10 +1418,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.enrichments.indicator.url.full,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.enrichments.indicator.url.original,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.enrichments.indicator.url.path,match_only_text,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.enrichments.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.enrichments.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1624,7 +1624,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1636,10 +1636,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.indicator.url.full,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.indicator.url.original,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.indicator.url.path,match_only_text,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1768,10 +1768,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,url,url.full,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,url,url.original,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,url,url.password,keyword,extended,,,Password of the request.
-9.1.0,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,url,url.path,match_only_text,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,url,url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,url,url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -2154,7 +2154,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -2363,7 +2363,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.

--- a/wcs/stateless/events/findings/docs/wcs_flat.yml
+++ b/wcs/stateless/events/findings/docs/wcs_flat.yml
@@ -3365,7 +3365,7 @@ email.message_id:
   name: message_id
   normalize: []
   short: Value from the Message-ID header.
-  type: wildcard
+  type: match_only_text
 email.origination_timestamp:
   dashed_name: email-origination-timestamp
   description: The date and time the email message was composed. Many email clients
@@ -3481,7 +3481,7 @@ error.stack_trace:
     relation: equivalent
     stability: stable
   short: The stack trace of this error in plain text.
-  type: wildcard
+  type: match_only_text
 error.type:
   dashed_name: error-type
   description: The type of the error, for example the class name of the exception.
@@ -7495,7 +7495,7 @@ http.request.body.content:
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
-  type: wildcard
+  type: match_only_text
 http.request.bytes:
   dashed_name: http-request-bytes
   description: Total size in bytes of the request (body and headers).
@@ -7602,7 +7602,7 @@ http.response.body.content:
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
-  type: wildcard
+  type: match_only_text
 http.response.bytes:
   dashed_name: http-response-bytes
   description: Total size in bytes of the response (body and headers).
@@ -9673,7 +9673,7 @@ process.command_line:
   - relation: match
     stability: development
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.elf.architecture:
   dashed_name: process-elf-architecture
   description: Machine architecture of the ELF file.
@@ -10224,7 +10224,7 @@ process.entry_leader.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.entry_leader.entity_id:
   dashed_name: process-entry-leader-entity-id
   description: 'Unique identifier for the process.
@@ -10823,7 +10823,7 @@ process.group_leader.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.group_leader.entity_id:
   dashed_name: process-group-leader-entity-id
   description: 'Unique identifier for the process.
@@ -11355,7 +11355,7 @@ process.io.text:
   name: io.text
   normalize: []
   short: A chunk of output or input sanitized to UTF-8.
-  type: wildcard
+  type: match_only_text
 process.io.total_bytes_captured:
   dashed_name: process-io-total-bytes-captured
   description: The total number of bytes captured in this event.
@@ -11796,7 +11796,7 @@ process.parent.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.parent.elf.architecture:
   dashed_name: process-parent-elf-architecture
   description: Machine architecture of the ELF file.
@@ -13638,7 +13638,7 @@ process.previous.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.previous.executable:
   dashed_name: process-previous-executable
   description: Absolute path to the process executable.
@@ -13848,7 +13848,7 @@ process.session_leader.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.session_leader.entity_id:
   dashed_name: process-session-leader-entity-id
   description: 'Unique identifier for the process.
@@ -14595,7 +14595,7 @@ registry.data.strings:
   normalize:
   - array
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 registry.data.type:
   dashed_name: registry-data-type
   description: Standard registry type for encoding contents
@@ -18688,7 +18688,7 @@ threat.enrichments.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.registry.data.type:
   dashed_name: threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -18918,7 +18918,7 @@ threat.enrichments.indicator.url.full:
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.url.original:
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -18934,7 +18934,7 @@ threat.enrichments.indicator.url.original:
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.url.password:
   dashed_name: threat-enrichments-indicator-url-password
   description: Password of the request.
@@ -18955,7 +18955,7 @@ threat.enrichments.indicator.url.path:
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.url.port:
   dashed_name: threat-enrichments-indicator-url-port
   description: Port of the request, such as 443.
@@ -21516,7 +21516,7 @@ threat.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 threat.indicator.registry.data.type:
   dashed_name: threat-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -21691,7 +21691,7 @@ threat.indicator.url.full:
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: wildcard
+  type: match_only_text
 threat.indicator.url.original:
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -21707,7 +21707,7 @@ threat.indicator.url.original:
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: wildcard
+  type: match_only_text
 threat.indicator.url.password:
   dashed_name: threat-indicator-url-password
   description: Password of the request.
@@ -21728,7 +21728,7 @@ threat.indicator.url.path:
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: wildcard
+  type: match_only_text
 threat.indicator.url.port:
   dashed_name: threat-indicator-url-port
   description: Port of the request, such as 443.
@@ -23511,7 +23511,7 @@ url.full:
   - relation: match
     stability: stable
   short: Full unparsed URL.
-  type: wildcard
+  type: match_only_text
 url.original:
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
@@ -23529,7 +23529,7 @@ url.original:
   - relation: match
     stability: development
   short: Unmodified original url as seen in the event source.
-  type: wildcard
+  type: match_only_text
 url.password:
   dashed_name: url-password
   description: Password of the request.
@@ -23551,7 +23551,7 @@ url.path:
   - relation: match
     stability: stable
   short: Path of the request, such as "/search".
-  type: wildcard
+  type: match_only_text
 url.port:
   dashed_name: url-port
   description: Port of the request, such as 443.
@@ -28365,7 +28365,7 @@ wazuh.threat.enrichments.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 wazuh.threat.enrichments.indicator.registry.data.type:
   dashed_name: wazuh-threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -31020,7 +31020,7 @@ wazuh.threat.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 wazuh.threat.indicator.registry.data.type:
   dashed_name: wazuh-threat-indicator-registry-data-type
   description: Standard registry type for encoding contents

--- a/wcs/stateless/events/main/docs/fields.csv
+++ b/wcs/stateless/events/main/docs/fields.csv
@@ -258,7 +258,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,email,email.direction,keyword,extended,,inbound,Direction of the message.
 9.1.0,true,email,email.from.address,keyword,extended,array,sender@example.com,The sender's email address.
 9.1.0,true,email,email.local_id,keyword,extended,,c26dbea0-80d5-463b-b93c-4e8b708219ce,Unique identifier given by the source.
-9.1.0,true,email,email.message_id,wildcard,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
+9.1.0,true,email,email.message_id,match_only_text,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
 9.1.0,true,email,email.origination_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time the email was composed.
 9.1.0,true,email,email.reply_to.address,keyword,extended,array,reply.here@example.com,Address replies should be delivered to.
 9.1.0,true,email,email.sender.address,keyword,extended,,,Address of the message sender.
@@ -268,7 +268,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,error,error.code,keyword,core,,,Error code describing the error.
 9.1.0,true,error,error.id,keyword,core,,,Unique identifier for the error.
 9.1.0,true,error,error.message,match_only_text,core,,,Error message.
-9.1.0,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
+9.1.0,true,error,error.stack_trace,match_only_text,extended,,,The stack trace of this error in plain text.
 9.1.0,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 9.1.0,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 9.1.0,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -537,14 +537,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,host,host.type,keyword,core,,,Type of host.
 9.1.0,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 9.1.0,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
-9.1.0,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
+9.1.0,true,http,http.request.body.content,match_only_text,extended,,Hello world,The full HTTP request body.
 9.1.0,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 9.1.0,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 9.1.0,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
 9.1.0,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 9.1.0,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 9.1.0,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
-9.1.0,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
+9.1.0,true,http,http.response.body.content,match_only_text,extended,,Hello world,The full HTTP response body.
 9.1.0,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 9.1.0,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 9.1.0,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -705,7 +705,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -751,7 +751,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.entry_leader.attested_groups.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.entry_leader.attested_user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 9.1.0,true,process,process.entry_leader.attested_user.name,keyword,core,,a.einstein,Short name or login of the user.
-9.1.0,true,process,process.entry_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.entry_leader.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.entry_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 9.1.0,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
@@ -795,7 +795,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.group.name,keyword,extended,,,Name of the group.
 9.1.0,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.group_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.group_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.group_leader.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -836,7 +836,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
 9.1.0,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 9.1.0,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
-9.1.0,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
+9.1.0,true,process,process.io.text,match_only_text,extended,,,A chunk of output or input sanitized to UTF-8.
 9.1.0,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
 9.1.0,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 9.1.0,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
@@ -870,7 +870,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 9.1.0,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 9.1.0,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-9.1.0,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.parent.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 9.1.0,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 9.1.0,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -1019,7 +1019,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.pid,long,core,,4242,Process id.
 9.1.0,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.previous.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.previous.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.previous.name,keyword,extended,,ssh,Process name.
 9.1.0,true,process,process.previous.parent.pid,long,custom,,1,PID of the parent process.
@@ -1035,7 +1035,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.saved_user.name,keyword,core,,a.einstein,Short name or login of the user.
 9.1.0,true,process,process.session_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 9.1.0,true,process,process.session_leader.args_count,long,extended,,4,Length of the process.args array.
-9.1.0,true,process,process.session_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+9.1.0,true,process,process.session_leader.command_line,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 9.1.0,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 9.1.0,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 9.1.0,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -1090,7 +1090,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,process,process.vpid,long,core,,4242,Virtual process id.
 9.1.0,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 9.1.0,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,registry,registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,registry,registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,registry,registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1400,7 +1400,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.enrichments.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1417,10 +1417,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.enrichments.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.enrichments.indicator.url.full,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.enrichments.indicator.url.original,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.enrichments.indicator.url.path,match_only_text,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.enrichments.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.enrichments.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1623,7 +1623,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,threat,threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,threat,threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,threat,threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,threat,threat.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,threat,threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,threat,threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,threat,threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -1635,10 +1635,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,threat,threat.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,threat,threat.indicator.url.full,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,threat,threat.indicator.url.original,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
-9.1.0,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,threat,threat.indicator.url.path,match_only_text,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,threat,threat.indicator.url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,threat,threat.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -1767,10 +1767,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 9.1.0,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 9.1.0,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
-9.1.0,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-9.1.0,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+9.1.0,true,url,url.full,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+9.1.0,true,url,url.original,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 9.1.0,true,url,url.password,keyword,extended,,,Password of the request.
-9.1.0,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
+9.1.0,true,url,url.path,match_only_text,extended,,,"Path of the request, such as ""/search""."
 9.1.0,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
 9.1.0,true,url,url.query,keyword,extended,,,Query string of the request.
 9.1.0,true,url,url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
@@ -2104,7 +2104,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
@@ -2313,7 +2313,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.1.0,true,wazuh,wazuh.threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
 9.1.0,true,wazuh,wazuh.threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.strings,match_only_text,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
 9.1.0,true,wazuh,wazuh.threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.

--- a/wcs/stateless/events/main/docs/wcs_flat.yml
+++ b/wcs/stateless/events/main/docs/wcs_flat.yml
@@ -3365,7 +3365,7 @@ email.message_id:
   name: message_id
   normalize: []
   short: Value from the Message-ID header.
-  type: wildcard
+  type: match_only_text
 email.origination_timestamp:
   dashed_name: email-origination-timestamp
   description: The date and time the email message was composed. Many email clients
@@ -3481,7 +3481,7 @@ error.stack_trace:
     relation: equivalent
     stability: stable
   short: The stack trace of this error in plain text.
-  type: wildcard
+  type: match_only_text
 error.type:
   dashed_name: error-type
   description: The type of the error, for example the class name of the exception.
@@ -7490,7 +7490,7 @@ http.request.body.content:
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
-  type: wildcard
+  type: match_only_text
 http.request.bytes:
   dashed_name: http-request-bytes
   description: Total size in bytes of the request (body and headers).
@@ -7597,7 +7597,7 @@ http.response.body.content:
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
-  type: wildcard
+  type: match_only_text
 http.response.bytes:
   dashed_name: http-response-bytes
   description: Total size in bytes of the response (body and headers).
@@ -9668,7 +9668,7 @@ process.command_line:
   - relation: match
     stability: development
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.elf.architecture:
   dashed_name: process-elf-architecture
   description: Machine architecture of the ELF file.
@@ -10219,7 +10219,7 @@ process.entry_leader.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.entry_leader.entity_id:
   dashed_name: process-entry-leader-entity-id
   description: 'Unique identifier for the process.
@@ -10818,7 +10818,7 @@ process.group_leader.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.group_leader.entity_id:
   dashed_name: process-group-leader-entity-id
   description: 'Unique identifier for the process.
@@ -11350,7 +11350,7 @@ process.io.text:
   name: io.text
   normalize: []
   short: A chunk of output or input sanitized to UTF-8.
-  type: wildcard
+  type: match_only_text
 process.io.total_bytes_captured:
   dashed_name: process-io-total-bytes-captured
   description: The total number of bytes captured in this event.
@@ -11791,7 +11791,7 @@ process.parent.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.parent.elf.architecture:
   dashed_name: process-parent-elf-architecture
   description: Machine architecture of the ELF file.
@@ -13633,7 +13633,7 @@ process.previous.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.previous.executable:
   dashed_name: process-previous-executable
   description: Absolute path to the process executable.
@@ -13843,7 +13843,7 @@ process.session_leader.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: match_only_text
 process.session_leader.entity_id:
   dashed_name: process-session-leader-entity-id
   description: 'Unique identifier for the process.
@@ -14590,7 +14590,7 @@ registry.data.strings:
   normalize:
   - array
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 registry.data.type:
   dashed_name: registry-data-type
   description: Standard registry type for encoding contents
@@ -18683,7 +18683,7 @@ threat.enrichments.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.registry.data.type:
   dashed_name: threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -18913,7 +18913,7 @@ threat.enrichments.indicator.url.full:
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.url.original:
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -18929,7 +18929,7 @@ threat.enrichments.indicator.url.original:
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.url.password:
   dashed_name: threat-enrichments-indicator-url-password
   description: Password of the request.
@@ -18950,7 +18950,7 @@ threat.enrichments.indicator.url.path:
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: wildcard
+  type: match_only_text
 threat.enrichments.indicator.url.port:
   dashed_name: threat-enrichments-indicator-url-port
   description: Port of the request, such as 443.
@@ -21511,7 +21511,7 @@ threat.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 threat.indicator.registry.data.type:
   dashed_name: threat-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -21686,7 +21686,7 @@ threat.indicator.url.full:
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
-  type: wildcard
+  type: match_only_text
 threat.indicator.url.original:
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
@@ -21702,7 +21702,7 @@ threat.indicator.url.original:
   normalize: []
   original_fieldset: url
   short: Unmodified original url as seen in the event source.
-  type: wildcard
+  type: match_only_text
 threat.indicator.url.password:
   dashed_name: threat-indicator-url-password
   description: Password of the request.
@@ -21723,7 +21723,7 @@ threat.indicator.url.path:
   normalize: []
   original_fieldset: url
   short: Path of the request, such as "/search".
-  type: wildcard
+  type: match_only_text
 threat.indicator.url.port:
   dashed_name: threat-indicator-url-port
   description: Port of the request, such as 443.
@@ -23506,7 +23506,7 @@ url.full:
   - relation: match
     stability: stable
   short: Full unparsed URL.
-  type: wildcard
+  type: match_only_text
 url.original:
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
@@ -23524,7 +23524,7 @@ url.original:
   - relation: match
     stability: development
   short: Unmodified original url as seen in the event source.
-  type: wildcard
+  type: match_only_text
 url.password:
   dashed_name: url-password
   description: Password of the request.
@@ -23546,7 +23546,7 @@ url.path:
   - relation: match
     stability: stable
   short: Path of the request, such as "/search".
-  type: wildcard
+  type: match_only_text
 url.port:
   dashed_name: url-port
   description: Port of the request, such as 443.
@@ -27765,7 +27765,7 @@ wazuh.threat.enrichments.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 wazuh.threat.enrichments.indicator.registry.data.type:
   dashed_name: wazuh-threat-enrichments-indicator-registry-data-type
   description: Standard registry type for encoding contents
@@ -30420,7 +30420,7 @@ wazuh.threat.indicator.registry.data.strings:
   - array
   original_fieldset: registry
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: match_only_text
 wazuh.threat.indicator.registry.data.type:
   dashed_name: wazuh-threat-indicator-registry-data-type
   description: Standard registry type for encoding contents


### PR DESCRIPTION
## Description

This PR changes  `wildcard`  to match only test as requested by 

Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1529

## Proposed Changes

Modify the list of fields to remap in `wcs/generator/images/schema_sanitizer.py`:

```diff
 TYPES_TO_REMAP = {
     'constant_keyword': 'keyword',
+    'wildcard': 'match_only_text',
     'flattened': 'flat_object',
 }
```

Generate again the files using the generator

### Results and Evidence

All 40 templates install and work on a live 5.0.0 node.

### Artifacts Affected

Index templates

### Configuration Changes

NA

### Documentation Updates

NA

### Tests Introduced

NA


## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...
